### PR TITLE
feat: warn when node version is incompatible

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -7,6 +7,7 @@ import { overrideEnv } from '../utils/env'
 import { showVersions } from '../utils/banner'
 import { defineCommand } from 'citty'
 import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { isCompatibleNodeVersion } from '../utils/nodeVersion'
 
 export default defineCommand({
   meta: {
@@ -27,6 +28,11 @@ export default defineCommand({
   },
   async run(ctx) {
     overrideEnv('production')
+    if (!isCompatibleNodeVersion()) {
+      consola.warn(
+        'You are using an outdated version of Node.js. Please upgrade to Node.js >= 16.10.0.',
+      )
+    }
 
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -17,6 +17,7 @@ import { clearBuildDir } from '../utils/fs'
 import { defineCommand } from 'citty'
 
 import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { isCompatibleNodeVersion } from '../utils/nodeVersion'
 
 export default defineCommand({
   meta: {
@@ -68,6 +69,12 @@ export default defineCommand({
   },
   async run(ctx) {
     overrideEnv('development')
+
+    if (!isCompatibleNodeVersion()) {
+      consola.warn(
+        'You are using an outdated version of Node.js. Please upgrade to Node.js >= 16.10.0.',
+      )
+    }
 
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
 

--- a/src/utils/nodeVersion.ts
+++ b/src/utils/nodeVersion.ts
@@ -1,0 +1,5 @@
+// should be above node 16.10.0
+export function isCompatibleNodeVersion() {
+    const [major, minor] = process.version.slice(1).split('.').map(Number)
+    return major > 16 || (major === 16 && minor >= 10)
+}


### PR DESCRIPTION
Closes #52 

- added a utility function `isCompatibleNodeVersion`
- added checks to build and dev commands and warnings if the version is incompatible