### PR TITLE
feat: support for nuxt 2 and edge releases in `nuxi upgrade`

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -12,15 +12,70 @@ import { defineCommand } from 'citty'
 
 import { legacyRootDirArgs, sharedArgs } from './_shared'
 
-async function getNuxtVersion(path: string): Promise<string | null> {
+interface NuxtPackage {
+  version: string | null
+  name: string | null
+  edge: boolean
+  major: number
+}
+
+const isFilled = <T extends {}>(v: PromiseSettledResult<T>): v is PromiseFulfilledResult<T> => v.status === 'fulfilled';
+
+function detectNuxtEdge (nuxtVersion: string): boolean {
   try {
-    const pkg = await readPackageJSON('nuxt', { url: path })
+    return (/-\d{8}.[a-z0-9]{7}/).test(nuxtVersion)
+  } catch {
+    return false
+  }
+}
+
+function detectMajorVersion (nuxtVersion: string): number {
+  try {
+    return parseInt(nuxtVersion.split('.')[0])
+  } catch {
+    // fallback to Nuxt 3
+    return 3
+  }
+}
+
+function getNpmTag (nuxtPackage: NuxtPackage): string {
+  // later we can extend support in case of using nuxt-edge for Nuxt 3
+  if (!nuxtPackage.edge && nuxtPackage.major === 2) {
+    return '2x'
+  }
+  return 'latest'
+}
+
+async function getNuxtPackage(path: string): Promise<NuxtPackage> {
+  try {
+    // check edge packages first, then stable nuxt
+    const possiblePackages = ['nuxt3', 'nuxt-edge', 'nuxt']
+    // Promise.any will be better, but it requires Node 15+
+    const pkgs = await Promise.allSettled(
+      possiblePackages.map(name => readPackageJSON(name, { url: path }))
+    )
+
+    const pkg = pkgs.find(isFilled)!.value || {}
+    
     if (!pkg.version) {
       consola.warn('Cannot find any installed nuxt versions in ', path)
     }
-    return pkg.version || null
+
+    const nuxtPackage = {
+      version: pkg.version || null,
+      name: pkg.name || 'nuxt',
+      edge: detectNuxtEdge(pkg.version || ''),
+      major: detectMajorVersion(pkg.version || ''),
+    }
+    return nuxtPackage
   } catch {
-    return null
+    // Even if we cannot read package.json, we can still upgrade to latest Nuxt 3
+    return {
+      version: null,
+      name: 'nuxt',
+      edge: false,
+      major: 3,
+    }
   }
 }
 
@@ -53,8 +108,17 @@ export default defineCommand({
     consola.info('Package Manager:', packageManager, packageManagerVersion)
 
     // Check currently installed nuxt version
-    const currentVersion = (await getNuxtVersion(cwd)) || '[unknown]'
-    consola.info('Current nuxt version:', currentVersion)
+    const currentNuxt = (await getNuxtPackage(cwd))
+
+    // Warn user to add alias to nuxt3 package or install stable rc version
+    if (currentNuxt.name === 'nuxt3') {
+      consola.warn('`nuxt3` package usage without alias is removed.\nPlease, update your code to continue working with new releases.\nSee more: https://github.com/nuxt/nuxt/pull/4449')
+    }
+    
+    consola.info(`Current nuxt version: ${currentNuxt.version}`)
+    if (currentNuxt.edge) {
+      consola.info('Edge release channel detected')
+    }
 
     // Force install
     if (ctx.args.force) {
@@ -65,11 +129,11 @@ export default defineCommand({
     }
 
     // Install latest version
-    consola.info('Installing latest Nuxt 3 release...')
+    consola.info(`Installing latest Nuxt ${currentNuxt.major} release...`)
     execSync(
       `${packageManager} ${
         packageManager === 'yarn' ? 'add' : 'install'
-      } -D nuxt`,
+      } -D ${currentNuxt.name}@${getNpmTag(currentNuxt)}`,
       { stdio: 'inherit', cwd },
     )
 
@@ -77,20 +141,20 @@ export default defineCommand({
     await cleanupNuxtDirs(cwd)
 
     // Check installed nuxt version again
-    const upgradedVersion = (await getNuxtVersion(cwd)) || '[unknown]'
-    consola.info('Upgraded nuxt version:', upgradedVersion)
+    const upgradedNuxt = (await getNuxtPackage(cwd)) || '[unknown]'
+    consola.info('Upgraded nuxt version:', upgradedNuxt.version)
 
-    if (upgradedVersion === currentVersion) {
+    if (upgradedNuxt.version === currentNuxt.version) {
       consola.success("You're already using the latest version of nuxt.")
     } else {
       consola.success(
         'Successfully upgraded nuxt from',
-        currentVersion,
+        currentNuxt.version,
         'to',
-        upgradedVersion,
+        upgradedNuxt.version,
       )
-      const commitA = nuxtVersionToGitIdentifier(currentVersion)
-      const commitB = nuxtVersionToGitIdentifier(upgradedVersion)
+      const commitA = nuxtVersionToGitIdentifier(currentNuxt.version || '')
+      const commitB = nuxtVersionToGitIdentifier(upgradedNuxt.version || '')
       if (commitA && commitB) {
         consola.info(
           'Changelog:',

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -15,6 +15,7 @@ import { legacyRootDirArgs, sharedArgs } from './_shared'
 interface NuxtPackage {
   version: string | null
   name: string | null
+  alias: string | null
   edge: boolean
   major: number
 }
@@ -57,15 +58,6 @@ async function getNuxtPackage(path: string): Promise<NuxtPackage> {
       possiblePackages.map(name => readPackageJSON(name, { url: path }))
     )
 
-    // also add package names to the result
-    pkgs.forEach((pkg, index) => {
-      if (!isFilled(pkg)) return
-      pkg.value = {
-        ...pkg.value,
-        searchedName: possiblePackages[index]
-      }
-    })
-
     const pkg = pkgs.find(isFilled)!.value || {}
     
     if (!pkg.version) {
@@ -74,7 +66,8 @@ async function getNuxtPackage(path: string): Promise<NuxtPackage> {
 
     const nuxtPackage = {
       version: pkg.version || null,
-      name: pkg.searchedName || 'nuxt',
+      name: pkg._name || 'nuxt',
+      alias: pkg.name || null,
       edge: detectNuxtEdge(pkg.version || ''),
       major: detectMajorVersion(pkg.version || ''),
     }
@@ -84,6 +77,7 @@ async function getNuxtPackage(path: string): Promise<NuxtPackage> {
     return {
       version: null,
       name: 'nuxt',
+      alias: null,
       edge: false,
       major: 3,
     }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -20,17 +20,19 @@ interface NuxtPackage {
   major: number
 }
 
-const isFilled = <T extends {}>(v: PromiseSettledResult<T>): v is PromiseFulfilledResult<T> => v.status === 'fulfilled';
+const isFilled = <T extends {}>(
+  v: PromiseSettledResult<T>,
+): v is PromiseFulfilledResult<T> => v.status === 'fulfilled'
 
-function detectNuxtEdge (nuxtVersion: string): boolean {
+function detectNuxtEdge(nuxtVersion: string): boolean {
   try {
-    return (/-\d{8}.[a-z0-9]{7}/).test(nuxtVersion)
+    return /-\d{8}.[a-z0-9]{7}/.test(nuxtVersion)
   } catch {
     return false
   }
 }
 
-function detectMajorVersion (nuxtVersion: string): number {
+function detectMajorVersion(nuxtVersion: string): number {
   try {
     return parseInt(nuxtVersion.split('.')[0])
   } catch {
@@ -39,7 +41,7 @@ function detectMajorVersion (nuxtVersion: string): number {
   }
 }
 
-function getNpmTag (nuxtPackage: NuxtPackage): string {
+function getNpmTag(nuxtPackage: NuxtPackage): string {
   // later we can extend support in case of using nuxt-edge for Nuxt 3
   if (nuxtPackage.name !== nuxtPackage.alias) {
     return `npm:${nuxtPackage.alias}@latest`
@@ -55,11 +57,11 @@ async function getNuxtPackage(path: string): Promise<NuxtPackage> {
     const possiblePackages = ['nuxt-edge', 'nuxt', 'nuxt3']
     // Promise.any will be better, but it requires Node 15+
     const pkgs = await Promise.allSettled(
-      possiblePackages.map(name => readPackageJSON(name, { url: path }))
+      possiblePackages.map((name) => readPackageJSON(name, { url: path })),
     )
 
     const pkg = pkgs.find(isFilled)!.value || {}
-    
+
     if (!pkg.version) {
       consola.warn('Cannot find any installed nuxt versions in ', path)
     }
@@ -113,13 +115,15 @@ export default defineCommand({
     consola.info('Package Manager:', packageManager, packageManagerVersion)
 
     // Check currently installed nuxt version
-    const currentNuxt = (await getNuxtPackage(cwd))
+    const currentNuxt = await getNuxtPackage(cwd)
 
     // Warn user to add alias to nuxt3 package or install stable rc version
     if (currentNuxt.name === 'nuxt3') {
-      consola.warn('`nuxt3` package usage without alias is removed.\nPlease, update your code to continue working with new releases.\nSee more: https://github.com/nuxt/nuxt/pull/4449')
+      consola.warn(
+        '`nuxt3` package usage without alias is removed.\nPlease, update your code to continue working with new releases.\nSee more: https://github.com/nuxt/nuxt/pull/4449',
+      )
     }
-    
+
     consola.info(`Current nuxt version: ${currentNuxt.version}`)
     if (currentNuxt.edge) {
       consola.info('Edge release channel detected')
@@ -136,9 +140,9 @@ export default defineCommand({
     // Install latest version
     consola.info(`Installing latest Nuxt ${currentNuxt.major} release...`)
     execSync(
-      `${packageManager} ${
-        packageManager === 'yarn' ? 'add' : 'install'
-      } -D ${currentNuxt.name}@${getNpmTag(currentNuxt)}`,
+      `${packageManager} ${packageManager === 'yarn' ? 'add' : 'install'} -D ${
+        currentNuxt.name
+      }@${getNpmTag(currentNuxt)}`,
       { stdio: 'inherit', cwd },
     )
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -41,8 +41,8 @@ function detectMajorVersion (nuxtVersion: string): number {
 
 function getNpmTag (nuxtPackage: NuxtPackage): string {
   // later we can extend support in case of using nuxt-edge for Nuxt 3
-  if (nuxtPackage.edge && nuxtPackage.major === 3 && nuxtPackage.name === 'nuxt') {
-    return 'npm:nuxt3@latest'
+  if (nuxtPackage.name !== nuxtPackage.alias) {
+    return `npm:${nuxtPackage.alias}@latest`
   }
   if (!nuxtPackage.edge && nuxtPackage.major === 2) {
     return '2x'

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { defineCommand } from 'citty'
 import { commands } from './commands'
 import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
-import { checkForUpdates } from './utils/update'
+// import { checkForUpdates } from './utils/update'
 
 export const main = defineCommand({
   meta: {


### PR DESCRIPTION
### 🔗 Linked issue

Issues to track:
https://github.com/nuxt/nuxt/issues/14741
~~https://github.com/nuxt/nuxt/pull/18427~~

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR extends `nuxi upgrade` command usage with some new features:
1. It respects not only stable Nuxt 3 packages (like `nuxt: "3.6.3"`), but also Nuxt 2 (`nuxt` & `nuxt-edge`) and Nuxt 3 packages, installed as `npm:nuxt3@latest`. This might be useful for nuxt 2 bridge users and people, who wants to get edge releases of Nuxt.