### PR TITLE
fix: reverse conditions to default to v3

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -58,11 +58,10 @@ export default defineCommand({
       getDepVersion('nuxt') ||
       getDepVersion('nuxt-edge') ||
       getDepVersion('nuxt3') ||
-      '0.0.0'
-    const isNuxt3 = nuxtVersion.startsWith('3')
-    const builder = isNuxt3
-      ? nuxtConfig.builder /* latest schema */ ||
-        (nuxtConfig.vite !== false ? 'vite' : 'webpack') /* previous schema */
+      '-'
+    const isLegacy = nuxtVersion.startsWith('2')
+    const builder = !isLegacy
+      ? nuxtConfig.builder /* latest schema */ || '-'
       : nuxtConfig.bridge?.vite
       ? 'vite' /* bridge vite implementation */
       : nuxtConfig.buildModules?.includes('nuxt-vite')
@@ -122,9 +121,7 @@ export default defineCommand({
       }\n\n${splitter}\n${infoStr}${splitter}\n`,
     )
 
-    const isNuxt3OrBridge =
-      infoObj.NuxtVersion.startsWith('3') ||
-      infoObj.BuildModules.includes('bridge')
+    const isNuxt3OrBridge = !isLegacy || infoObj.BuildModules.includes('bridge')
     console.log(
       [
         '👉 Report an issue: https://github.com/nuxt/nuxt/issues/new',


### PR DESCRIPTION
This means that when run on a project directory without Nuxt we get Nuxt 3 defaults:

```
Working directory: /Users/daniel
Nuxt project info: (copied to clipboard)

------------------------------
- Operating System: Darwin
- Node Version:     v20.3.1
- Nuxt Version:     -
- CLI Version:      0.2.0
- Nitro Version:    -
- Package Manager:  unknown
- Builder:          -
- User Config:      -
- Runtime Modules:  -
- Build Modules:    -
------------------------------

👉 Report an issue: https://github.com/nuxt/nuxt/issues/new

👉 Suggest an improvement: https://github.com/nuxt/nuxt/discussions/new

👉 Read documentation: https://nuxt.com
```