### PR TITLE
feat(init): support `--package-manager` 

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -52,9 +52,9 @@ export default defineCommand({
       type: 'boolean',
       description: 'Start shell after installation in project directory',
     },
-    manager: {
+    packageManager: {
       type: 'string',
-      description: 'Package manager choice',
+      description: 'Package manager choice (npm, pnpm, yarn, bun)',
     },
   },
   async run(ctx) {
@@ -95,9 +95,11 @@ export default defineCommand({
       'yarn',
       'bun',
     ]
-    const managerArg = ctx.args.manager as PackageManagerName
-    const selectedPackageManager = packageManagerOptions.includes(managerArg)
-      ? managerArg
+    const packageManagerArg = ctx.args.packageManager as PackageManagerName
+    const selectedPackageManager = packageManagerOptions.includes(
+      packageManagerArg,
+    )
+      ? packageManagerArg
       : await consola.prompt<{
           type: 'select'
           options: PackageManagerName[]

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -52,6 +52,10 @@ export default defineCommand({
       type: 'boolean',
       description: 'Start shell after installation in project directory',
     },
+    manager: {
+      type: 'string',
+      description: 'Package manager choice',
+    },
   },
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd || '.')
@@ -84,14 +88,23 @@ export default defineCommand({
       process.exit(1)
     }
 
-    // Prompt user to select package manager
-    const selectedPackageManager = await consola.prompt<{
-      type: 'select'
-      options: PackageManagerName[]
-    }>('Which package manager would you like to use?', {
-      type: 'select',
-      options: ['npm', 'pnpm', 'yarn', 'bun'],
-    })
+    // Resolve package manager
+    const packageManagerOptions: PackageManagerName[] = [
+      'npm',
+      'pnpm',
+      'yarn',
+      'bun',
+    ]
+    const managerArg = ctx.args.manager as PackageManagerName
+    const selectedPackageManager = packageManagerOptions.includes(managerArg)
+      ? managerArg
+      : await consola.prompt<{
+          type: 'select'
+          options: PackageManagerName[]
+        }>('Which package manager would you like to use?', {
+          type: 'select',
+          options: packageManagerOptions,
+        })
 
     // Get relative project path
     const relativeProjectPath = relative(process.cwd(), template.dir)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -100,10 +100,7 @@ export default defineCommand({
       packageManagerArg,
     )
       ? packageManagerArg
-      : await consola.prompt<{
-          type: 'select'
-          options: PackageManagerName[]
-        }>('Which package manager would you like to use?', {
+      : await consola.prompt('Which package manager would you like to use?', {
           type: 'select',
           options: packageManagerOptions,
         })


### PR DESCRIPTION
### ❓ Type of change

- [ ]  📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces the `manager` CLI argument, allowing users to skip the package manager selection prompt.


resolves https://github.com/nuxt/cli/issues/161