### PR TITLE
fix(dev): add backward compatibility for `-o` and `-p` and deprecate `ssl*` args

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -31,14 +31,6 @@ const command = defineCommand({
       type: 'boolean',
       description: 'Clear console on restart',
     },
-    sslCert: {
-      type: 'string',
-      description: 'Path to SSL certificate',
-    },
-    sslKey: {
-      type: 'string',
-      description: 'Path to SSL key',
-    },
   },
   async run(ctx) {
     // Prepare
@@ -184,6 +176,7 @@ function _resolveListenOptions(
 
   const _port =
     args.port ??
+    args.p ??
     process.env.NUXT_PORT ??
     process.env.NITRO_PORT ??
     process.env.PORT ??
@@ -206,7 +199,7 @@ function _resolveListenOptions(
 
   const _httpsCert =
     args['https.cert'] ||
-    args.sslCert ||
+    (args.sslCert as string) ||
     process.env.NUXT_SSL_CERT ||
     process.env.NITRO_SSL_CERT ||
     (typeof _devServerConfig.https !== 'boolean' &&
@@ -215,7 +208,7 @@ function _resolveListenOptions(
 
   const _httpsKey =
     args['https.key'] ||
-    args.sslKey ||
+    (args.sslKey as string) ||
     process.env.NUXT_SSL_KEY ||
     process.env.NITRO_SSL_KEY ||
     (typeof _devServerConfig.https !== 'boolean' &&
@@ -225,6 +218,7 @@ function _resolveListenOptions(
   return {
     ...parseArgs({
       ...args,
+      open: args.open ?? args.o,
       'https.cert': _httpsCert,
       'https.key': _httpsKey,
     }),


### PR DESCRIPTION
resolves #103

This PR adds backward compatible `-o` and `-p` aliases for `--open` and `--port`.

Adding an alias for `-h` is impossible as is a reserved keyword for `--help` in citty.

I have also removed `--sslCert` and `--sslKey` from args to hide from usage as they are deprecated. (we might think about CLI warnings as well to eventually drop them and make sure usage is simple as much as possible)