### PR TITLE
refactor(upgrade): use `--force` by default

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -35,6 +35,7 @@ export default defineCommand({
     force: {
       type: 'boolean',
       alias: 'f',
+      default: true,
       description: 'Force upgrade to recreate lockfile and node_modules',
     },
   },


### PR DESCRIPTION
Most of the times and by default we recommend `--force` with the upgrade command. I think it is sensible to have it enabled by default and enable `--no-force` for opt-out.

<img width="603" alt="image" src="https://github.com/nuxt/cli/assets/5158436/8d00a16a-f31c-4ff4-9fdf-524ef61db27d">
