### PR TITLE
fix(devtools): define `enable|disable` command as positional argument

### DIFF
--- a/src/commands/devtools.ts
+++ b/src/commands/devtools.ts
@@ -11,12 +11,12 @@ export default defineCommand({
   },
   args: {
     ...sharedArgs,
-    ...legacyRootDirArgs,
     command: {
-      type: 'string',
+      type: 'positional',
       description: 'Command to run',
       valueHint: 'enable|disable',
     },
+    ...legacyRootDirArgs,
   },
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')

--- a/src/commands/devtools.ts
+++ b/src/commands/devtools.ts
@@ -6,8 +6,8 @@ import { legacyRootDirArgs, sharedArgs } from './_shared'
 
 export default defineCommand({
   meta: {
-    name: 'enable',
-    description: 'Enable or disable features in a Nuxt project',
+    name: 'devtools',
+    description: 'Enable or disable devtools in a Nuxt project',
   },
   args: {
     ...sharedArgs,


### PR DESCRIPTION
Resolves #69 

This PR registers `command` as positional argument and reorders it before legacy `[rootDir]` option to align behavior with described in [docs](https://nuxt.com/docs/api/commands/devtools)

Also it changes defined command meta to give right output when user types `nuxi devtools` without specifying the action.