### PR TITLE
fix(dev): pass listener interface to the `listen` hook

### DIFF
--- a/src/commands/dev-internal.ts
+++ b/src/commands/dev-internal.ts
@@ -149,12 +149,12 @@ export default defineCommand({
 
       // Emulate a listener for listen hook
       // Currently it is typed as any in nuxt. we try to keep it close to listhen interface
-      const listenrInfo = JSON.parse(
+      const listenerInfo = JSON.parse(
         process.env.__NUXT_DEV_LISTENER__ || 'null',
       ) || { url: serverURL, urls: [] }
       await currentNuxt.hooks.callHook('listen', server, {
         server,
-        url: listenrInfo.url,
+        url: listenerInfo.url,
         https: false,
         address: { host: 'localhost', port },
         close: () => Promise.reject('Cannot close internal dev server!'),
@@ -162,7 +162,7 @@ export default defineCommand({
         showURL: () => Promise.resolve(),
         getURLs: () =>
           Promise.resolve([
-            ...listenrInfo.urls,
+            ...listenerInfo.urls,
             { url: serverURL, type: 'local' },
           ]),
       } satisfies Listener)


### PR DESCRIPTION
resolves #117

Since we now listen on the main process, this PR makes modules that depending on `listen` hook keep working.

**Note:** This is not a stable solution. Modules should not depend deeply on internal server listeners. 

Also, we pass the server without HTTPs to the vite-node server to avoid certificate issues as we had before.

--- 

Verified on tailwind module:

<img width="792" alt="image" src="https://github.com/nuxt/cli/assets/5158436/56a17df6-4594-4b4a-9923-8de0bc908a9b">
