### PR TITLE
fix: add cli version and name in usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nuxi",
   "version": "3.7.2",
+  "description": "⚡️ Nuxt Generation CLI Experience",
   "repository": "nuxt/cli",
   "license": "MIT",
   "type": "module",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,15 @@ import { defineCommand } from 'citty'
 import { commands } from './commands'
 import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
+import { name, version, description } from '../package.json'
+
 // import { checkForUpdates } from './utils/update'
 
 export const main = defineCommand({
   meta: {
-    name: 'nuxi',
-    description: 'Nuxt CLI',
+    name,
+    version,
+    description,
   },
   subCommands: commands,
   async setup(ctx) {


### PR DESCRIPTION
We were missing nuxi version and description in usage

<img width="391" alt="image" src="https://github.com/nuxt/cli/assets/5158436/8d946036-d6b8-4605-8384-f63da84e3fe6">
