### PR TITLE
fix: improve preview banner and add backward compatible `start`

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,7 @@ export const commands = {
   module: () => import('./module').then(_rDefault),
   prepare: () => import('./prepare').then(_rDefault),
   preview: () => import('./preview').then(_rDefault),
+  start: () => import('./preview').then(_rDefault),
   test: () => import('./test').then(_rDefault),
   typecheck: () => import('./typecheck').then(_rDefault),
   upgrade: () => import('./upgrade').then(_rDefault),

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -70,7 +70,7 @@ export default defineCommand({
     consola.log(
       box(
         [
-          'You are running Nuxt production build in preview mode',
+          'You are running Nuxt production build in preview mode.',
           `For production deployments, please directly use ${colors.cyan(
             nitroJSON.commands.preview,
           )} command.`,


### PR DESCRIPTION
Resolves #113 by adding backward compatible `start` command.

Also improves the Preview mode experience with explicit warnings about production usage.

<img width="717" alt="image" src="https://github.com/nuxt/cli/assets/5158436/6a1ea307-1fe3-41a6-9f8e-11610c78aa32">
