### PR TITLE
fix(dev): pass `https` info to the vite hmr

### DIFF
--- a/src/commands/dev-internal.ts
+++ b/src/commands/dev-internal.ts
@@ -152,7 +152,6 @@ export default defineCommand({
       const listenerInfo = JSON.parse(
         process.env.__NUXT_DEV_LISTENER__ || 'null',
       ) || { url: serverURL, urls: [], https: false }
-      consola.log(listenerInfo)
       await currentNuxt.hooks.callHook('listen', server, {
         // Internal server
         server,

--- a/src/commands/dev-internal.ts
+++ b/src/commands/dev-internal.ts
@@ -151,12 +151,15 @@ export default defineCommand({
       // Currently it is typed as any in nuxt. we try to keep it close to listhen interface
       const listenerInfo = JSON.parse(
         process.env.__NUXT_DEV_LISTENER__ || 'null',
-      ) || { url: serverURL, urls: [] }
+      ) || { url: serverURL, urls: [], https: false }
+      consola.log(listenerInfo)
       await currentNuxt.hooks.callHook('listen', server, {
+        // Internal server
         server,
-        url: listenerInfo.url,
-        https: false,
         address: { host: '127.0.0.1', port },
+        // Exposed server
+        url: listenerInfo.url,
+        https: listenerInfo.https,
         close: () => Promise.reject('Cannot close internal dev server!'),
         open: () => Promise.resolve(),
         showURL: () => Promise.resolve(),
@@ -172,7 +175,7 @@ export default defineCommand({
       currentNuxt.options.devServer.url = `http://127.0.0.1:${port}/`
       currentNuxt.options.devServer.host = '127.0.0.1'
       currentNuxt.options.devServer.port = port
-      currentNuxt.options.devServer.https = false
+      currentNuxt.options.devServer.https = listenerInfo.https
 
       await Promise.all([
         writeTypes(currentNuxt).catch(console.error),

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -141,6 +141,7 @@ function _startSubprocess(devServer: DevServer, listener: Listener) {
         __NUXT_DEV_LISTENER__: JSON.stringify({
           url: listener.url,
           urls: listener.getURLs(),
+          https: listener.https,
         }),
       },
     },


### PR DESCRIPTION
resolves #112

Currently vite dev server listens on a dedicated port to handle HMR events with WebSocket support. 

When the main dev server is listening on HTTPs, Vite HMR server also needs a secure protocol `wss://`. 

We wouldn't need it in the close future when can reuse same port but until then it is required in order to have vite HMR with HTTPs