### PR TITLE
fix(dev): support ws upgrades

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
   "extends": ["@nuxt/eslint-config"],
   "rules": {
-    "no-extra-semi": 0
+    "no-extra-semi": 0,
+    "vue/html-self-closing": 0,
+    "vue/singleline-html-element-content-newline": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/mri": "^1.1.1",
     "@types/node": "^20.5.7",
     "@types/semver": "^7.5.1",
+    "@types/ws": "^8.5.5",
     "c12": "^1.4.2",
     "changelogen": "^0.5.5",
     "chokidar": "^3.5.3",
@@ -78,7 +79,9 @@
     "prettier": "^3.0.3",
     "scule": "^1.0.0",
     "semver": "^7.5.4",
-    "unbuild": "^2.0.0"
+    "unbuild": "^2.0.0",
+    "unws": "^0.2.4",
+    "ws": "^8.13.0"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.3"

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    Hi!
-  </div>
-</template>

--- a/playground/modules/ws.ts
+++ b/playground/modules/ws.ts
@@ -1,0 +1,45 @@
+import { WebSocketServer } from 'ws'
+import { defineNuxtModule } from 'nuxt/kit'
+
+// Note: This is an unofficial and unstable usage to add a WebSocket server to Nuxt.
+// Please only use this file for testing purposes and avoid using it in real projects!
+export default defineNuxtModule({
+  setup(_, nuxt) {
+    if (!nuxt.options.dev) {
+      return
+    }
+
+    // https://github.com/websockets/ws
+    const wss = new WebSocketServer({
+      port: 8080,
+    })
+
+    wss.on('connection', (ws) => {
+      ws.on('error', console.error)
+      ws.on('message', (data) => {
+        console.log('[wss] received: %s', data)
+      })
+      ws.send('🏓 pong')
+    })
+
+    wss.on('listening', () => {
+      const port = (wss.address() as { port: number }).port
+      console.log(`  ➜ WSS:      \`ws://localhost:${port}/ws\`\n`)
+    })
+
+    nuxt.hooks.hook('close', () => {
+      wss.close()
+    })
+
+    nuxt.hook('listen', (server) => {
+      server.on('upgrade', (req, socket, head) => {
+        console.log(`[server] WebSocket upgrade for path: ${req.url}`)
+        if (req.url === '/api/ws') {
+          return wss.handleUpgrade(req, socket, head, (ws) => {
+            wss.emit('connection', ws, req)
+          })
+        }
+      })
+    })
+  },
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,2 +1,19 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-export default defineNuxtConfig({})
+export default defineNuxtConfig({
+  hooks: {
+    async listen(server) {
+      const { wss } = await import('./server/ws')
+      server.on('upgrade', (req, socket, head) => {
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit('connection', ws, req)
+        })
+      })
+    },
+  },
+  nitro: {
+    devProxy: {
+      // TODO: Not working yet
+      // '/api/ws': { target: 'ws://localhost:8080/ws', ws: true },
+    },
+  },
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,19 +1,2 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-export default defineNuxtConfig({
-  hooks: {
-    async listen(server) {
-      const { wss } = await import('./server/ws')
-      server.on('upgrade', (req, socket, head) => {
-        wss.handleUpgrade(req, socket, head, (ws) => {
-          wss.emit('connection', ws, req)
-        })
-      })
-    },
-  },
-  nitro: {
-    devProxy: {
-      // TODO: Not working yet
-      // '/api/ws': { target: 'ws://localhost:8080/ws', ws: true },
-    },
-  },
-})
+export default defineNuxtConfig({})

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>
+    Welcome to the Nuxt CLI playground!
+    <br />
+    <br />
+    <NuxtLink to="/ws"> /ws </NuxtLink>
+  </div>
+</template>

--- a/playground/pages/ws.vue
+++ b/playground/pages/ws.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { WebSocket } from 'unws'
+
+const reqURL = useRequestURL()
+const urls = [`ws://${reqURL.host}/api/ws`, 'ws://localhost:8080']
+const _queryURL = useRoute().query.url as string
+if (_queryURL && !urls.includes(_queryURL)) {
+  urls.push(_queryURL)
+}
+
+// Poor man logger
+const logs = ref<string[]>([])
+let lastTime = Date.now()
+const log = (message: string) => {
+  console.log(message)
+  const now = Date.now()
+  const timeTaken = now - lastTime
+  logs.value.push(`${message} ${timeTaken > 0 ? `(+${timeTaken}ms)` : ''}`)
+  lastTime = now
+}
+
+const wsAddress = ref<string>((useRoute().query.url as string) || urls[0])
+
+if (process.client) {
+  const init = () => {
+    logs.value = []
+
+    // Create WebSocket connection.
+    log(`Creating WebSocket connection to ${wsAddress.value}...`)
+    const socket = new WebSocket(wsAddress.value)
+
+    // Connection opened
+    socket.addEventListener('open', () => {
+      log('WebSocket connection opened!')
+      log('Sending ping...')
+      socket.send('ping from client')
+    })
+
+    // Listen for messages
+    socket.addEventListener('message', (event) => {
+      log(`Message from server: ${JSON.stringify(event.data)}`)
+    })
+  }
+  onMounted(() => init())
+  watch(wsAddress, () => {
+    const u = new URL(window.location.href)
+    u.searchParams.set('url', wsAddress.value)
+    history.pushState({}, '', u)
+    init()
+  })
+}
+</script>
+
+<template>
+  <div>
+    <h1>WebSocket Playground</h1>
+    <select v-model="wsAddress">
+      <option
+        v-for="url in urls"
+        :key="url"
+        :value="url"
+        :selected="url === wsAddress"
+      >
+        {{ url }}
+      </option>
+    </select>
+    <h2>Logs</h2>
+    <pre><code>{{ logs.join('\n') }}</code></pre>
+  </div>
+</template>

--- a/playground/server/ws.ts
+++ b/playground/server/ws.ts
@@ -1,0 +1,20 @@
+import { WebSocketServer } from 'ws'
+
+// https://github.com/websockets/ws
+
+export const wss = new WebSocketServer({
+  port: 8080,
+})
+
+wss.on('connection', (ws) => {
+  ws.on('error', console.error)
+  ws.on('message', (data) => {
+    console.log('[wss] received: %s', data)
+  })
+  ws.send('🏓 pong')
+})
+
+wss.on('listening', () => {
+  const port = (wss.address() as { port: number }).port
+  console.log(`  ➜ WSS:      \`ws://localhost:${port}/ws\`\n`)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ devDependencies:
   '@types/semver':
     specifier: ^7.5.1
     version: 7.5.1
+  '@types/ws':
+    specifier: ^8.5.5
+    version: 8.5.5
   c12:
     specifier: ^1.4.2
     version: 1.4.2
@@ -142,6 +145,12 @@ devDependencies:
   unbuild:
     specifier: ^2.0.0
     version: 2.0.0(typescript@5.2.2)
+  unws:
+    specifier: ^0.2.4
+    version: 0.2.4(ws@8.13.0)
+  ws:
+    specifier: ^8.13.0
+    version: 8.13.0
 
 packages:
 
@@ -1545,6 +1554,12 @@ packages:
 
   /@types/semver@7.5.1:
     resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
+    dev: true
+
+  /@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
+    dependencies:
+      '@types/node': 20.5.7
     dev: true
 
   /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.2.2):
@@ -5844,6 +5859,15 @@ packages:
       - supports-color
     dev: true
 
+  /unws@0.2.4(ws@8.13.0):
+    resolution: {integrity: sha512-/N1ajiqrSp0A/26/LBg7r10fOcPtGXCqJRJ61sijUFoGZMr6ESWGYn7i0cwr7fR7eEECY5HsitqtjGHDZLAu2w==}
+    engines: {node: '>=16.14.0'}
+    peerDependencies:
+      ws: '*'
+    dependencies:
+      ws: 8.13.0
+    dev: true
+
   /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
@@ -6142,6 +6166,19 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
+
+  /ws@8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dev: true
 
   /xml-name-validator@4.0.0:

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -96,7 +96,7 @@ async function _createDevServer(nuxtOptions: NuxtOptions) {
       res.end(loadingTemplate({ loading: loadingMessage }))
       return
     }
-    return proxy.web(req, res, { target: address, ws: true })
+    return proxy.web(req, res, { target: address })
   }
 
   const wsHandler = (req: IncomingMessage, socket: any, head: any) => {
@@ -104,7 +104,7 @@ async function _createDevServer(nuxtOptions: NuxtOptions) {
       socket.destroy()
       return
     }
-    return proxy.ws(req, socket, { target: address, ws: true }, head)
+    return proxy.ws(req, socket, { target: address }, head)
   }
 
   return {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -96,9 +96,6 @@ async function _createDevServer(nuxtOptions: NuxtOptions) {
       res.end(loadingTemplate({ loading: loadingMessage }))
       return
     }
-    if (req.url?.includes('/api/ws')) {
-      console.log(req.url, 'proxy to', address)
-    }
     return proxy.web(req, res, { target: address, ws: true })
   }
 


### PR DESCRIPTION
#108

#101

This PR adds support for `upgrade` event from dev server wrapper, proxying it to the underlying (build time) userland server instance.

I have also added a simple playground page to try things out (it is obviously not a right usage to register ws but current workaround)

<img width="754" alt="image" src="https://github.com/nuxt/cli/assets/5158436/0e8bf5de-b71e-4858-bae7-a04961c3dc2c">

