### PR TITLE
feat(build-module): add `--sourcemap` support

### DIFF
--- a/src/commands/build-module.ts
+++ b/src/commands/build-module.ts
@@ -19,6 +19,10 @@ export default defineCommand({
       type: 'boolean',
       description: 'Stub dist instead of actually building it for development',
     },
+    sourcemap: {
+      type: 'boolean',
+      description: 'Generate sourcemaps',
+    },
     prepare: {
       type: 'boolean',
       description: 'Prepare module for local development',
@@ -35,6 +39,7 @@ export default defineCommand({
 
     const execArgs = Object.entries({
       '--stub': ctx.args.stub,
+      '--sourcemap': ctx.args.sourcemap,
       '--prepare': ctx.args.prepare,
     })
       .filter(([, value]) => value)


### PR DESCRIPTION
This PR depends on https://github.com/nuxt/module-builder/pull/163 which has now been merged and [released](https://github.com/nuxt/module-builder/releases/tag/v0.5.1).

Adding the sourcemap option is useful for those debugging built modules using a debugger.