### PR TITLE
fix(dev): enable `https` by default when `devServer.https` options is set

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -6,7 +6,10 @@ import { importModule } from '../utils/esm'
 import { overrideEnv } from '../utils/env'
 import { defineCommand, ParsedArgs } from 'citty'
 import type { Listener, ListenOptions } from 'listhen'
-import { getArgs, parseArgs } from 'listhen/cli'
+import {
+  getArgs as getListhenArgs,
+  parseArgs as parseListhenArgs,
+} from 'listhen/cli'
 import type { NuxtOptions } from '@nuxt/schema'
 import { sharedArgs, legacyRootDirArgs } from './_shared'
 import { fork } from 'node:child_process'
@@ -22,7 +25,7 @@ const command = defineCommand({
   args: {
     ...sharedArgs,
     ...legacyRootDirArgs,
-    ...getArgs(),
+    ...getListhenArgs(),
     dotenv: {
       type: 'string',
       description: 'Path to .env file',
@@ -237,7 +240,7 @@ function _resolveListenOptions(
     ''
 
   return {
-    ...parseArgs({
+    ...parseListhenArgs({
       ...args,
       open: (args.o as boolean) || args.open,
       'https.cert': _httpsCert,
@@ -246,6 +249,7 @@ function _resolveListenOptions(
     port: _port,
     hostname: _hostname,
     public: _public,
+    https: args.https ?? _devServerConfig.https,
     showURL: false,
   }
 }

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -5,7 +5,7 @@ import { loadKit } from '../utils/kit'
 import { importModule } from '../utils/esm'
 import { overrideEnv } from '../utils/env'
 import { defineCommand, ParsedArgs } from 'citty'
-import type { Listener, ListenOptions } from 'listhen'
+import type { HTTPSOptions, Listener, ListenOptions } from 'listhen'
 import {
   getArgs as getListhenArgs,
   parseArgs as parseListhenArgs,
@@ -239,17 +239,28 @@ function _resolveListenOptions(
       _devServerConfig.https?.key) ||
     ''
 
+  const httpsEnabled =
+    args.https == true || (args.https === undefined && !!_devServerConfig.https)
+
+  const _listhenOptions = parseListhenArgs({
+    ...args,
+    open: (args.o as boolean) || args.open,
+    https: httpsEnabled,
+    'https.cert': _httpsCert,
+    'https.key': _httpsKey,
+  })
+
+  const httpsOptions = httpsEnabled && {
+    ...(_devServerConfig.https as HTTPSOptions),
+    ...(_listhenOptions.https as HTTPSOptions),
+  }
+
   return {
-    ...parseListhenArgs({
-      ...args,
-      open: (args.o as boolean) || args.open,
-      'https.cert': _httpsCert,
-      'https.key': _httpsKey,
-    }),
+    ..._listhenOptions,
     port: _port,
     hostname: _hostname,
     public: _public,
-    https: args.https ?? _devServerConfig.https,
     showURL: false,
+    https: httpsOptions,
   }
 }


### PR DESCRIPTION
Resolves #144

When `devServer.https` options are provided, we should enable https mode by default (can be temporarily disabled with `--no-https`)