### PR TITLE
refactor: import `package.json` with json assertion

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -17,7 +17,7 @@ import { findup } from '../utils/fs'
 import { defineCommand } from 'citty'
 
 import { legacyRootDirArgs, sharedArgs } from './_shared'
-import { version } from '../../package.json'
+import nuxiPkg from '../../package.json'
 
 export default defineCommand({
   meta: {
@@ -80,7 +80,7 @@ export default defineCommand({
       OperatingSystem: os.type(),
       NodeVersion: process.version,
       NuxtVersion: nuxtVersion,
-      CLIVersion: version,
+      CLIVersion: nuxiPkg.version,
       NitroVersion: getDepVersion('nitropack'),
       PackageManager: packageManager,
       Builder: builder,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,15 @@ import { defineCommand } from 'citty'
 import { commands } from './commands'
 import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
-import { name, version, description } from '../package.json'
+import nuxiPkg from '../package.json' assert { type: 'json' }
 
 // import { checkForUpdates } from './utils/update'
 
 export const main = defineCommand({
   meta: {
-    name,
-    version,
-    description,
+    name: nuxiPkg.name,
+    version: nuxiPkg.version,
+    description: nuxiPkg.description,
   },
   subCommands: commands,
   async setup(ctx) {

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -1,13 +1,13 @@
 import clear from 'clear'
 import { bold, gray, green } from 'colorette'
-import { version } from '../../package.json'
+import nuxiPkg from '../../package.json'
 import { tryRequireModule } from './cjs'
 
 export function showBanner(_clear?: boolean) {
   if (_clear) {
     clear()
   }
-  console.log(gray(`Nuxt CLI ${bold(version)}`))
+  console.log(gray(`Nuxt CLI ${bold(nuxiPkg.version)}`))
 }
 
 export function showVersions(cwd: string) {

--- a/src/utils/engines.ts
+++ b/src/utils/engines.ts
@@ -1,4 +1,4 @@
-import { engines } from '../../package.json'
+import nuxiPkg from '../../package.json'
 
 export async function checkEngines() {
   const satisfies = await import('semver/functions/satisfies.js').then(
@@ -6,7 +6,7 @@ export async function checkEngines() {
       r.default || (r as any as typeof import('semver/functions/satisfies.js')),
   ) // npm/node-semver#381
   const currentNode = process.versions.node
-  const nodeRange = engines.node
+  const nodeRange = nuxiPkg.engines.node
 
   if (!satisfies(currentNode, nodeRange)) {
     console.warn(

--- a/src/utils/update.ts
+++ b/src/utils/update.ts
@@ -1,4 +1,4 @@
-import { name as pkgName, version as currentVersion } from '../../package.json'
+import nuxiPkg from '../../package.json'
 import { $fetch } from 'ofetch'
 import { cyan, green, yellow, underline } from 'colorette'
 import consola from 'consola'
@@ -9,12 +9,12 @@ export async function checkForUpdates() {
     return
   }
   const { version: latestVersion = '' } = await $fetch(
-    `https://registry.npmjs.org/${pkgName}/latest`,
+    `https://registry.npmjs.org/${nuxiPkg.name}/latest`,
   )
   if (!latestVersion) {
     return
   }
-  if (semver.gt(latestVersion, currentVersion, { loose: true })) {
+  if (semver.gt(latestVersion, nuxiPkg.version, { loose: true })) {
     const changelogURL = `https://github.com/nuxt/cli/releases/tag/v${latestVersion}`
     consola.box({
       title: 'Nuxt CLI Update is Available!',
@@ -23,11 +23,11 @@ export async function checkForUpdates() {
       },
       message: [
         `A new version of Nuxt CLI is available: ${green(latestVersion)}`,
-        `You are currently using ${yellow(currentVersion)}`,
+        `You are currently using ${yellow(nuxiPkg.version)}`,
         '',
         `Release notes: ${underline(cyan(changelogURL))}`,
         '',
-        `To update: \`npm install -g ${pkgName}\``,
+        `To update: \`npm install -g ${nuxiPkg.name}\``,
       ].join('\n'),
     })
   }


### PR DESCRIPTION
Use import assertion + default import of package.json. While this adds (relatively) little to the dist size, helps better compatibility with using Bun and other toolings.