### PR TITLE
fix(dev): add polyfill for `writeTypes`

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,9 +1,6 @@
 import { relative, resolve } from 'pathe'
 import { consola } from 'consola'
 import type { Nitro } from 'nitropack'
-// we are deliberately inlining this code as a backup in case user has `@nuxt/schema<3.7`
-import { writeTypes as writeTypesLegacy } from '@nuxt/kit'
-
 import { loadKit } from '../utils/kit'
 import { clearBuildDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
@@ -35,14 +32,9 @@ export default defineCommand({
 
     showVersions(cwd)
 
-    const {
-      loadNuxt,
-      buildNuxt,
-      useNitro,
-      writeTypes = writeTypesLegacy,
-    } = await loadKit(cwd)
+    const kit = await loadKit(cwd)
 
-    const nuxt = await loadNuxt({
+    const nuxt = await kit.loadNuxt({
       rootDir: cwd,
       dotenv: {
         cwd,
@@ -61,21 +53,21 @@ export default defineCommand({
     // In Bridge, if nitro is not enabled, useNitro will throw an error
     try {
       // Use ? for backward compatibility for Nuxt <= RC.10
-      nitro = useNitro?.()
+      nitro = kit.useNitro?.()
     } catch {
       //
     }
 
     await clearBuildDir(nuxt.options.buildDir)
 
-    await writeTypes(nuxt)
+    await kit.writeTypes(nuxt)
 
     nuxt.hook('build:error', (err) => {
       consola.error('Nuxt Build Error:', err)
       process.exit(1)
     })
 
-    await buildNuxt(nuxt)
+    await kit.buildNuxt(nuxt)
 
     if (ctx.args.prerender) {
       if (!nuxt.options.ssr) {


### PR DESCRIPTION
This PR resolves #157

Previously we were having a polyfill for `writeTypes` that is only available in Nuxt 3.7+. 

This PR adds it from one place so in the future, we don't forget in some places.