### PR TITLE
fix: allow overriding internal dev server error via `_PORT`

### DIFF
--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -48,6 +48,7 @@ export default defineCommand({
       clear: !!ctx.args.clear,
       dotenv: !!ctx.args.dotenv,
       https: devProxyOptions.https,
+      port: process.env._PORT ?? undefined,
     })
 
     // IPC Hooks

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -24,13 +24,14 @@ export interface NuxtDevServerOptions {
   clear: boolean
   overrides: NuxtConfig
   https?: boolean | HTTPSOptions
+  port?: string | number
   loadingTemplate?: ({ loading }: { loading: string }) => string
 }
 
 export async function createNuxtDevServer(options: NuxtDevServerOptions) {
   const devServer = new NuxtDevServer(options)
   devServer.listener = await listen(devServer.handler, {
-    port: 0,
+    port: options.port ?? 0,
     hostname: '127.0.0.1',
     showURL: false,
   })


### PR DESCRIPTION
The internal `_PORT` was introduced in #94 in order to make running in test env easier and used in `@nuxt/test-utils`

With #53 rewrites, it is unnecessary for test utils to depend on `_dev` as main `dev` commands smartly disables forked mode for testing environment but this fix avoid a regression (i hope for a while until all migrate to latest test-utils and we land migration back to main `dev`)