### PR TITLE
fix: Allow layers to define devServer

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -226,8 +226,10 @@ function _resolveListenOptions(
   args: ParsedArgs<ArgsT>,
 ): Partial<ListenOptions> {
   // TODO: Default host in schema should be undefined
-  const _devServerConfig =
-    (nuxtOptions._layers?.[0].config || nuxtOptions)?.devServer || {}
+  const _devServerConfig = 
+    nuxtOptions._layers?.[0].config?.devServer || 
+    nuxtOptions.devServer || 
+    {}
 
   const _port =
     args.port ??


### PR DESCRIPTION
Prior to Nux(t/i) 3.7 the layers could predefine the dev server. This is no longer the case. 

This was something we used for all our internal projects to allow setting the devServer URL using an `APP_URL` env var, which also included HTTPS config for all our developers. So I'm hoping it is just an oversight and not intentional. 

This PR amends the resolution to use any dev server configuration, not just the app layer.