### PR TITLE
fix(dev): use dedicated signal for restart

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -150,16 +150,16 @@ async function _createDevProxy(
 async function _startSubprocess(devProxy: DevProxy) {
   let childProc: ChildProcess | undefined
 
-  const kill = () => {
+  const kill = (signal: NodeJS.Signals | number) => {
     if (childProc) {
-      childProc.kill(0)
+      childProc.kill(signal)
       childProc = undefined
     }
   }
 
   const restart = async () => {
-    // Kill previous process
-    kill()
+    // Kill previous process with restart signal
+    kill('SIGHUP')
 
     // Start new process
     childProc = fork(
@@ -209,7 +209,7 @@ async function _startSubprocess(devProxy: DevProxy) {
     'SIGQUIT' /* Ctrl-\ */,
   ] as const) {
     process.once(signal, () => {
-      kill()
+      kill(signal === 'exit' ? 0 : signal)
     })
   }
 


### PR DESCRIPTION
While normally no modules should directly call `process.exit(0)` within nuxt build process / dev, some might (for example for testing). 

This PR uses internal `SIGHUP` which is commonly used in UNIX processes as restart indicator for internal reload (we shall later also support it for main process)