### PR TITLE
feat(dev): reuse main dev port for vite hmr

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -153,6 +153,13 @@ class NuxtDevServer extends EventEmitter {
       (config, { isClient }) => {
         if (isClient && config.server) {
           config.server.hmr = {
+            ...(config.server.hmr as Exclude<
+              typeof config.server.hmr,
+              boolean
+            >),
+            protocol: undefined,
+            port: undefined,
+            host: undefined,
             server: this.listener.server,
           }
         }

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -147,6 +147,18 @@ class NuxtDevServer extends EventEmitter {
       },
     })
 
+    // Connect Vite HMR
+    this._currentNuxt.hooks.hookOnce(
+      'vite:extendConfig',
+      (config, { isClient }) => {
+        if (isClient && config.server) {
+          config.server.hmr = {
+            server: this.listener.server,
+          }
+        }
+      },
+    )
+
     // Write manifest and also check if we need cache invalidation
     if (!reload) {
       const previousManifest = await loadNuxtManifest(

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -158,6 +158,9 @@ class NuxtDevServer extends EventEmitter {
         }
       },
     )
+    this._currentNuxt.hooks.hookOnce('close', () => {
+      this.listener.server.removeAllListeners('upgrade')
+    })
 
     // Write manifest and also check if we need cache invalidation
     if (!reload) {


### PR DESCRIPTION
This PR enables Nuxt to use main dev server as HMR server instead of requiring an external port.

Instead of updating Nuxt, using hook in nuxi allows moving forward faster and keep it closer to the listener.

~~Current issues: Vite keeps hooking on internal web server for ws. After a (soft) reload, hmr will be broken~~

Currently, seems quite fast and stable. 


https://github.com/nuxt/cli/assets/5158436/b23573f9-61d1-4611-bac6-73cc511f69dd


