### PR TITLE
chore: allow disabling vite hmr port integration

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -148,23 +148,27 @@ class NuxtDevServer extends EventEmitter {
     })
 
     // Connect Vite HMR
-    this._currentNuxt.hooks.hookOnce(
-      'vite:extendConfig',
-      (config, { isClient }) => {
-        if (isClient && config.server) {
-          config.server.hmr = {
-            ...(config.server.hmr as Exclude<
-              typeof config.server.hmr,
-              boolean
-            >),
-            protocol: undefined,
-            port: undefined,
-            host: undefined,
-            server: this.listener.server,
+    if (!process.env._NUXI_DISABLE_VITE_HMR) {
+      this._currentNuxt.hooks.hookOnce(
+        'vite:extendConfig',
+        (config, { isClient }) => {
+          if (isClient && config.server) {
+            config.server.hmr = {
+              ...(config.server.hmr as Exclude<
+                typeof config.server.hmr,
+                boolean
+              >),
+              protocol: undefined,
+              port: undefined,
+              host: undefined,
+              server: this.listener.server,
+            }
           }
-        }
-      },
-    )
+        },
+      )
+    }
+
+    // Remove websocket handlers on close
     this._currentNuxt.hooks.hookOnce('close', () => {
       this.listener.server.removeAllListeners('upgrade')
     })

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -148,7 +148,7 @@ class NuxtDevServer extends EventEmitter {
     })
 
     // Connect Vite HMR
-    if (!process.env._NUXI_DISABLE_VITE_HMR) {
+    if (!process.env.NUXI_DISABLE_VITE_HMR) {
       this._currentNuxt.hooks.hookOnce(
         'vite:extendConfig',
         (config, { isClient }) => {


### PR DESCRIPTION
Followup on #184

Since this is a new feature, there might be conditions we might want to disable hmr port integration. ~~Also seems bun has some issues which we might need to disable for bun for now.~~ 

This PR allows disabling the effect of #184 using `NUXI_DISABLE_VITE_HMR` env. It is not a flag since probably won't last long.