### PR TITLE
feat: modules db integration with `nuxi module add`

### DIFF
--- a/src/commands/module/_utils.ts
+++ b/src/commands/module/_utils.ts
@@ -27,6 +27,9 @@ export const categories = [
 export interface ModuleCompatibility {
   nuxt: string
   requires: { bridge?: boolean | 'optional' }
+  versionMap: {
+    [nuxtVersion: string]: string
+  }
 }
 
 export interface MaintainerInfo {

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -176,17 +176,6 @@ async function resolveModule(
       }
     }
 
-    // TODO: Preview for https://github.com/nuxt/modules/pull/770
-    if (
-      matchedModule.name === 'image' &&
-      !matchedModule.compatibility.versionMap
-    ) {
-      matchedModule.compatibility.versionMap = {
-        '^2.x': '^0',
-        '^3.x': 'rc',
-      }
-    }
-
     // Match corresponding version of module for local Nuxt version
     const versionMap = matchedModule.compatibility.versionMap
     if (versionMap) {

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -162,7 +162,7 @@ async function resolveModule(
     // Check for Module Compatibility
     if (!checkNuxtCompatibility(matchedModule, nuxtVersion)) {
       consola.warn(
-        `The module \`${pkgName}\` is not compatible with Nuxt ${nuxtVersion} (requires ${matchedModule.compatibility.nuxt})`,
+        `The module \`${pkgName}\` is not compatible with Nuxt \`${nuxtVersion}\` (requires \`${matchedModule.compatibility.nuxt}\`)`,
       )
       const shouldContinue = await consola.prompt(
         'Do you want to continue installing incompatible version?',

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -159,14 +159,15 @@ async function resolveModule(
         '^2.x': '^0',
         '^3.x': 'rc',
       }
-      // Match corresponding version of module for local Nuxt version
-      const versionMap = matchedModule.compatibility.versionMap
-      if (versionMap) {
-        for (const _nuxtVersion in versionMap) {
-          if (satisfies(nuxtVersion, _nuxtVersion)) {
-            npmName = `${npmName}@${versionMap[_nuxtVersion]}`
-            break
-          }
+    }
+
+    // Match corresponding version of module for local Nuxt version
+    const versionMap = matchedModule.compatibility.versionMap
+    if (versionMap) {
+      for (const _nuxtVersion in versionMap) {
+        if (satisfies(nuxtVersion, _nuxtVersion)) {
+          npmName = `${npmName}@${versionMap[_nuxtVersion]}`
+          break
         }
       }
     }

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -185,7 +185,7 @@ async function resolveModule(
             pkgVersion = _moduleVersion
           } else {
             consola.warn(
-              `Recommanded version of \`${pkgName}\` for Nuxt \`${nuxtVersion}\` is \`${_moduleVersion}\` but you have requested \`${pkgVersion}\``,
+              `Recommended version of \`${pkgName}\` for Nuxt \`${nuxtVersion}\` is \`${_moduleVersion}\` but you have requested \`${pkgVersion}\``,
             )
             pkgVersion = await consola.prompt('Choose a version:', {
               type: 'select',

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -26,10 +26,6 @@ export default defineCommand({
       type: 'boolean',
       description: 'Skip nuxt.config.ts update',
     },
-    exact: {
-      type: 'string',
-      description: 'use exact module name as npm package name to install',
-    },
   },
   async setup(ctx) {
     const cwd = resolve(ctx.args.cwd || '.')

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -179,17 +179,17 @@ async function resolveModule(
     // Match corresponding version of module for local Nuxt version
     const versionMap = matchedModule.compatibility.versionMap
     if (versionMap) {
-      for (const _version in versionMap) {
-        if (satisfies(nuxtVersion, _version)) {
+      for (const [_nuxtVersion, _moduleVersion] of Object.entries(versionMap)) {
+        if (satisfies(nuxtVersion, _nuxtVersion)) {
           if (!pkgVersion) {
-            pkgVersion = versionMap[_version]
+            pkgVersion = _moduleVersion
           } else {
             consola.warn(
-              `Recommanded version of \`${pkgName}\` for Nuxt \`${nuxtVersion}\` is \`${_version}\` but you have requested \`${pkgVersion}\``,
+              `Recommanded version of \`${pkgName}\` for Nuxt \`${nuxtVersion}\` is \`${_moduleVersion}\` but you have requested \`${pkgVersion}\``,
             )
-            pkgVersion = await consola.prompt('Choose a version', {
+            pkgVersion = await consola.prompt('Choose a version:', {
               type: 'select',
-              options: [versionMap[_version], pkgVersion],
+              options: [_moduleVersion, pkgVersion],
             })
           }
           break


### PR DESCRIPTION
- resolves #194
- resolves https://github.com/nuxt/rfcs/issues/31 (from 2019!)

----

Search in [nuxt/modules](https://github.com/nuxt/modules) database when adding a new module. This allows installing modules as easy as `nuxt module add tailwindcss`.

## Compatibility Checker

This feature checks for possible compatibility issues and confirms whether to continue or not.

`nuxi module add axios` on a nuxt 3 project:

<img width="622" alt="image" src="https://github.com/nuxt/cli/assets/5158436/9c395061-acb9-4c7f-af55-69ad6f781770">

## Offline Usage

In case of network issues, we fall back with a warning and use the input as npm package name without validation. This could be improved later with `--preferOffline` and a disk cache of modules (to be used also for search functionality). (PR welcome!)

## Automatically choosing the right version

Some Nuxt modules use different major versions for different Nuxt versions (such as image Module).

With the introduction of `compatibility.versionMap` in modules DB (https://github.com/nuxt/modules/pull/770), we can now even match the corresponding version compatible with the local Nuxt version. 

`nuxi module add image` on a nuxt 3 project:

<img width="482" alt="image" src="https://github.com/nuxt/cli/assets/5158436/d9727617-7c73-4d2a-a091-5618bfe00351">

## Validate (npm) input

Users can choose to directly use an npm package name (with optional `@` constraint) to be installed. 

Also in this mode, we try to match explicitly provided npm package names against DB and provide recommendations!

`nuxi module add @nuxt/image@^0.6.0` on a nuxt 3 project:

<img width="674" alt="image" src="https://github.com/nuxt/cli/assets/5158436/75621a01-5afc-424b-b977-ee3f6fc1126c">
