### PR TITLE
fix: make dev proxy url available for `listen` hook

### DIFF
--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -4,14 +4,7 @@ import { overrideEnv } from '../utils/env'
 import { defineCommand } from 'citty'
 import { sharedArgs, legacyRootDirArgs } from './_shared'
 import { isTest } from 'std-env'
-import { NuxtDevIPCMessage, createNuxtDevServer } from '../utils/dev'
-import type { ListenURL, HTTPSOptions } from 'listhen'
-
-export type DevChildContext = {
-  url?: string
-  urls?: ListenURL[]
-  https?: boolean | HTTPSOptions
-}
+import { NuxtDevContext, NuxtDevIPCMessage, createNuxtDevServer } from '../utils/dev'
 
 export default defineCommand({
   meta: {
@@ -36,9 +29,9 @@ export default defineCommand({
     overrideEnv('development')
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
 
-    // Get host info
-    const devProxyOptions: DevChildContext =
-      JSON.parse(process.env.__NUXT_DEV_PROXY__ || 'null') || {}
+    // Get dev context info
+    const devContext: NuxtDevContext =
+      JSON.parse(process.env.__NUXT_DEV__ || 'null') || {}
 
     // Init Nuxt dev
     const nuxtDev = await createNuxtDevServer({
@@ -47,8 +40,8 @@ export default defineCommand({
       logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
       clear: !!ctx.args.clear,
       dotenv: !!ctx.args.dotenv,
-      https: devProxyOptions.https,
       port: process.env._PORT ?? undefined,
+      devContext,
     })
 
     // IPC Hooks

--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -4,7 +4,11 @@ import { overrideEnv } from '../utils/env'
 import { defineCommand } from 'citty'
 import { sharedArgs, legacyRootDirArgs } from './_shared'
 import { isTest } from 'std-env'
-import { NuxtDevContext, NuxtDevIPCMessage, createNuxtDevServer } from '../utils/dev'
+import {
+  NuxtDevContext,
+  NuxtDevIPCMessage,
+  createNuxtDevServer,
+} from '../utils/dev'
 
 export default defineCommand({
   meta: {

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -84,8 +84,8 @@ const command = defineCommand({
             https: devProxy.listener.https,
             url: devProxy.listener.url,
             urls: await devProxy.listener.getURLs(),
-          }
-        }
+          },
+        },
       })
       devProxy.setAddress(devServer.listener.url)
       await devServer.init()
@@ -182,7 +182,7 @@ async function _startSubprocess(devProxy: DevProxy) {
               url: devProxy.listener.url,
               urls: await devProxy.listener.getURLs(),
               https: devProxy.listener.https,
-            }
+            },
           } satisfies NuxtDevContext),
         },
       },
@@ -244,16 +244,16 @@ function _resolveListenOptions(
     typeof args.host === 'string'
       ? args.host
       : (args.host === true ? '' : undefined) ??
-      process.env.NUXT_HOST ??
-      process.env.NITRO_HOST ??
-      process.env.HOST ??
-      // TODO: Default host in schema should be undefined instead of ''
-      nuxtOptions._layers?.[0].config?.devServer?.host ??
-      undefined
+        process.env.NUXT_HOST ??
+        process.env.NITRO_HOST ??
+        process.env.HOST ??
+        // TODO: Default host in schema should be undefined instead of ''
+        nuxtOptions._layers?.[0].config?.devServer?.host ??
+        undefined
 
   const _public: boolean | undefined =
     args.public ??
-      (_hostname && !['localhost', '127.0.0.1', '::1'].includes(_hostname))
+    (_hostname && !['localhost', '127.0.0.1', '::1'].includes(_hostname))
       ? true
       : undefined
 

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -18,7 +18,7 @@ export type NuxtDevIPCMessage =
   | { type: 'nuxt:internal:dev:restart' }
 
 export interface NuxtDevContext {
-  proxy: {
+  proxy?: {
     url?: string
     urls?: ListenURL[]
     https?: boolean | HTTPSOptions
@@ -110,7 +110,7 @@ class NuxtDevServer extends EventEmitter {
         await importModule('@nuxt/ui-templates', this.options.cwd).then(
           (r) => r.loading,
         )
-      ).catch(() => {}) ||
+      ).catch(() => { }) ||
       ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
     res.end(
       loadingTemplate({
@@ -234,11 +234,10 @@ class NuxtDevServer extends EventEmitter {
     const addr = this.listener.address
     this._currentNuxt.options.devServer.host = addr.address
     this._currentNuxt.options.devServer.port = addr.port
-    this._currentNuxt.options.devServer.url = `http://${
-      addr.address.includes(':') ? `[${addr.address}]` : addr.address
-    }:${addr.port}/`
+    this._currentNuxt.options.devServer.url = `http://${addr.address.includes(':') ? `[${addr.address}]` : addr.address
+      }:${addr.port}/`
     this._currentNuxt.options.devServer.https = this.options.devContext.proxy
-      .https as boolean | { key: string; cert: string }
+      ?.https as boolean | { key: string; cert: string }
 
     await Promise.all([
       kit.writeTypes(this._currentNuxt).catch(console.error),

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -110,7 +110,7 @@ class NuxtDevServer extends EventEmitter {
         await importModule('@nuxt/ui-templates', this.options.cwd).then(
           (r) => r.loading,
         )
-      ).catch(() => { }) ||
+      ).catch(() => {}) ||
       ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
     res.end(
       loadingTemplate({
@@ -234,8 +234,9 @@ class NuxtDevServer extends EventEmitter {
     const addr = this.listener.address
     this._currentNuxt.options.devServer.host = addr.address
     this._currentNuxt.options.devServer.port = addr.port
-    this._currentNuxt.options.devServer.url = `http://${addr.address.includes(':') ? `[${addr.address}]` : addr.address
-      }:${addr.port}/`
+    this._currentNuxt.options.devServer.url = `http://${
+      addr.address.includes(':') ? `[${addr.address}]` : addr.address
+    }:${addr.port}/`
     this._currentNuxt.options.devServer.https = this.options.devContext.proxy
       ?.https as boolean | { key: string; cert: string }
 

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -5,7 +5,7 @@ import chokidar from 'chokidar'
 import { consola } from 'consola'
 import { debounce } from 'perfect-debounce'
 import { toNodeListener } from 'h3'
-import { HTTPSOptions, listen, Listener } from 'listhen'
+import { HTTPSOptions, ListenURL, listen, Listener } from 'listhen'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { loadKit } from '../utils/kit'
 import { loadNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
@@ -17,24 +17,49 @@ export type NuxtDevIPCMessage =
   | { type: 'nuxt:internal:dev:loading'; message: string }
   | { type: 'nuxt:internal:dev:restart' }
 
+
+export interface NuxtDevContext {
+  proxy: {
+    url?: string
+    urls?: ListenURL[]
+    https?: boolean | HTTPSOptions
+  }
+}
+
 export interface NuxtDevServerOptions {
   cwd: string
   logLevel: 'silent' | 'info' | 'verbose'
   dotenv: boolean
   clear: boolean
   overrides: NuxtConfig
-  https?: boolean | HTTPSOptions
   port?: string | number
   loadingTemplate?: ({ loading }: { loading: string }) => string
+  devContext: NuxtDevContext
 }
 
 export async function createNuxtDevServer(options: NuxtDevServerOptions) {
+  // Initialize dev server
   const devServer = new NuxtDevServer(options)
+
+  // Attach internal listener
   devServer.listener = await listen(devServer.handler, {
     port: options.port ?? 0,
     hostname: '127.0.0.1',
     showURL: false,
   })
+
+  // Merge interface with public context
+  if (options.devContext.proxy?.url) {
+    devServer.listener.url = options.devContext.proxy.url
+  }
+  if (options.devContext.proxy?.urls) {
+    const _getURLs = devServer.listener.getURLs.bind(devServer.listener)
+    devServer.listener.getURLs = async () => Array.from(new Set([
+      ...options.devContext.proxy!.urls!,
+      ...await _getURLs(),
+    ]))
+  }
+
   return devServer
 }
 
@@ -86,7 +111,7 @@ class NuxtDevServer extends EventEmitter {
         await importModule('@nuxt/ui-templates', this.options.cwd).then(
           (r) => r.loading,
         )
-      ).catch(() => {}) ||
+      ).catch(() => { }) ||
       ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
     res.end(
       loadingTemplate({
@@ -210,10 +235,9 @@ class NuxtDevServer extends EventEmitter {
     const addr = this.listener.address
     this._currentNuxt.options.devServer.host = addr.address
     this._currentNuxt.options.devServer.port = addr.port
-    this._currentNuxt.options.devServer.url = `http://${
-      addr.address.includes(':') ? `[${addr.address}]` : addr.address
-    }:${addr.port}/`
-    this._currentNuxt.options.devServer.https = this.options.https as
+    this._currentNuxt.options.devServer.url = `http://${addr.address.includes(':') ? `[${addr.address}]` : addr.address
+      }:${addr.port}/`
+    this._currentNuxt.options.devServer.https = this.options.devContext.proxy.https as
       | boolean
       | { key: string; cert: string }
 

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -17,7 +17,6 @@ export type NuxtDevIPCMessage =
   | { type: 'nuxt:internal:dev:loading'; message: string }
   | { type: 'nuxt:internal:dev:restart' }
 
-
 export interface NuxtDevContext {
   proxy: {
     url?: string
@@ -54,10 +53,10 @@ export async function createNuxtDevServer(options: NuxtDevServerOptions) {
   }
   if (options.devContext.proxy?.urls) {
     const _getURLs = devServer.listener.getURLs.bind(devServer.listener)
-    devServer.listener.getURLs = async () => Array.from(new Set([
-      ...options.devContext.proxy!.urls!,
-      ...await _getURLs(),
-    ]))
+    devServer.listener.getURLs = async () =>
+      Array.from(
+        new Set([...options.devContext.proxy!.urls!, ...(await _getURLs())]),
+      )
   }
 
   return devServer
@@ -111,7 +110,7 @@ class NuxtDevServer extends EventEmitter {
         await importModule('@nuxt/ui-templates', this.options.cwd).then(
           (r) => r.loading,
         )
-      ).catch(() => { }) ||
+      ).catch(() => {}) ||
       ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
     res.end(
       loadingTemplate({
@@ -235,11 +234,11 @@ class NuxtDevServer extends EventEmitter {
     const addr = this.listener.address
     this._currentNuxt.options.devServer.host = addr.address
     this._currentNuxt.options.devServer.port = addr.port
-    this._currentNuxt.options.devServer.url = `http://${addr.address.includes(':') ? `[${addr.address}]` : addr.address
-      }:${addr.port}/`
-    this._currentNuxt.options.devServer.https = this.options.devContext.proxy.https as
-      | boolean
-      | { key: string; cert: string }
+    this._currentNuxt.options.devServer.url = `http://${
+      addr.address.includes(':') ? `[${addr.address}]` : addr.address
+    }:${addr.port}/`
+    this._currentNuxt.options.devServer.https = this.options.devContext.proxy
+      .https as boolean | { key: string; cert: string }
 
     await Promise.all([
       kit.writeTypes(this._currentNuxt).catch(console.error),


### PR DESCRIPTION
resolves #205

This PR includes a refactor to preserve more context of dev server / proxy and give it to the internal `listener` instance that is passed to `listen` hook usable for modules.

```ts
export default defineNuxtConfig({
  hooks: {
    listen: async (_server, listener) => {
      console.log('listener.url', listener.url)
      console.log('listener.getURLs', JSON.stringify(await listener.getURLs()))
    },
  },
})
```

```
listener.url http://localhost:3000/                                                                                                              

listener.getURLs [{"url":"http://localhost:3000/","type":"local"},{"url":"http://127.0.0.1:50409/","type":"local"}]   
```