### PR TITLE
fix: prompt to abort `module add` if install failed

### DIFF
--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -12,6 +12,7 @@ import {
   getNuxtVersion,
 } from './_utils'
 import { satisfies } from 'semver'
+import { colors } from 'consola/utils'
 
 export default defineCommand({
   meta: {
@@ -44,12 +45,25 @@ export default defineCommand({
     // Add npm dependency
     if (!ctx.args.skipInstall) {
       consola.info(`Installing dev dependency \`${r.pkg}\``)
-      await addDependency(r.pkg, { cwd, dev: true }).catch((err) => {
-        consola.error(err)
-        consola.error(
-          `Please manually install \`${r.pkg}\` as a dev dependency`,
-        )
-      })
+      const res = await addDependency(r.pkg, { cwd, dev: true }).catch(
+        (error) => {
+          consola.error(error)
+          return consola.prompt(
+            `Install failed for ${colors.cyan(
+              r.pkg,
+            )}. Do you want to continue adding the module to ${colors.cyan(
+              'nuxt.config',
+            )}?`,
+            {
+              type: 'confirm',
+              initial: false,
+            },
+          )
+        },
+      )
+      if (res === false) {
+        return
+      }
     }
 
     // Update nuxt.config.ts


### PR DESCRIPTION
Resolves #131

<img width="690" alt="image" src="https://github.com/nuxt/cli/assets/5158436/bc571ba0-71b4-47a0-8b65-bab59b3584cb">
