### PR TITLE
fix: respect buildDir in `cleanup`, `analyze` and `upgrade`

### DIFF
--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -3,6 +3,7 @@ import { cleanupNuxtDirs } from '../utils/nuxt'
 import { defineCommand } from 'citty'
 
 import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { loadKit } from '../utils/kit'
 
 export default defineCommand({
   meta: {
@@ -15,6 +16,15 @@ export default defineCommand({
   },
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
-    await cleanupNuxtDirs(cwd)
+
+    const { loadNuxt } = await loadKit(cwd)
+    const nuxt = await loadNuxt({
+      rootDir: cwd,
+      overrides: {
+        ...ctx.data?.overrides,
+      },
+    })
+
+    await cleanupNuxtDirs(cwd, nuxt.options.buildDir)
   },
 })

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -12,6 +12,7 @@ import { cleanupNuxtDirs, nuxtVersionToGitIdentifier } from '../utils/nuxt'
 import { defineCommand } from 'citty'
 
 import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { loadKit } from '../utils/kit'
 
 async function getNuxtVersion(path: string): Promise<string | null> {
   try {
@@ -88,8 +89,17 @@ export default defineCommand({
       { stdio: 'inherit', cwd },
     )
 
+    // Load nuxt for cleanup buildDir
+    const { loadNuxt } = await loadKit(cwd)
+    const nuxt = await loadNuxt({
+      rootDir: cwd,
+      overrides: {
+        ...ctx.data?.overrides,
+      },
+    })
+
     // Cleanup after upgrade
-    await cleanupNuxtDirs(cwd)
+    await cleanupNuxtDirs(cwd, nuxt.options.buildDir)
 
     // Check installed nuxt version again
     const upgradedVersion = (await getNuxtVersion(cwd)) || '[unknown]'

--- a/src/utils/nuxt.ts
+++ b/src/utils/nuxt.ts
@@ -15,17 +15,13 @@ export interface NuxtProjectManifest {
   }
 }
 
-export async function cleanupNuxtDirs(rootDir: string) {
+export async function cleanupNuxtDirs(rootDir: string, buildDir: string) {
   consola.info('Cleaning up generated nuxt files and caches...')
 
   await rmRecursive(
-    [
-      '.nuxt',
-      '.output',
-      'dist',
-      'node_modules/.vite',
-      'node_modules/.cache',
-    ].map((dir) => resolve(rootDir, dir)),
+    ['.output', 'dist', 'node_modules/.vite', 'node_modules/.cache']
+      .map((dir) => resolve(rootDir, dir))
+      .concat(buildDir),
   )
 }
 


### PR DESCRIPTION
This tries to resolve #225

I am not particularly happy with the fact that I had to add the boilerplate of `loadKit()` & `loadNuxt()` multiple times just to get the buildDir passed down, but that's what felt most in line with the current setup. 

Marking as draft as `analyze` feeds the hardcoded path into loadNuxt, so still trying to wrap my head around how to resolve the path beforehand, ideally without calling `loadNuxt()` twice.