### PR TITLE
fix: call `nuxt.ready()` before registering hooks

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -207,7 +207,9 @@ class NuxtDevServer extends EventEmitter {
     }
 
     // Remove websocket handlers on close
-    this._currentNuxt.hooks.hook('close', () => {
+    // nuxt bridge doesn't have support for `hookOnce` here
+    const unsubClose = this._currentNuxt.hooks.hook('close', () => {
+      unsubClose()
       this.listener.server.removeAllListeners('upgrade')
     })
 

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -184,7 +184,7 @@ class NuxtDevServer extends EventEmitter {
         ...this.options.overrides,
       },
     })
-
+    await this._currentNuxt.ready();
     // Connect Vite HMR
     if (!process.env.NUXI_DISABLE_VITE_HMR) {
       this._currentNuxt.hooks.hook(
@@ -207,7 +207,7 @@ class NuxtDevServer extends EventEmitter {
     }
 
     // Remove websocket handlers on close
-    this._currentNuxt.hooks.hookOnce('close', () => {
+    this._currentNuxt.hooks.hook('close', () => {
       this.listener.server.removeAllListeners('upgrade')
     })
 
@@ -225,8 +225,6 @@ class NuxtDevServer extends EventEmitter {
         await clearBuildDir(this._currentNuxt.options.buildDir)
       }
     }
-
-    await this._currentNuxt.ready()
 
     const unsub = this._currentNuxt.hooks.hook('restart', async (options) => {
       unsub() // We use this instead of `hookOnce` for Nuxt Bridge support

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -184,7 +184,7 @@ class NuxtDevServer extends EventEmitter {
         ...this.options.overrides,
       },
     })
-    await this._currentNuxt.ready();
+    await this._currentNuxt.ready()
     // Connect Vite HMR
     if (!process.env.NUXI_DISABLE_VITE_HMR) {
       this._currentNuxt.hooks.hook(


### PR DESCRIPTION
@pi0 please check. Fixed issue: https://github.com/nuxt/bridge/issues/918

this happen only 3.9.0. But 3.8.4 work normally