### PR TITLE
fix: support `-nightly` nuxt releases and publish `nuxi-nightly`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           !contains(github.event.head_commit.message, 'docs')
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc &&
-          pnpm changelogen --canary edge --publish
+          pnpm changelogen --canary nightly --publish
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: false

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -56,6 +56,7 @@ export default defineCommand({
     // Check nuxt version
     const nuxtVersion =
       getDepVersion('nuxt') ||
+      getDepVersion('nuxt-nightly') ||
       getDepVersion('nuxt-edge') ||
       getDepVersion('nuxt3') ||
       '-'

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -42,7 +42,11 @@ export default defineCommand({
 // @ts-ignore TODO
 async function importTestUtils(): Promise<typeof import('@nuxt/test-utils')> {
   let err
-  for (const pkg of ['@nuxt/test-utils-nightly', '@nuxt/test-utils-edge', '@nuxt/test-utils']) {
+  for (const pkg of [
+    '@nuxt/test-utils-nightly',
+    '@nuxt/test-utils-edge',
+    '@nuxt/test-utils',
+  ]) {
     try {
       const exports = await import(pkg)
       // Detect old @nuxt/test-utils

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -42,7 +42,7 @@ export default defineCommand({
 // @ts-ignore TODO
 async function importTestUtils(): Promise<typeof import('@nuxt/test-utils')> {
   let err
-  for (const pkg of ['@nuxt/test-utils-edge', '@nuxt/test-utils']) {
+  for (const pkg of ['@nuxt/test-utils-nightly', '@nuxt/test-utils-edge', '@nuxt/test-utils']) {
     try {
       const exports = await import(pkg)
       // Detect old @nuxt/test-utils
@@ -56,6 +56,6 @@ async function importTestUtils(): Promise<typeof import('@nuxt/test-utils')> {
   }
   console.error(err)
   throw new Error(
-    '`@nuxt/test-utils-edge` seems missing. Run `npm i -D @nuxt/test-utils-edge` or `yarn add -D @nuxt/test-utils-edge` to install.',
+    '`@nuxt/test-utils` seems missing. Run `npm i -D @nuxt/test-utils` or `yarn add -D @nuxt/test-utils` to install.',
   )
 }

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -5,8 +5,13 @@ export function showVersions(cwd: string) {
   const getPkgVersion = (pkg: string) => {
     return tryRequireModule(`${pkg}/package.json`, cwd)?.version || ''
   }
-  const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-nightly') || getPkgVersion('nuxt3') || getPkgVersion('nuxt-edge')
-  const nitroVersion = getPkgVersion('nitropack') || getPkgVersion('nitropack-edge')
+  const nuxtVersion =
+    getPkgVersion('nuxt') ||
+    getPkgVersion('nuxt-nightly') ||
+    getPkgVersion('nuxt3') ||
+    getPkgVersion('nuxt-edge')
+  const nitroVersion =
+    getPkgVersion('nitropack') || getPkgVersion('nitropack-edge')
   console.log(
     gray(
       green(`Nuxt ${bold(nuxtVersion)}`) +

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -5,8 +5,8 @@ export function showVersions(cwd: string) {
   const getPkgVersion = (pkg: string) => {
     return tryRequireModule(`${pkg}/package.json`, cwd)?.version || ''
   }
-  const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-edge')
-  const nitroVersion = getPkgVersion('nitropack')
+  const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-nightly') || getPkgVersion('nuxt3') || getPkgVersion('nuxt-edge')
+  const nitroVersion = getPkgVersion('nitropack') || getPkgVersion('nitropack-edge')
   console.log(
     gray(
       green(`Nuxt ${bold(nuxtVersion)}`) +

--- a/src/utils/kit.ts
+++ b/src/utils/kit.ts
@@ -31,7 +31,7 @@ export const loadKit = async (
 }
 
 async function tryResolveNuxt() {
-  for (const pkg of ['nuxt3', 'nuxt', 'nuxt-edge']) {
+  for (const pkg of ['nuxt-nightly', 'nuxt3', 'nuxt', 'nuxt-edge']) {
     const path = await tryResolveModule(pkg)
     if (path) {
       return path


### PR DESCRIPTION
part of https://github.com/nuxt/nuxt/issues/22143

needs to be merged before: https://github.com/nuxt/nuxt/pull/23508

related: https://github.com/nuxt/cli/commit/d1120b1