### PR TITLE
feat: detecting if cwd contains a nuxt project

### DIFF
--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -3,6 +3,7 @@ import { defineCommand } from 'citty'
 import { sharedArgs } from '../_shared'
 import { existsSync } from 'node:fs'
 import { loadFile, writeFile, parseModule, ProxifiedModule } from 'magicast'
+import { exists } from '../../utils/fs'
 import consola from 'consola'
 import { addDependency } from 'nypm'
 import {
@@ -36,10 +37,25 @@ export default defineCommand({
   },
   async setup(ctx) {
     const cwd = resolve(ctx.args.cwd || '.')
+    const nuxtConfigFile = await exists(resolve(cwd, 'nuxt.config.ts'))
 
     const r = await resolveModule(ctx.args.moduleName, cwd)
     if (r === false) {
       return
+    }
+
+    if (!nuxtConfigFile) {
+      const notValidDirPrompt = await consola.prompt(
+        `This directory does not appear to contain a Nuxt project. Do you still want to continue?`,
+        {
+          type: 'confirm',
+          initial: false,
+        },
+      )
+
+      if (notValidDirPrompt !== true) {
+        return
+      }
     }
 
     // Add npm dependency


### PR DESCRIPTION
This PR is dedicated to checking weather `nuxt.config.ts` exists or not. If not it fires a consola prompt to ask users if they want to proceed or not. Screenshot below for a demo. 


![2023-10-17 at 6  59 10@2x](https://github.com/nuxt/cli/assets/23562275/c2fef282-1a95-4a30-a7b9-b588adab6544)


Fixes #203 