### PR TITLE
feat: add commands to analyse payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build:stub": "unbuild --stub",
     "dev": "node ./bin/nuxi.mjs dev ./playground",
     "dev:bun": "bun --bun ./bin/nuxi.mjs dev ./playground",
+    "build:dev": "node ./bin/nuxi.mjs build ./playground",
+    "generate:dev": "node ./bin/nuxi.mjs generate ./playground",
     "lint": "eslint . && prettier --check src",
     "lint:fix": "eslint --fix . && prettier --write src",
     "nuxi": "node ./bin/nuxi.mjs",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,4 +21,5 @@ export const commands = {
   test: () => import('./test').then(_rDefault),
   typecheck: () => import('./typecheck').then(_rDefault),
   upgrade: () => import('./upgrade').then(_rDefault),
+  payloads: () => import('./payloads').then(_rDefault),
 } as const

--- a/src/commands/payloads.ts
+++ b/src/commands/payloads.ts
@@ -1,0 +1,72 @@
+import { resolve } from "pathe";
+import { defineCommand } from "citty";
+import fs from "node:fs"
+
+import { legacyRootDirArgs, sharedArgs } from './_shared'
+
+export default defineCommand({
+  meta: {
+    name: "payloads",
+    description: "Used to analyse size of generated payloads"
+  },
+  args: {
+    ...sharedArgs,
+    ...legacyRootDirArgs,
+  },
+  async run(ctx) {
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || ".");
+
+    const outputDir = resolve(cwd, ".output");
+    const publicDir = resolve(outputDir, "public");
+
+    // List payloads files in .output/public (can be in subfolders so we call the function recursively)
+    const listPayloads = (sourceDir: string): string[] => {
+      const payloads: string[] = [];
+      const files = fs.readdirSync(sourceDir);
+      files.forEach(file => {
+        const filePath = resolve(sourceDir, file);
+
+        const isFile = fs.statSync(filePath).isFile();
+        if (isFile && file === "_payload.json") {
+          payloads.push(filePath);
+          return
+        }
+
+        const isDirectory = fs.statSync(filePath).isDirectory();
+        if (isDirectory) {
+          const subPayloads = listPayloads(filePath);
+          payloads.push(...subPayloads);
+          return
+        }
+      });
+      return payloads;
+    }
+
+    const payloads = listPayloads(publicDir);
+
+    // Get size of each payload
+    const payloadsSizes = payloads.map(payload => {
+      const payloadSize = fs.statSync(payload).size;
+      return {
+        payload,
+        payloadSize
+      }
+    });
+
+    // Sort payloads by size
+    const sortedPayloads = payloadsSizes.sort((a, b) => b.payloadSize - a.payloadSize);
+
+    // Display sorted payloads
+    sortedPayloads.forEach(payload => {
+      console.log(`${payload.payload} ${toHumainSize(payload.payloadSize)}`);
+    });
+    // TODO: improve output. We could use a table like or a tree like output (waiting for https://github.com/unjs/consola/pull/223).
+  },
+})
+
+function toHumainSize(bytes: number): string {
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+  if (bytes === 0) return "0 Byte";
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${Math.round(bytes / Math.pow(1024, i))} ${sizes[i]}`;
+}


### PR DESCRIPTION
fix #257

Hello,

This is a first draft to fix #257. I'm not sure if it's the best way to do it.

In fact, we could have more options with this features

- add a warning and a error level in order to alert user if a file is too heavy (could throw an error in case of a file too heavy)
- add more formatting options
- add a way to only list ?
- add a way to sort by size or by file path

And maybe more options.
