### PR TITLE
fix(analyze): don't override analyze options

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -48,7 +48,7 @@ export default defineCommand({
       rootDir: cwd,
       overrides: defu(ctx.data?.overrides, {
         build: {
-          analyze: true,
+          analyze: { enabled: true },
         },
         analyzeDir,
         buildDir,


### PR DESCRIPTION
This should be backwards compatible as we just checking truthiness of this option in previous versions of Nuxt.

Once https://github.com/nuxt/nuxt/pull/23856 is merged, we will then be able to respect user-set defaults in `nuxt.config`.

resolves https://github.com/nuxt/cli/issues/238