### PR TITLE
refactor: use magicast `.includes` helper

### DIFF
--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -72,11 +72,10 @@ export default defineCommand({
         if (!config.modules) {
           config.modules = []
         }
-        for (let i = 0; i < config.modules.length; i++) {
-          if (config.modules[i] === r.pkgName) {
-            consola.info(`\`${r.pkgName}\` is already in the \`modules\``)
-            return
-          }
+       
+        if (config.modules.includes(r.pkgName) {
+          consola.info(`\`${r.pkgName}\` is already in the \`modules\``)
+          return
         }
         consola.info(`Adding \`${r.pkgName}\` to the \`modules\``)
         config.modules.push(r.pkgName)

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -73,7 +73,7 @@ export default defineCommand({
           config.modules = []
         }
        
-        if (config.modules.includes(r.pkgName) {
+        if (config.modules.includes(r.pkgName)) {
           consola.info(`\`${r.pkgName}\` is already in the \`modules\``)
           return
         }

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -72,7 +72,7 @@ export default defineCommand({
         if (!config.modules) {
           config.modules = []
         }
-       
+
         if (config.modules.includes(r.pkgName)) {
           consola.info(`\`${r.pkgName}\` is already in the \`modules\``)
           return


### PR DESCRIPTION
This pr replaces the for loop to check if the modules array contains the added module, with a more performant `Array.includes`.

```
"Array.includes time:" 30 "ms"
"Manual loop time:" 326 "ms"
"Array.includes time:" 27 "ms"
"Manual loop time:" 242 "ms"
```

If the purpose of the for loop is backward compatibility, ignore this pr. 

🔥💚