### PR TITLE
fix(init): use absolute path for installing dependencies

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -110,9 +110,12 @@ export default defineCommand({
         })
 
     // Get relative project path
-    const relativeProjectPath = relative(process.cwd(), template.dir)
+    let relativeProjectPath = relative(process.cwd(), template.dir)
+    if (relativeProjectPath === '') {
+      relativeProjectPath = '.';
+    }
 
-    // Write .nuxtrc with `shamefully-hoist=true` for pnpm
+    // Write .npmrc with `shamefully-hoist=true` for pnpm
     if (selectedPackageManager === 'pnpm') {
       await writeFile(`${relativeProjectPath}/.npmrc`, 'shamefully-hoist=true')
     }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,7 +1,7 @@
 import { writeFile } from 'node:fs/promises'
 import { downloadTemplate, startShell } from 'giget'
 import type { DownloadTemplateResult } from 'giget'
-import { relative, resolve } from 'pathe'
+import { join, relative, resolve } from 'pathe'
 import { consola } from 'consola'
 import { installDependencies } from 'nypm'
 import type { PackageManagerName } from 'nypm'
@@ -109,15 +109,9 @@ export default defineCommand({
           options: packageManagerOptions,
         })
 
-    // Get relative project path
-    let relativeProjectPath = relative(process.cwd(), template.dir)
-    if (relativeProjectPath === '') {
-      relativeProjectPath = '.';
-    }
-
-    // Write .npmrc with `shamefully-hoist=true` for pnpm
+    // Write `.npmrc` with `shamefully-hoist=true` for pnpm
     if (selectedPackageManager === 'pnpm') {
-      await writeFile(`${relativeProjectPath}/.npmrc`, 'shamefully-hoist=true')
+      await writeFile(join(template.dir, '.npmrc'), 'shamefully-hoist=true')
     }
 
     // Install project dependencies
@@ -129,7 +123,7 @@ export default defineCommand({
 
       try {
         await installDependencies({
-          cwd: relativeProjectPath,
+          cwd: template.dir,
           packageManager: {
             name: selectedPackageManager,
             command: selectedPackageManager,
@@ -165,11 +159,11 @@ export default defineCommand({
     consola.log(
       `\n✨ Nuxt project has been created with the \`${template.name}\` template. Next steps:`,
     )
-
+    const relativeTemplateDir = relative(process.cwd(), template.dir) || '.'
     const nextSteps = [
       !ctx.args.shell &&
-        relativeProjectPath.length > 1 &&
-        `\`cd ${relativeProjectPath}\``,
+        relativeTemplateDir.length > 1 &&
+        `\`cd ${relativeTemplateDir}\``,
       `Start development server with \`${selectedPackageManager} run dev\``,
     ].filter(Boolean)
 


### PR DESCRIPTION
Fixes #213

---

I've tested this out locally using:

```shell
node {path_to_locally_built_cli_with_this_change}/bin/nuxi.mjs init . --force
```