### PR TITLE
fix(dev): pass programmatic args to sub process

### DIFF
--- a/run.ts
+++ b/run.ts
@@ -1,0 +1,8 @@
+import { runCommand } from './src/index'
+
+export async function run() {
+  await runCommand('dev', ['playground'])
+  return true
+}
+
+run()

--- a/run.ts
+++ b/run.ts
@@ -1,8 +1,0 @@
-import { runCommand } from './src/index'
-
-export async function run() {
-  await runCommand('dev', ['playground'])
-  return true
-}
-
-run()

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -68,7 +68,7 @@ const command = defineCommand({
     if (ctx.args.fork) {
       // Fork nuxt dev process
       const devProxy = await _createDevProxy(nuxtOptions, listenOptions)
-      await _startSubprocess(devProxy)
+      await _startSubprocess(devProxy, ctx.rawArgs)
     } else {
       // Directly start nuxt dev
       const { createNuxtDevServer } = await import('../utils/dev')
@@ -148,7 +148,7 @@ async function _createDevProxy(
   }
 }
 
-async function _startSubprocess(devProxy: DevProxy) {
+async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
   let childProc: ChildProcess | undefined
 
   const kill = (signal: NodeJS.Signals | number) => {
@@ -163,26 +163,22 @@ async function _startSubprocess(devProxy: DevProxy) {
     kill('SIGHUP')
 
     // Start new process
-    childProc = fork(
-      globalThis.__nuxt_cli__?.entry!,
-      ['_dev', ...process.argv.slice(3)],
-      {
-        execArgv: [
-          '--enable-source-maps',
-          process.argv.includes('--inspect') && '--inspect',
-        ].filter(Boolean) as string[],
-        env: {
-          ...process.env,
-          __NUXT_DEV__: JSON.stringify({
-            proxy: {
-              url: devProxy.listener.url,
-              urls: await devProxy.listener.getURLs(),
-              https: devProxy.listener.https,
-            },
-          } satisfies NuxtDevContext),
-        },
+    childProc = fork(globalThis.__nuxt_cli__?.entry!, ['_dev', ...rawArgs], {
+      execArgv: [
+        '--enable-source-maps',
+        process.argv.includes('--inspect') && '--inspect',
+      ].filter(Boolean) as string[],
+      env: {
+        ...process.env,
+        __NUXT_DEV__: JSON.stringify({
+          proxy: {
+            url: devProxy.listener.url,
+            urls: await devProxy.listener.getURLs(),
+            https: devProxy.listener.https,
+          },
+        } satisfies NuxtDevContext),
       },
-    )
+    })
 
     // Close main process on child exit with error
     childProc.on('close', (errorCode) => {


### PR DESCRIPTION
Resolves #274

Normally process.argv is same as ctx.rawArgs but when using programmatic API, the args can be different (like containing a custom root dir)