### PR TITLE
fix(analyze, cleanup, upgrade): respect custom `buildDir`

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -36,10 +36,6 @@ export default defineCommand({
     const name = ctx.args.name || 'default'
     const slug = name.trim().replace(/[^a-z0-9_-]/gi, '_')
 
-    let analyzeDir = join(cwd, '.nuxt/analyze', slug)
-    let buildDir = join(analyzeDir, '.nuxt')
-    let outDir = join(analyzeDir, '.output')
-
     const startTime = Date.now()
 
     const { loadNuxt, buildNuxt } = await loadKit(cwd)
@@ -48,22 +44,18 @@ export default defineCommand({
       rootDir: cwd,
       overrides: defu(ctx.data?.overrides, {
         build: {
-          analyze: { enabled: true },
-        },
-        analyzeDir,
-        buildDir,
-        nitro: {
-          output: {
-            dir: outDir,
+          analyze: {
+            enabled: true,
           },
         },
         logLevel: ctx.args.logLevel,
       }),
     })
 
-    analyzeDir = nuxt.options.analyzeDir
-    buildDir = nuxt.options.buildDir
-    outDir = nuxt.options.nitro.output?.dir || outDir
+    const analyzeDir = nuxt.options.analyzeDir
+    const buildDir = nuxt.options.buildDir
+    const outDir =
+      nuxt.options.nitro.output?.dir || join(nuxt.options.rootDir, '.output')
 
     await clearDir(analyzeDir)
     await buildNuxt(nuxt)

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -3,6 +3,7 @@ import { cleanupNuxtDirs } from '../utils/nuxt'
 import { defineCommand } from 'citty'
 
 import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { loadKit } from '../utils/kit'
 
 export default defineCommand({
   meta: {
@@ -15,6 +16,8 @@ export default defineCommand({
   },
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
-    await cleanupNuxtDirs(cwd)
+    const { loadNuxtConfig } = await loadKit(cwd)
+    const nuxtOptions = await loadNuxtConfig({ cwd })
+    await cleanupNuxtDirs(nuxtOptions.rootDir, nuxtOptions.buildDir)
   },
 })

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -12,6 +12,7 @@ import { cleanupNuxtDirs, nuxtVersionToGitIdentifier } from '../utils/nuxt'
 import { defineCommand } from 'citty'
 
 import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { loadKit } from '../utils/kit'
 
 async function getNuxtVersion(path: string): Promise<string | null> {
   try {
@@ -91,7 +92,15 @@ export default defineCommand({
     )
 
     // Cleanup after upgrade
-    await cleanupNuxtDirs(cwd)
+    let buildDir: string = '.nuxt'
+    try {
+      const { loadNuxtConfig } = await loadKit(cwd)
+      const nuxtOptions = await loadNuxtConfig({ cwd })
+      buildDir = nuxtOptions.buildDir
+    } catch {
+      // Use default buildDir (.nuxt)
+    }
+    await cleanupNuxtDirs(cwd, buildDir)
 
     // Check installed nuxt version again
     const upgradedVersion = (await getNuxtVersion(cwd)) || '[unknown]'

--- a/src/utils/nuxt.ts
+++ b/src/utils/nuxt.ts
@@ -15,12 +15,12 @@ export interface NuxtProjectManifest {
   }
 }
 
-export async function cleanupNuxtDirs(rootDir: string) {
+export async function cleanupNuxtDirs(rootDir: string, buildDir: string) {
   consola.info('Cleaning up generated nuxt files and caches...')
 
   await rmRecursive(
     [
-      '.nuxt',
+      buildDir,
       '.output',
       'dist',
       'node_modules/.vite',


### PR DESCRIPTION
Resolves #225

Respect custom `buildDir` option if provided to clean instead of default `.nuxt` dir