### PR TITLE
fix(analyze): set path for client analyze results

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -57,6 +57,9 @@ export default defineCommand({
     const outDir =
       nuxt.options.nitro.output?.dir || join(nuxt.options.rootDir, '.output')
 
+    nuxt.options.build.analyze.filename =
+      nuxt.options.build.analyze.filename || join(analyzeDir, 'client.html')
+
     await clearDir(analyzeDir)
     await buildNuxt(nuxt)
 


### PR DESCRIPTION
Working on #276 noticed that nuxt by default does not sets client dist path causing `stats.html` to be generated in rootDir/workspaceDir ([src](https://github.com/nuxt/nuxt/blob/main/packages/vite/src/plugins/analyze.ts#L29))