### PR TITLE
fix: handle spaces in path at repo initialization

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -147,8 +147,8 @@ export default defineCommand({
     }
     if (ctx.args.gitInit) {
       consola.info('Initializing git repository...\n')
-      const { execaCommand } = await import('execa')
-      await execaCommand(`git init ${template.dir}`, {
+      const { execa } = await import('execa')
+      await execa('git', ['init', template.dir], {
         stdio: 'inherit',
       }).catch((err) => {
         consola.warn(`Failed to initialize git repository: ${err}`)


### PR DESCRIPTION
This PR fix the issue happening when one run `nuxi init .` in a directory whose path contains spaces.

It just surround the path variable with in double quote in the string literal.

(This is my first public PR, I've looked for a contribution guide but did not find it... If there is anything wrong with the way I made it feel free to discard it and fix the concerned line directly, I'll learn by watching :wink: )