### PR TITLE
fix(prepare): run prepare for `extends`/`_layers`

### DIFF
--- a/playground/layer/components/LayerButton.vue
+++ b/playground/layer/components/LayerButton.vue
@@ -1,0 +1,9 @@
+<template>
+  <button>{{ props.label || 'Link Button' }}</button>
+</template>
+
+<script setup lang="ts">
+import type { ButtonAction } from '#my-module/types'
+
+const props = defineProps<{ label: string | undefined } & ButtonAction>();
+</script>

--- a/playground/layer/modules/my-module/index.ts
+++ b/playground/layer/modules/my-module/index.ts
@@ -1,0 +1,9 @@
+import { createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  meta: { name: 'my-module' },
+  setup(_resolvedOptions, nuxt) {
+    const { resolve } = createResolver(import.meta.url);
+    nuxt.options.alias['#my-module'] = resolve('./runtime')
+  },
+})

--- a/playground/layer/modules/my-module/runtime/types.ts
+++ b/playground/layer/modules/my-module/runtime/types.ts
@@ -1,0 +1,1 @@
+export type ButtonAction = { onClick: Event };

--- a/playground/layer/nuxt.config.ts
+++ b/playground/layer/nuxt.config.ts
@@ -1,0 +1,2 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({})

--- a/playground/layer/tsconfig.json
+++ b/playground/layer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // https://nuxt.com/docs/guide/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,2 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-export default defineNuxtConfig({})
+export default defineNuxtConfig({
+  extends: ['./layer'],
+  modules: ['./layer/modules/my-module']
+})

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -6,5 +6,6 @@
     <br />
     <br />
     <NuxtLink to="/ws"> /ws </NuxtLink>
+    <LayerButton />
   </div>
 </template>


### PR DESCRIPTION
A layer may make use of a module and then use imports from it through alias. The main project that uses this layer should also install this module, but even when that's the case, these imports aren't resolved unless it is in a corresponding `tsconfig.json`, but that may not be the case (in a monorepo especially, where your Nuxt app is in `packages/app`, and a layer may be in `../node_modules`). We need to ship layers with `tsconfig.json` most likely, but will still need to generate paths resolved accordingly.

Refer https://github.com/nuxt/ui-pro/issues/118