### PR TITLE
fix: don't write `.npmrc` with `shamefully-hoist=true` anymore

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -108,7 +108,7 @@ export default defineCommand({
           type: 'select',
           options: packageManagerOptions,
         })
-    
+
     // Install project dependencies
     // or skip installation based on the '--no-install' flag
     if (ctx.args.install === false) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -108,12 +108,7 @@ export default defineCommand({
           type: 'select',
           options: packageManagerOptions,
         })
-
-    // Write `.npmrc` with `shamefully-hoist=true` for pnpm
-    if (selectedPackageManager === 'pnpm') {
-      await writeFile(join(template.dir, '.npmrc'), 'shamefully-hoist=true')
-    }
-
+    
     // Install project dependencies
     // or skip installation based on the '--no-install' flag
     if (ctx.args.install === false) {


### PR DESCRIPTION
This removes the npmrc with shamefully-hoist=true for pnpm Package Manager as it's not needed anymore
Closes https://github.com/nuxt/starter/issues/547
Closes https://github.com/nuxt/cli/issues/316