### PR TITLE
feat: support volta

### DIFF
--- a/bin/_.mjs
+++ b/bin/_.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'node:url'
+import { runMain } from '../dist/index.mjs'
+
+global.__nuxt_cli__ = {
+  startTime: Date.now(),
+  entry: fileURLToPath(import.meta.url),
+}
+
+runMain()

--- a/bin/nuxi.mjs
+++ b/bin/nuxi.mjs
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
 
-import { fileURLToPath } from 'node:url'
-import { runMain } from '../dist/index.mjs'
+import { voltaRunMain } from '../dist/index.mjs'
 
-global.__nuxt_cli__ = {
-  startTime: Date.now(),
-  entry: fileURLToPath(import.meta.url),
-}
-
-runMain()
+voltaRunMain('node ./bin/_.mjs')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { main } from './main'
-export { runCommand, runMain } from './run'
+export { runCommand, runMain, voltaRunMain } from './run'

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,6 +3,7 @@ import { runCommand as _runCommand, runMain as _runMain } from 'citty'
 
 import { commands } from './commands'
 import { main } from './main'
+import { voltaRun } from './utils/volta'
 
 globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
   // Programmatic usage fallback
@@ -18,6 +19,8 @@ globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
 }
 
 export const runMain = () => _runMain(main)
+
+export const voltaRunMain = (command: string) => voltaRun(command)
 
 export async function runCommand(
   name: string,

--- a/src/utils/volta.ts
+++ b/src/utils/volta.ts
@@ -1,0 +1,51 @@
+import { execa } from 'execa'
+import { clean, valid } from 'semver'
+
+export const getVoltaCommand = (command: string, args: string[] = []) => {
+  return ['volta', ...command.split(' '), ...args].filter(Boolean)
+}
+
+export const runVoltaCommand = (command: string, args: string[] = []) => {
+  return execa(getVoltaCommand(command, args).join(' '))
+}
+
+export const hasVolta = async () => {
+  try {
+    const { stdout, stderr } = await runVoltaCommand('', ['--version'])
+    if (stderr) {
+      return false
+    }
+    return !!valid(stdout)
+  } catch {
+    return false
+  }
+}
+
+export const getVoltaNodeVersion = async () => {
+  const { stdout } = await runVoltaCommand('which node')
+  if (!stdout) {
+    return
+  }
+  const { stdout: version } = await execa(stdout, ['--version'])
+  if (!valid(version)) {
+    return
+  }
+  return clean(version)
+}
+
+export const voltaRun = async (command: string) => {
+  const args = process.argv.slice(2)
+  if (args.length) {
+    command = `${command} ${args.join(' ')}`
+  }
+  try {
+    if (await hasVolta()) {
+      const v = await getVoltaNodeVersion()
+      if (v) {
+        command = `volta run --node ${v} ${command}`
+      }
+    }
+  } finally {
+    execa(command, { stdio: 'inherit' })
+  }
+}


### PR DESCRIPTION
### Linked issue

Resolves: #343 

### Describe

Do not need to use `volta run` to declare a specified version of Node.js.

Use `execa` to run `nuxi.mjs` with a volta wrapper.

First check if there has `volta` command in local environment, and then use `volta which node` check which node version will be use in current project, finally transfer the command from `node ./bin/nuxt.mjs` -> `volta run --node 18.0.0 node ./bin/nuxt.mjs`

It might also be possible to add some logic like if the local environment has Volta and the `package.json` does not specify a Node version, `nuxi` could specify a Node version to run.

Resolves: #343 