### PR TITLE
fix(dev): prepend `baseURL` for vite hmr ws upgrade

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -245,9 +245,10 @@ class NuxtDevServer extends EventEmitter {
         'upgrade',
         async (req: any, socket: any, head: any) => {
           const nuxt = this._currentNuxt
-          if (!nuxt)
-            return
-          const viteHmrPath = (nuxt.options.app.baseURL + nuxt.options.app.buildAssetsDir).replace(/\/\//g, '/')
+          if (!nuxt) return
+          const viteHmrPath = (
+            nuxt.options.app.baseURL + nuxt.options.app.buildAssetsDir
+          ).replace(/\/\//g, '/')
           if (req.url.startsWith(viteHmrPath)) {
             return // Skip for Vite HMR
           }

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -5,6 +5,7 @@ import chokidar from 'chokidar'
 import { consola } from 'consola'
 import { debounce } from 'perfect-debounce'
 import { toNodeListener } from 'h3'
+import { joinURL } from 'ufo'
 import {
   HTTPSOptions,
   ListenURL,
@@ -246,9 +247,10 @@ class NuxtDevServer extends EventEmitter {
         async (req: any, socket: any, head: any) => {
           const nuxt = this._currentNuxt
           if (!nuxt) return
-          const viteHmrPath = (
-            nuxt.options.app.baseURL + nuxt.options.app.buildAssetsDir
-          ).replace(/\/\//g, '/')
+          const viteHmrPath = joinURL(
+            nuxt.options.app.baseURL,
+            nuxt.options.app.buildAssetsDir,
+          )
           if (req.url.startsWith(viteHmrPath)) {
             return // Skip for Vite HMR
           }

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -244,14 +244,14 @@ class NuxtDevServer extends EventEmitter {
       this.listener.server.on(
         'upgrade',
         async (req: any, socket: any, head: any) => {
-          if (
-            req.url.startsWith(
-              this._currentNuxt?.options.app.buildAssetsDir /* /_nuxt/ */,
-            )
-          ) {
+          const nuxt = this._currentNuxt
+          if (!nuxt)
+            return
+          const viteHmrPath = (nuxt.options.app.baseURL + nuxt.options.app.buildAssetsDir).replace(/\/\//g, '/')
+          if (req.url.startsWith(viteHmrPath)) {
             return // Skip for Vite HMR
           }
-          await this._currentNuxt?.server.upgrade(req, socket, head)
+          await nuxt.server.upgrade(req, socket, head)
         },
       )
     }


### PR DESCRIPTION
This was causing errors for apps with custom `baseUrl` and making dev server non-usable at all

<img width="710" alt="Screenshot 2024-03-19 at 21 00 53" src="https://github.com/nuxt/cli/assets/11247099/c8d46693-c7f9-4477-9508-571d94b745ca">
