### PR TITLE
change script setup in templates to match Vue documentation

### DIFF
--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -43,7 +43,7 @@ const component: Template = ({ name, args }) => ({
     'mode',
   )}.vue`,
   contents: `
-<script lang="ts" setup></script>
+<script setup lang="ts"></script>
 
 <template>
   <div>
@@ -79,7 +79,7 @@ export default defineNuxtRouteMiddleware((to, from) => {})
 const layout: Template = ({ name }) => ({
   path: `layouts/${name}.vue`,
   contents: `
-<script lang="ts" setup></script>
+<script setup lang="ts"></script>
 
 <template>
   <div>
@@ -95,7 +95,7 @@ const layout: Template = ({ name }) => ({
 const page: Template = ({ name }) => ({
   path: `pages/${name}.vue`,
   contents: `
-<script lang="ts" setup></script>
+<script setup lang="ts"></script>
 
 <template>
   <div>


### PR DESCRIPTION
This PR is to change the `<script setup lang="ts">` block in the templates for `component`, `layout`, and `page` to match official Vue [documentation](https://vuejs.org/guide/typescript/composition-api.html). 

Previous templates:
`<script lang="ts" setup>`

Official Vue documentation:
`<script setup lang="ts">`