### PR TITLE
feat(module add): add module peer-dependencies args

### DIFF
--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -24,19 +24,19 @@ export default defineCommand({
   },
   args: {
     ...sharedArgs,
-    moduleName: {
+    'moduleName': {
       type: 'positional',
       description: 'Module name',
     },
-    skipInstall: {
+    'skipInstall': {
       type: 'boolean',
       description: 'Skip npm install',
     },
-    skipConfig: {
+    'skipConfig': {
       type: 'boolean',
       description: 'Skip nuxt.config.ts update',
     },
-    install: {
+    'install': {
       type: 'string',
       description: 'Installing module peer dependencies.',
       default: undefined,
@@ -179,12 +179,12 @@ async function resolveModule(
 ): Promise<
   | false
   | {
-      nuxtModule?: NuxtModule
-      pkg: string
-      pkgName: string
-      pkgVersion: string
-      peerDeps: string[]
-    }
+    nuxtModule?: NuxtModule
+    pkg: string
+    pkgName: string
+    pkgVersion: string
+    peerDeps: string[]
+  }
 > {
   let pkgName = moduleName
   let pkgVersion: string | undefined

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -36,19 +36,16 @@ export default defineCommand({
       type: 'boolean',
       description: 'Skip nuxt.config.ts update',
     },
-    peerDeps: {
+    install: {
       type: 'string',
-      description: 'Installing peer dependencies.',
-      alias: 'p',
+      description: 'Installing module peer dependencies.',
       default: undefined,
     },
-    devDeps: {
-      type: 'boolean',
-      description:
-        'Use this with "-p" option.\n\t \
-           Enabling this option will install to devDependencies.',
-      alias: 'D',
-      default: false,
+    'install-dev': {
+      type: 'string',
+      description: 'Installing module peer dependencies in devDependencies.',
+      alias: 'installDev',
+      default: undefined,
     },
   },
   async setup(ctx) {
@@ -123,17 +120,10 @@ export default defineCommand({
     }
 
     // Install module peer dependencies
-    const _deps = ctx.args.peerDeps
-    if (typeof _deps === 'undefined') {
-      consola.info('peer dependencies is not installed')
-    } else {
-      consola.info(`Installing ${colors.cyan(_deps)} dependencies`)
-      await addDependency(_deps, { cwd, dev: ctx.args.devDeps }).catch(
-        (error) => {
-          consola.error(error)
-        },
-      )
-    }
+    await installPeerDeps(cwd, ctx.args.install)
+
+    // Install module peer dependencies in devDependencies
+    await installPeerDeps(cwd, ctx.args['install-dev'], true)
   },
 })
 
@@ -298,5 +288,26 @@ async function resolveModule(
     pkg: `${pkgName}@${pkgVersion}`,
     pkgName,
     pkgVersion,
+  }
+}
+
+/**
+ * Installing module peer dependencies.
+ * @param cwd Current working directory.
+ * @param isDev Installing module peer dependencies to devDependencies.
+ * @param deps Installing module peer dependencies.
+ */
+async function installPeerDeps(
+  cwd: string,
+  deps?: string,
+  isDev: boolean = false,
+): Promise<void> {
+  if (typeof deps === 'undefined') {
+    consola.info('peer dependencies is not installed')
+  } else {
+    consola.info(`Installing ${colors.cyan(deps)} dependencies`)
+    await addDependency(deps, { cwd, dev: isDev }).catch((error) => {
+      consola.error(error)
+    })
   }
 }

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -36,6 +36,20 @@ export default defineCommand({
       type: 'boolean',
       description: 'Skip nuxt.config.ts update',
     },
+    peerDeps: {
+      type: 'string',
+      description: 'Installing peer dependencies.',
+      alias: 'p',
+      default: undefined,
+    },
+    devDeps: {
+      type: 'boolean',
+      description:
+        'Use this with "-p" option.\n\t \
+           Enabling this option will install to devDependencies.',
+      alias: 'D',
+      default: false,
+    },
   },
   async setup(ctx) {
     const cwd = resolve(ctx.args.cwd || '.')
@@ -106,6 +120,19 @@ export default defineCommand({
           `Please manually add \`${r.pkgName}\` to the \`modules\` in \`nuxt.config.ts\``,
         )
       })
+    }
+
+    // Install module peer dependencies
+    const _deps = ctx.args.peerDeps
+    if (typeof _deps === 'undefined') {
+      consola.info('peer dependencies is not installed')
+    } else {
+      consola.info(`Installing ${colors.cyan(_deps)} dependencies`)
+      await addDependency(_deps, { cwd, dev: ctx.args.devDeps }).catch(
+        (error) => {
+          consola.error(error)
+        },
+      )
     }
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

closed #385 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I created an args for the `nuxi module add` command to install dependent libraries together.

The two added args are:

#### `--install`: Install peer dependencies.

```sh
# installiing @nuxt/eslint module and installing eslint
npx nuxi module add eslint --install eslint
```

If you specify only the xyz argument, install peerDependencies defined in the module to be installed.

```sh
# installiing @nuxt/eslint module and installing peerDependencies in pacakge.json
npx nuxi module add eslint --install
```

You can install multiple peer dependencies by specifying multiple peer dependencies.

```sh
# installing @nuxt/eslint module and installing eslint, prettier
npx nuxi module add eslint --install eslint --install prettier
```

If not specified, only the module will be installed as before.

```sh
# installing only @nuxt/eslint module
npx nuxi module add eslint
```

#### `--install-dev`:  Install peer dependencies for devDependenies

There are some cases where it is preferable to use `devDependencies` instead of `dependencies` to install peer dependencies.  In that case, specify this option as well and install it to devDependencies.

```sh
# installiing @nuxt/eslint module and installing eslint in devDependencies
npx nuxi module add eslint --install-dev eslint
```

You can also install multiple peer dependencies by specifying multiple peer dependencies.

```sh
# installiing @nuxt/eslint module and installing eslint, prettier in devDependencies
npx nuxi module add eslint --install-dev eslint --install-dev prettier
```

#### The following is displayed in the help

```sh
USAGE module add [OPTIONS] <MODULENAME>

ARGUMENTS

  MODULENAME    Module name    

OPTIONS

                       --cwd    Current working directory                              
                  --logLevel    Log level                                              
               --skipInstall    Skip npm install                                       
                --skipConfig    Skip nuxt.config.ts update                             
                   --install    Installing module peer dependencies.                   
  -installDev, --install-dev    Installing module peer dependencies in devDependencies.                  
```

### 🚀 Examples

```sh
# installing only @nuxt/eslint module
npx nuxi module add eslint

# installiing @nuxt/eslint module and installing eslint
npx nuxi module add eslint --install eslint

# installing @nuxt/eslint module and installing eslint, prettier
npx nuxi module add eslint --install eslint --install prettier

# installing @nuxt/eslint module and installing eslint, prettier in devDependencies 
npx nuxi module add eslint --install-dev eslint --install-dev prettier

# installing @nuxt/test-utils module and installing related libraries in devDependencies 
 npx nuxi module add test-utils --install-dev vitest --install-dev @vue/test-utils --install-dev happy-dom --install-dev playwright-core

# installing nuxt-graphql-server module and installing related libraries 
 npx nuxi module add nuxt-graphql-server --install graphql --install @apollo/server --install @as-integrations/h3
```

### 📝 Note

#### old proposal ~~Additional expansion proposals~~

Depending on the module, there are cases where the creator sets peerDependencies.

By adding the following items to the nuxt module, there is no need for the user to specify `peerDeps`.

```diff
  name: test-utils
  description: Test utilities for Nuxt
  repo: nuxt/test-utils#main
  npm: '@nuxt/test-utils'
+ peer: 
+   - vitest
+   - @vue/test-utils
+   - happy-dom
+   - playwright-core
  icon: nuxt.svg
  github: https://github.com/nuxt/test-utils
  website: https://nuxt.com/docs/getting-started/testing
  learn_more: ''
  category: Devtools
  type: official
  maintainers:
    - name: Daniel Roe
      github: danielroe
      twitter: danielcroe
    - name: Anthony Fu
      github: antfu
      twitter: antfu7
  compatibility:
    nuxt: ^3.0.0
    requires: {}
```

#### docs

I am also preparing the documentation.

- [exp branch](https://github.com/shinGangan/nuxt/commits/exp/add-peer-deps-in-docs/)