### PR TITLE
fix(dev): set `hmr.server` earlier in lifecycle

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -188,23 +188,17 @@ class NuxtDevServer extends EventEmitter {
 
     // Connect Vite HMR
     if (!process.env.NUXI_DISABLE_VITE_HMR) {
-      this._currentNuxt.hooks.hook(
-        'vite:extendConfig',
-        (config, { isClient }) => {
-          if (isClient && config.server) {
-            config.server.hmr = {
-              ...(config.server.hmr as Exclude<
-                typeof config.server.hmr,
-                boolean
-              >),
-              protocol: undefined,
-              port: undefined,
-              host: undefined,
-              server: this.listener.server,
-            }
+      this._currentNuxt.hooks.hook('vite:extend', ({ config }) => {
+        if (config.server) {
+          config.server.hmr = {
+            ...(config.server.hmr as Exclude<typeof config.server.hmr, boolean>),
+            protocol: undefined,
+            port: undefined,
+            host: undefined,
+            server: this.listener.server,
           }
-        },
-      )
+        }
+      })
     }
 
     // Remove websocket handlers on close


### PR DESCRIPTION
This addresses an edge case and hopefully also improves performance. By setting `hmr.server` earlier on, we can avoid calling `getPort` in nuxt, which avoids issues with binding to ports that are not available.

context: https://github.com/nuxt/nuxt/pull/27326