### PR TITLE
feat: add env-flag for env-specific config (#357)

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -9,6 +9,13 @@ export const sharedArgs = {
   },
 } as const
 
+export const envNameArgs = {
+  envName: {
+    type: 'string',
+    description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
+  },
+} as const
+
 export const legacyRootDirArgs = {
   rootDir: {
     type: 'positional',

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -12,7 +12,7 @@ export const sharedArgs = {
 export const envNameArgs = {
   envName: {
     type: 'string',
-    description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
+    description: 'The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server)',
   },
 } as const
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -27,6 +27,10 @@ export default defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
+    env: {
+      type: 'string',
+      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+    },
     ...legacyRootDirArgs,
   },
   async run(ctx) {
@@ -50,6 +54,7 @@ export default defineCommand({
         cwd,
         fileName: ctx.args.dotenv,
       },
+      envName: ctx.args.env, // c12 will fall back to NODE_ENV
       overrides: {
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
         // TODO: remove in 3.8

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -29,7 +29,7 @@ export default defineCommand({
     },
     env: {
       type: 'string',
-      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
     ...legacyRootDirArgs,
   },

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -6,7 +6,7 @@ import { loadKit } from '../utils/kit'
 import { clearBuildDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
 import { showVersions } from '../utils/banner'
-import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -27,10 +27,7 @@ export default defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
-    env: {
-      type: 'string',
-      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
-    },
+    ...envNameArgs,
     ...legacyRootDirArgs,
   },
   async run(ctx) {
@@ -54,7 +51,7 @@ export default defineCommand({
         cwd,
         fileName: ctx.args.dotenv,
       },
-      envName: ctx.args.env, // c12 will fall back to NODE_ENV
+      envName: ctx.args.envName, // c12 will fall back to NODE_ENV
       overrides: {
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
         // TODO: remove in 3.8

--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -16,6 +16,10 @@ export default defineCommand({
   args: {
     ...sharedArgs,
     ...legacyRootDirArgs,
+    env: {
+      type: 'string',
+      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+    },
   },
   async run(ctx) {
     const logger = consola.withTag('nuxi')
@@ -41,6 +45,7 @@ export default defineCommand({
       logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
       clear: !!ctx.args.clear,
       dotenv: !!ctx.args.dotenv,
+      env: ctx.args.env,
       port: process.env._PORT ?? undefined,
       devContext,
     })

--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -18,7 +18,7 @@ export default defineCommand({
     ...legacyRootDirArgs,
     env: {
       type: 'string',
-      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
   },
   async run(ctx) {

--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -5,7 +5,7 @@ import { isTest } from 'std-env'
 import { overrideEnv } from '../utils/env'
 import type { NuxtDevContext, NuxtDevIPCMessage } from '../utils/dev'
 import { createNuxtDevServer } from '../utils/dev'
-import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -15,11 +15,8 @@ export default defineCommand({
   },
   args: {
     ...sharedArgs,
+    ...envNameArgs,
     ...legacyRootDirArgs,
-    env: {
-      type: 'string',
-      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
-    },
   },
   async run(ctx) {
     const logger = consola.withTag('nuxi')
@@ -45,7 +42,7 @@ export default defineCommand({
       logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
       clear: !!ctx.args.clear,
       dotenv: !!ctx.args.dotenv,
-      env: ctx.args.env,
+      envName: ctx.args.envName,
       port: process.env._PORT ?? undefined,
       devContext,
     })

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -17,7 +17,7 @@ import { loadKit } from '../utils/kit'
 import { importModule } from '../utils/esm'
 import { overrideEnv } from '../utils/env'
 import type { NuxtDevContext, NuxtDevIPCMessage } from '../utils/dev'
-import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
 
 const forkSupported = !isBun && !isTest
 
@@ -28,15 +28,12 @@ const command = defineCommand({
   },
   args: {
     ...sharedArgs,
+    ...envNameArgs,
     ...legacyRootDirArgs,
     ...getListhenArgs(),
     dotenv: {
       type: 'string',
       description: 'Path to .env file',
-    },
-    env: {
-      type: 'string',
-      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
     clear: {
       type: 'boolean',
@@ -59,7 +56,7 @@ const command = defineCommand({
     const { loadNuxtConfig } = await loadKit(cwd)
     const nuxtOptions = await loadNuxtConfig({
       cwd,
-      envName: ctx.args.env, // c12 will fall back to NODE_ENV
+      envName: ctx.args.envName, // c12 will fall back to NODE_ENV
       overrides: {
         dev: true,
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
@@ -86,7 +83,7 @@ const command = defineCommand({
           logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
           clear: ctx.args.clear,
           dotenv: !!ctx.args.dotenv,
-          env: ctx.args.env,
+          envName: ctx.args.envName,
           loadingTemplate: nuxtOptions.devServer.loadingTemplate,
           devContext: {},
         },

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -36,7 +36,7 @@ const command = defineCommand({
     },
     env: {
       type: 'string',
-      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
     clear: {
       type: 'boolean',

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -34,6 +34,10 @@ const command = defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
+    env: {
+      type: 'string',
+      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+    },
     clear: {
       type: 'boolean',
       description: 'Clear console on restart',
@@ -55,6 +59,7 @@ const command = defineCommand({
     const { loadNuxtConfig } = await loadKit(cwd)
     const nuxtOptions = await loadNuxtConfig({
       cwd,
+      envName: ctx.args.env, // c12 will fall back to NODE_ENV
       overrides: {
         dev: true,
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
@@ -81,6 +86,7 @@ const command = defineCommand({
           logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
           clear: ctx.args.clear,
           dotenv: !!ctx.args.dotenv,
+          env: ctx.args.env,
           loadingTemplate: nuxtOptions.devServer.loadingTemplate,
           devContext: {},
         },

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 import buildCommand from './build'
 
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -10,14 +10,11 @@ export default defineCommand({
   },
   args: {
     ...sharedArgs,
+    ...envNameArgs,
     ...legacyRootDirArgs,
     dotenv: {
       type: 'string',
       description: 'Path to .env file',
-    },
-    env: {
-      type: 'string',
-      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
   },
   async run(ctx) {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -15,6 +15,10 @@ export default defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
+    env: {
+      type: 'string',
+      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+    },
   },
   async run(ctx) {
     ctx.args.prerender = true

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -17,7 +17,7 @@ export default defineCommand({
     },
     env: {
       type: 'string',
-      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
   },
   async run(ctx) {

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -19,6 +19,10 @@ export default defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
+    env: {
+      type: 'string',
+      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+    },
     ...sharedArgs,
     ...legacyRootDirArgs,
   },
@@ -38,6 +42,7 @@ export default defineCommand({
         cwd,
         fileName: ctx.args.dotenv,
       },
+      envName: ctx.args.env, // c12 will fall back to NODE_ENV
       overrides: {
         _prepare: true,
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -21,7 +21,7 @@ export default defineCommand({
     },
     env: {
       type: 'string',
-      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
     ...sharedArgs,
     ...legacyRootDirArgs,

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -7,7 +7,7 @@ import { defineCommand } from 'citty'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -19,11 +19,8 @@ export default defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
-    env: {
-      type: 'string',
-      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
-    },
     ...sharedArgs,
+    ...envNameArgs,
     ...legacyRootDirArgs,
   },
   async run(ctx) {
@@ -42,7 +39,7 @@ export default defineCommand({
         cwd,
         fileName: ctx.args.dotenv,
       },
-      envName: ctx.args.env, // c12 will fall back to NODE_ENV
+      envName: ctx.args.envName, // c12 will fall back to NODE_ENV
       overrides: {
         _prepare: true,
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -8,7 +8,7 @@ import { box, colors } from 'consola/utils'
 import { defineCommand } from 'citty'
 import { loadKit } from '../utils/kit'
 
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -17,14 +17,11 @@ export default defineCommand({
   },
   args: {
     ...sharedArgs,
+    ...envNameArgs,
     ...legacyRootDirArgs,
     dotenv: {
       type: 'string',
       description: 'Path to .env file',
-    },
-    env: {
-      type: 'string',
-      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
   },
   async run(ctx) {
@@ -35,7 +32,7 @@ export default defineCommand({
     const { loadNuxtConfig } = await loadKit(cwd)
     const config = await loadNuxtConfig({
       cwd,
-      envName: ctx.args.env, // c12 will fall back to NODE_ENV
+      envName: ctx.args.envName, // c12 will fall back to NODE_ENV
       overrides: /* ctx.options?.overrides || */ {},
     })
 

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -24,7 +24,7 @@ export default defineCommand({
     },
     env: {
       type: 'string',
-      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+      description: 'Name of the build environment to use (see \'Environment overrides\' in the docs)',
     },
   },
   async run(ctx) {

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -22,6 +22,10 @@ export default defineCommand({
       type: 'string',
       description: 'Path to .env file',
     },
+    env: {
+      type: 'string',
+      description: "Name of the build environment to use (see 'Environment overrides' in the docs)",
+    },
   },
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
@@ -31,6 +35,7 @@ export default defineCommand({
     const { loadNuxtConfig } = await loadKit(cwd)
     const config = await loadNuxtConfig({
       cwd,
+      envName: ctx.args.env, // c12 will fall back to NODE_ENV
       overrides: /* ctx.options?.overrides || */ {},
     })
 

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -32,7 +32,7 @@ export interface NuxtDevServerOptions {
   cwd: string
   logLevel: 'silent' | 'info' | 'verbose'
   dotenv: boolean
-  env: string
+  envName: string
   clear: boolean
   overrides: NuxtConfig
   port?: string | number
@@ -173,7 +173,7 @@ class NuxtDevServer extends EventEmitter {
       cwd: this.options.cwd,
       dev: true,
       ready: false,
-      envName: this.options.env,
+      envName: this.options.envName,
       overrides: {
         logLevel: this.options.logLevel as 'silent' | 'info' | 'verbose',
         vite: {

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -32,6 +32,7 @@ export interface NuxtDevServerOptions {
   cwd: string
   logLevel: 'silent' | 'info' | 'verbose'
   dotenv: boolean
+  env: string
   clear: boolean
   overrides: NuxtConfig
   port?: string | number
@@ -172,6 +173,7 @@ class NuxtDevServer extends EventEmitter {
       cwd: this.options.cwd,
       dev: true,
       ready: false,
+      envName: this.options.env,
       overrides: {
         logLevel: this.options.logLevel as 'silent' | 'info' | 'verbose',
         vite: {


### PR DESCRIPTION
This PR is proposing to add a new `--env [name]` attribute to Nuxi. The attribute will be passed to the `envName` option of the c12 library. This adds the ability to support environment overrides (environment-specific configuration) for custom environments. Currently, c12 supports that and the types of the nuxt configuration file are aware of that, but there is no way to actually use custom environments, because `NODE_ENV` cannot be set to values other than `production` or `development`. This PR closes the gap, making deployments to different environments easier.

See #357.

Should this be approved, I would be happy to amend the documentation accordingly.