### PR TITLE
fix: use -w arg for pnpm root workspace

### DIFF
--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { consola } from 'consola'
 import { colors } from 'consola/utils'
 import { relative, resolve } from 'pathe'
@@ -25,6 +26,11 @@ async function getNuxtVersion(path: string): Promise<string | null> {
   catch {
     return null
   }
+}
+
+function hasPnpmWorkspaceFile(): boolean {
+  const pnpmWorkspaceFilePath = `${process.cwd()}/pnpm-workspace.yaml`
+  return existsSync(pnpmWorkspaceFilePath)
 }
 
 export default defineCommand({
@@ -88,7 +94,7 @@ export default defineCommand({
     execSync(
       `${packageManager} ${
         packageManager === 'yarn' ? 'add' : 'install'
-      } -D nuxt`,
+      } -D nuxt ${packageManager === 'pnpm' && hasPnpmWorkspaceFile() ? '-w' : ''}`,
       { stdio: 'inherit', cwd },
     )
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -28,8 +28,8 @@ async function getNuxtVersion(path: string): Promise<string | null> {
   }
 }
 
-function hasPnpmWorkspaceFile(): boolean {
-  const pnpmWorkspaceFilePath = `${process.cwd()}/pnpm-workspace.yaml`
+function hasPnpmWorkspaceFile(cwd: string): boolean {
+  const pnpmWorkspaceFilePath = resolve(cwd, 'pnpm-workspace.yaml')
   return existsSync(pnpmWorkspaceFilePath)
 }
 
@@ -94,7 +94,7 @@ export default defineCommand({
     execSync(
       `${packageManager} ${
         packageManager === 'yarn' ? 'add' : 'install'
-      } -D nuxt ${packageManager === 'pnpm' && hasPnpmWorkspaceFile() ? '-w' : ''}`,
+      } -D nuxt ${packageManager === 'pnpm' && hasPnpmWorkspaceFile(cwd) ? '-w' : ''}`,
       { stdio: 'inherit', cwd },
     )
 


### PR DESCRIPTION
Hi :wave: 

This PR adds `-w` arg to the install command when having pnpm and pnpm workspaces. Pnpm prevents running installing new deps in the root directory without `-w`