### PR TITLE
feat(module): Force new dependencies to be devDependencies (if it's in a specific list)

### DIFF
--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -15,6 +15,12 @@ import {
 } from './_utils'
 import type { NuxtModule } from './_utils'
 
+// Maybe we can import the list from somewhere, but idk
+const forceDevDependencies = [
+  "@nuxt/eslint@latest",
+  "@nuxtjs/color-mode"
+]
+
 export default defineCommand({
   meta: {
     name: 'add',
@@ -60,7 +66,7 @@ export default defineCommand({
 
     // Add npm dependency
     if (!ctx.args.skipInstall) {
-      const isDev = Boolean(projectPkg.devDependencies?.nuxt)
+      const isDev = Boolean(projectPkg.devDependencies?.nuxt || forceDevDependencies.includes(r.pkg))
       consola.info(
         `Installing \`${r.pkg}\`${isDev ? ' development' : ''} dependency`,
       )

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -17,7 +17,7 @@ import type { NuxtModule } from './_utils'
 
 // Maybe we can import the list from somewhere, but idk
 const forceDevDependencies = [
-  "@nuxt/eslint@latest",
+  "@nuxt/eslint",
   "@nuxtjs/color-mode"
 ]
 
@@ -66,7 +66,7 @@ export default defineCommand({
 
     // Add npm dependency
     if (!ctx.args.skipInstall) {
-      const isDev = Boolean(projectPkg.devDependencies?.nuxt || forceDevDependencies.includes(r.pkg))
+      const isDev = Boolean(projectPkg.devDependencies?.nuxt || forceDevDependencies.includes(r.pkg.replace(/@latest$/,'')))
       consola.info(
         `Installing \`${r.pkg}\`${isDev ? ' development' : ''} dependency`,
       )


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

#454 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR makes some changes to the module add directive: it detects a specific list of npm dependencies when adding them, and if the npm dependency to be installed is in that list, it will be installed as a development dependency.

While Nuxt will extract what is needed into the final build product, dependencies like `@nuxt/eslint` should not be installed as “dependencies” but as “devDependencies” in the original meaning of dependencies and devDependencies. Hence the PR.

It's not a good practice to write a dead list inside the module add function, but I haven't come up with a perfect way to do it at this stage either.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
