### PR TITLE
fix(dev): handle relative baseURL

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -298,6 +298,6 @@ function _resolveListenOptions(
     hostname: _hostname,
     public: _public,
     https: httpsOptions,
-    baseURL: nuxtOptions.app.baseURL,
+    baseURL: nuxtOptions.app.baseURL.startsWith('./') ? nuxtOptions.app.baseURL.slice(1) : nuxtOptions.app.baseURL,
   }
 }

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -239,7 +239,7 @@ class NuxtDevServer extends EventEmitter {
           const nuxt = this._currentNuxt
           if (!nuxt) return
           const viteHmrPath = joinURL(
-            nuxt.options.app.baseURL,
+            nuxt.options.app.baseURL.startsWith('./') ? nuxt.options.app.baseURL.slice(1) : nuxt.options.app.baseURL,
             nuxt.options.app.buildAssetsDir,
           )
           if (req.url.startsWith(viteHmrPath)) {


### PR DESCRIPTION
### 🔗 Linked issue

related: https://github.com/nuxt/nuxt/issues/28474

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When passing a relative `app.baseURL`, this should not affect how the server is started. This applies the same fix in Nuxt `runtimeConfig`:

https://github.com/nuxt/nuxt/blob/d1c40328fe959f05ae77cc66311c40d5f151a109/packages/schema/src/config/nitro.ts#L18-L20