### PR TITLE
fix(dev): respect explicit address and port in `--inspect`

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -171,7 +171,7 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
     childProc = fork(globalThis.__nuxt_cli__!.entry!, ['_dev', ...rawArgs], {
       execArgv: [
         '--enable-source-maps',
-        process.argv.find((a: string) => a.includes("--inspect")),
+        process.argv.find((a: string) => a.includes('--inspect')),
       ].filter(Boolean) as string[],
       env: {
         ...process.env,

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -167,12 +167,11 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
   const restart = async () => {
     // Kill previous process with restart signal
     kill('SIGHUP')
-    const inspect = process.argv.find((argument:string) => /--inspect(=(\d\.\d\.\d\.\d)?(:\d{1,4})?)?/.test(argument))
     // Start new process
     childProc = fork(globalThis.__nuxt_cli__!.entry!, ['_dev', ...rawArgs], {
       execArgv: [
         '--enable-source-maps',
-        inspect,
+        process.argv.find((a: string) => a.includes("--inspect")),
       ].filter(Boolean) as string[],
       env: {
         ...process.env,

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -167,12 +167,12 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
   const restart = async () => {
     // Kill previous process with restart signal
     kill('SIGHUP')
-
+    const inspect = process.argv.find((argument:string) => /--inspect(=(\d\.\d\.\d\.\d)?(:\d{1,4})?)?/.test(argument))
     // Start new process
     childProc = fork(globalThis.__nuxt_cli__!.entry!, ['_dev', ...rawArgs], {
       execArgv: [
         '--enable-source-maps',
-        process.argv.includes('--inspect') && '--inspect',
+        inspect,
       ].filter(Boolean) as string[],
       env: {
         ...process.env,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #403 

### ❓ Type of change

respect the `--inspect` argument that is passed to `nuxi dev`

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's not easy to attach the debugger to a nuxt running in docker beacuse --inspect is passed without host (typically 0.0.0.0) and port.
it now passes the argument as it's passed by the user

Typical values could be
 - nuxi dev --inspect
 - nuxi dev --inspect=0.0.0.0
 - nuxi dev --inspect=9229
 - nuxi dev --inspect=0.0.0.0:9229

at the moment only the first option works but all the other are supported (just filtered out)
