### PR TITLE
fix(build): respect environment variable preset overrides

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -38,7 +38,7 @@ export default defineCommand({
 
     const kit = await loadKit(cwd)
 
-    const nitroPreset = ctx.args.prerender ? 'static' : ctx.args.preset
+    const nitroPreset = ctx.args.prerender ? 'static' : ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET
     if (nitroPreset) {
       if (ctx.args.prerender && ctx.args.preset) {
         consola.warn(`\`--prerender\` is set. Ignoring \`--preset ${ctx.args.preset}\``)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #513

resolves nuxt/nuxt#29525

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR ensures that the `NITRO_PRESET` and `SERVER_PRESET` environment variables are passed to nuxt kit for nitro overrides. It also follows the same order of priority as nitro (i.e. cli argument -> `NITRO_PRESET` -> `SERVER_PRESET`)