### PR TITLE
fix(#518): Adds auth token to fetch req

### DIFF
--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -21,6 +21,11 @@ import {
 } from './_utils'
 import type { NuxtModule } from './_utils'
 
+export type RegistryMeta = {
+  registry: string
+  authToken: string | null
+}
+
 export default defineCommand({
   meta: {
     name: 'add',
@@ -227,8 +232,22 @@ async function resolveModule(
   // Fetch package on npm
   pkgVersion = pkgVersion || 'latest'
   const pkgScope = pkgName.startsWith('@') ? pkgName.split('/')[0] : null
-  const registry = await detectNpmRegistry(pkgScope)
-  const pkg = await $fetch(joinURL(registry, `${pkgName}/${pkgVersion}`))
+  const meta: RegistryMeta = await detectNpmRegistry(pkgScope)
+  const headers: HeadersInit = {}
+
+  if (meta.authToken) {
+    headers.Authorization = `Bearer ${meta.authToken}`
+  }
+
+  const pkgDetails = await $fetch(joinURL(meta.registry, `${pkgName}`), {
+    headers,
+  })
+
+  // check if a dist-tag exists
+  pkgVersion = (pkgDetails['dist-tags']?.[pkgVersion] || pkgVersion) as string
+
+  const pkg = pkgDetails.versions[pkgVersion]
+
   const pkgDependencies = Object.assign(
     pkg.dependencies || {},
     pkg.devDependencies || {},
@@ -259,16 +278,61 @@ async function resolveModule(
   }
 }
 
-async function detectNpmRegistry(scope: string | null) {
+function getNpmrcPaths(): string[] {
+  const userNpmrcPath = join(homedir(), '.npmrc')
+  const cwdNpmrcPath = join(process.cwd(), '.npmrc')
+
+  return [cwdNpmrcPath, userNpmrcPath]
+}
+
+async function getAuthToken(registry: RegistryMeta['registry']): Promise<RegistryMeta['authToken']> {
+  const paths = getNpmrcPaths()
+  const authTokenRegex = new RegExp(`^//${registry.replace(/^https?:\/\//, '').replace(/\/$/, '')}/:_authToken=(.+)$`, 'm')
+
+  for (const npmrcPath of paths) {
+    let fd: FileHandle | undefined
+    try {
+      fd = await fs.promises.open(npmrcPath, 'r')
+      if (await fd.stat().then(r => r.isFile())) {
+        const npmrcContent = await fd.readFile('utf-8')
+        const authTokenMatch = npmrcContent.match(authTokenRegex)
+
+        if (authTokenMatch) {
+          return authTokenMatch[1].trim()
+        }
+      }
+    }
+    catch {
+      // swallow errors as file does not exist
+    }
+    finally {
+      await fd?.close()
+    }
+  }
+
+  return null
+}
+
+async function detectNpmRegistry(scope: string | null): Promise<RegistryMeta> {
+  const registry = await getRegistry(scope)
+  const authToken = await getAuthToken(registry)
+
+  return {
+    registry,
+    authToken,
+  }
+}
+
+async function getRegistry(scope: string | null): Promise<string> {
   if (process.env.COREPACK_NPM_REGISTRY) {
     return process.env.COREPACK_NPM_REGISTRY
   }
-  const userNpmrcPath = join(homedir(), '.npmrc')
-  const cwdNpmrcPath = join(process.cwd(), '.npmrc')
-  const registry = await getRegistryFromFile([cwdNpmrcPath, userNpmrcPath], scope)
+  const registry = await getRegistryFromFile(getNpmrcPaths(), scope)
+
   if (registry) {
     process.env.COREPACK_NPM_REGISTRY = registry
   }
+
   return registry || 'https://registry.npmjs.org'
 }
 


### PR DESCRIPTION
### 🔗 Linked issue
resolves #518 

### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This PR adresses a bug where the fetch request dosen't take the authToken of the found registry into account. This fix will use the .npmrc(s) to first find the registry and then search for an associated authToken.

Unfortunately npm.pkg.github.com dosen't support fetching a specific version like the NPM registry like: `/<pkgName>/latest`. So i we-wrote to use the `/<pkgName>` endpoint and then find the desired version meta data.