### PR TITLE
Fix nuxt fails to restart if restarted after the server failed to start due to a context conflict

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -235,7 +235,7 @@ class NuxtDevServer extends EventEmitter {
       await this.load(true)
     })
 
-    if ('upgrade' in this._currentNuxt.server) {
+    if (this._currentNuxt.server && 'upgrade' in this._currentNuxt.server) {
       this.listener.server.on(
         'upgrade',
         async (req: any, socket: any, head: any) => {


### PR DESCRIPTION
Fixes an edge case where server can be null during a restart

Logs:
```txt
web:dev:  ERROR  Cannot restart nuxt:  Cannot use 'in' operator to search for 'upgrade' in undefined                                                                                                                                 3:46:49 PM
web:dev:
web:dev:   at NuxtDevServer._load (/node_modules/nuxi/dist/chunks/dev2.mjs:1903:19)
```