### PR TITLE
feat(upgrade): add `--dedupe` as option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 nuxt-app
 .pnpm-store
 coverage
+.idea

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -146,7 +146,7 @@ export default defineCommand({
             {
               label: 'dedupe',
               value: 'dedupe',
-              hint: 'Recommended'
+              hint: 'Recommended',
             },
             {
               label: 'force',
@@ -156,7 +156,7 @@ export default defineCommand({
               label: 'skip',
               value: 'skip',
             },
-          ]
+          ],
         },
       )
     }
@@ -181,8 +181,8 @@ export default defineCommand({
 
     execSync(command, { stdio: 'inherit', cwd })
 
-    if(methode === 'dedupe') {
-      if(packageManager !== 'bun') {
+    if (methode === 'dedupe') {
+      if (packageManager !== 'bun') {
         consola.info('Deduping dependencies...')
         execSync(`${packageManager} dedupe`, { stdio: 'inherit', cwd })
       }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -136,6 +136,7 @@ export default defineCommand({
       .join(' and ')
 
     let method: 'force' | 'dedupe' | 'skip' | undefined = ctx.args.force ? 'force' : ctx.args.dedupe ? 'dedupe' : undefined
+    // @ts-expect-error can be removed on next consola release
     method ||= await consola.prompt(
       `Would you like to dedupe your lockfile (recommended) or recreate ${forceRemovals}? This can fix problems with hoisted dependency versions and ensure you have the most up-to-date dependencies.`,
       {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/554

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`nuxi upgrade` was not able to dedupe lockfile. I've added dedupe command for all supprted package managers (npm, pnpm, yarn)

`pnpm nuxi upgrade --dedupe`

or via `pnpm nuxi upgrade` prompt

```
ℹ Package manager: pnpm 9.13.2                                                                                                                                                                                           13:32:01
ℹ Current Nuxt version: 3.14.1592                                                                                                                                                                                        13:32:01

❯ Would you like to dedupe your lockfile (recommended) or force recreate node_modules and pnpm-lock.yaml to fix problems with hoisted dependency versions and ensure you have the most up-to-date dependencies?
● dedupe (Recommended)
○ force
○ skip
```
