### PR TITLE
fix(add): respect custom dirs from nuxt project

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -61,7 +61,7 @@ export default defineCommand({
     const config = await kit.loadNuxtConfig({ cwd })
 
     // Resolve template
-    const res = template({ name, args: ctx.args, nuxt: config })
+    const res = template({ name, args: ctx.args, nuxtOptions: config })
 
     // Ensure not overriding user code
     if (!ctx.args.force && existsSync(res.path)) {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -61,10 +61,13 @@ export default defineCommand({
     const config = await kit.loadNuxtConfig({ cwd })
 
     // Resolve template
-    const res = template({ name, args: ctx.args })
+    const res = template({ name, args: ctx.args, nuxt: config })
+
+    // Change resolution root dir when applicable
+    const resolveFromRoot = config.future.compatibilityVersion === 4 && templateName === 'api'
 
     // Resolve full path to generated file
-    const path = resolve(config.srcDir, res.path)
+    const path = resolve(resolveFromRoot ? config.rootDir : config.srcDir, res.path)
 
     // Ensure not overriding user code
     if (!ctx.args.force && existsSync(path)) {

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -63,22 +63,16 @@ export default defineCommand({
     // Resolve template
     const res = template({ name, args: ctx.args, nuxt: config })
 
-    // Change resolution root dir when applicable
-    const resolveFromRoot = config.future.compatibilityVersion === 4 && templateName === 'api'
-
-    // Resolve full path to generated file
-    const path = resolve(resolveFromRoot ? config.rootDir : config.srcDir, res.path)
-
     // Ensure not overriding user code
-    if (!ctx.args.force && existsSync(path)) {
+    if (!ctx.args.force && existsSync(res.path)) {
       consola.error(
-        `File exists: ${path} . Use --force to override or use a different name.`,
+        `File exists: ${res.path} . Use --force to override or use a different name.`,
       )
       process.exit(1)
     }
 
     // Ensure parent directory exists
-    const parentDir = dirname(path)
+    const parentDir = dirname(res.path)
     if (!existsSync(parentDir)) {
       consola.info('Creating directory', parentDir)
       if (templateName === 'page') {
@@ -88,7 +82,7 @@ export default defineCommand({
     }
 
     // Write file
-    await fsp.writeFile(path, res.contents.trim() + '\n')
-    consola.info(`🪄 Generated a new ${templateName} in ${path}`)
+    await fsp.writeFile(res.path, res.contents.trim() + '\n')
+    consola.info(`🪄 Generated a new ${templateName} in ${res.path}`)
   },
 })

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -24,10 +24,8 @@ const httpMethods = [
   'patch',
 ]
 const api: Template = ({ name, args, nuxt }) => {
-  const pathRoot = nuxt.future.compatibilityVersion === 4 ? nuxt.rootDir : nuxt.srcDir
-
   return {
-    path: resolve(pathRoot, `${nuxt.serverDir}/api/${name}${applySuffix(args, httpMethods, 'method')}.ts`),
+    path: resolve(nuxt.srcDir, nuxt.serverDir, `api/${name}${applySuffix(args, httpMethods, 'method')}.ts`),
     contents: `
 export default defineEventHandler((event) => {
   return 'Hello ${name}'
@@ -37,7 +35,7 @@ export default defineEventHandler((event) => {
 }
 
 const plugin: Template = ({ name, args, nuxt }) => ({
-  path: resolve(nuxt.srcDir, `${nuxt.dir.plugins}/${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`),
+  path: resolve(nuxt.srcDir, nuxt.dir.plugins, `${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`),
   contents: `
 export default defineNuxtPlugin((nuxtApp) => {})
   `,
@@ -77,14 +75,14 @@ export const composable: Template = ({ name, nuxt }) => {
 }
 
 const middleware: Template = ({ name, args, nuxt }) => ({
-  path: resolve(nuxt.srcDir, `${nuxt.dir.middleware}/${name}${applySuffix(args, ['global'])}.ts`),
+  path: resolve(nuxt.srcDir, nuxt.dir.middleware, `${name}${applySuffix(args, ['global'])}.ts`),
   contents: `
 export default defineNuxtRouteMiddleware((to, from) => {})
 `,
 })
 
 const layout: Template = ({ name, nuxt }) => ({
-  path: resolve(nuxt.srcDir, `${nuxt.dir.layouts}/${name}.vue`),
+  path: resolve(nuxt.srcDir, nuxt.dir.layouts, `${name}.vue`),
   contents: `
 <script setup lang="ts"></script>
 
@@ -100,7 +98,7 @@ const layout: Template = ({ name, nuxt }) => ({
 })
 
 const page: Template = ({ name, nuxt }) => ({
-  path: resolve(nuxt.srcDir, `${nuxt.dir.pages}/${name}.vue`),
+  path: resolve(nuxt.srcDir, nuxt.dir.pages, `${name}.vue`),
   contents: `
 <script setup lang="ts"></script>
 

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -5,7 +5,7 @@ import type { NuxtOptions } from '@nuxt/schema'
 interface TemplateOptions {
   name: string
   args: Record<string, any>
-  nuxt: NuxtOptions
+  nuxtOptions: NuxtOptions
 }
 
 interface Template {
@@ -23,9 +23,9 @@ const httpMethods = [
   'trace',
   'patch',
 ]
-const api: Template = ({ name, args, nuxt }) => {
+const api: Template = ({ name, args, nuxtOptions }) => {
   return {
-    path: resolve(nuxt.srcDir, nuxt.serverDir, `api/${name}${applySuffix(args, httpMethods, 'method')}.ts`),
+    path: resolve(nuxtOptions.srcDir, nuxtOptions.serverDir, `api/${name}${applySuffix(args, httpMethods, 'method')}.ts`),
     contents: `
 export default defineEventHandler((event) => {
   return 'Hello ${name}'
@@ -34,15 +34,15 @@ export default defineEventHandler((event) => {
   }
 }
 
-const plugin: Template = ({ name, args, nuxt }) => ({
-  path: resolve(nuxt.srcDir, nuxt.dir.plugins, `${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`),
+const plugin: Template = ({ name, args, nuxtOptions }) => ({
+  path: resolve(nuxtOptions.srcDir, nuxtOptions.dir.plugins, `${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`),
   contents: `
 export default defineNuxtPlugin((nuxtApp) => {})
   `,
 })
 
-const component: Template = ({ name, args, nuxt }) => ({
-  path: resolve(nuxt.srcDir, `components/${name}${applySuffix(
+const component: Template = ({ name, args, nuxtOptions }) => ({
+  path: resolve(nuxtOptions.srcDir, `components/${name}${applySuffix(
     args,
     ['client', 'server'],
     'mode',
@@ -60,12 +60,12 @@ const component: Template = ({ name, args, nuxt }) => ({
 `,
 })
 
-export const composable: Template = ({ name, nuxt }) => {
+export const composable: Template = ({ name, nuxtOptions }) => {
   const nameWithoutUsePrefix = name.replace(/^use-?/, '')
   const nameWithUsePrefix = `use${upperFirst(camelCase(nameWithoutUsePrefix))}`
 
   return {
-    path: resolve(nuxt.srcDir, `composables/${name}.ts`),
+    path: resolve(nuxtOptions.srcDir, `composables/${name}.ts`),
     contents: `
   export const ${nameWithUsePrefix} = () => {
     return ref()
@@ -74,15 +74,15 @@ export const composable: Template = ({ name, nuxt }) => {
   }
 }
 
-const middleware: Template = ({ name, args, nuxt }) => ({
-  path: resolve(nuxt.srcDir, nuxt.dir.middleware, `${name}${applySuffix(args, ['global'])}.ts`),
+const middleware: Template = ({ name, args, nuxtOptions }) => ({
+  path: resolve(nuxtOptions.srcDir, nuxtOptions.dir.middleware, `${name}${applySuffix(args, ['global'])}.ts`),
   contents: `
 export default defineNuxtRouteMiddleware((to, from) => {})
 `,
 })
 
-const layout: Template = ({ name, nuxt }) => ({
-  path: resolve(nuxt.srcDir, nuxt.dir.layouts, `${name}.vue`),
+const layout: Template = ({ name, nuxtOptions }) => ({
+  path: resolve(nuxtOptions.srcDir, nuxtOptions.dir.layouts, `${name}.vue`),
   contents: `
 <script setup lang="ts"></script>
 
@@ -97,8 +97,8 @@ const layout: Template = ({ name, nuxt }) => ({
 `,
 })
 
-const page: Template = ({ name, nuxt }) => ({
-  path: resolve(nuxt.srcDir, nuxt.dir.pages, `${name}.vue`),
+const page: Template = ({ name, nuxtOptions }) => ({
+  path: resolve(nuxtOptions.srcDir, nuxtOptions.dir.pages, `${name}.vue`),
   contents: `
 <script setup lang="ts"></script>
 

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'pathe'
 import { camelCase, upperFirst } from 'scule'
 import type { NuxtOptions } from '@nuxt/schema'
 
@@ -22,28 +23,32 @@ const httpMethods = [
   'trace',
   'patch',
 ]
-const api: Template = ({ name, args, nuxt }) => ({
-  path: `${nuxt.serverDir}/api/${name}${applySuffix(args, httpMethods, 'method')}.ts`,
-  contents: `
+const api: Template = ({ name, args, nuxt }) => {
+  const pathRoot = nuxt.future.compatibilityVersion === 4 ? nuxt.rootDir : nuxt.srcDir
+
+  return {
+    path: resolve(pathRoot, `${nuxt.serverDir}/api/${name}${applySuffix(args, httpMethods, 'method')}.ts`),
+    contents: `
 export default defineEventHandler((event) => {
   return 'Hello ${name}'
 })
 `,
-})
+  }
+}
 
 const plugin: Template = ({ name, args, nuxt }) => ({
-  path: `${nuxt.dir.plugins}/${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`,
+  path: resolve(nuxt.srcDir, `${nuxt.dir.plugins}/${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`),
   contents: `
 export default defineNuxtPlugin((nuxtApp) => {})
   `,
 })
 
-const component: Template = ({ name, args }) => ({
-  path: `components/${name}${applySuffix(
+const component: Template = ({ name, args, nuxt }) => ({
+  path: resolve(nuxt.srcDir, `components/${name}${applySuffix(
     args,
     ['client', 'server'],
     'mode',
-  )}.vue`,
+  )}.vue`),
   contents: `
 <script setup lang="ts"></script>
 
@@ -57,12 +62,12 @@ const component: Template = ({ name, args }) => ({
 `,
 })
 
-export const composable: Template = ({ name }) => {
+export const composable: Template = ({ name, nuxt }) => {
   const nameWithoutUsePrefix = name.replace(/^use-?/, '')
   const nameWithUsePrefix = `use${upperFirst(camelCase(nameWithoutUsePrefix))}`
 
   return {
-    path: `composables/${name}.ts`,
+    path: resolve(nuxt.srcDir, `composables/${name}.ts`),
     contents: `
   export const ${nameWithUsePrefix} = () => {
     return ref()
@@ -72,14 +77,14 @@ export const composable: Template = ({ name }) => {
 }
 
 const middleware: Template = ({ name, args, nuxt }) => ({
-  path: `${nuxt.dir.middleware}/${name}${applySuffix(args, ['global'])}.ts`,
+  path: resolve(nuxt.srcDir, `${nuxt.dir.middleware}/${name}${applySuffix(args, ['global'])}.ts`),
   contents: `
 export default defineNuxtRouteMiddleware((to, from) => {})
 `,
 })
 
 const layout: Template = ({ name, nuxt }) => ({
-  path: `${nuxt.dir.layouts}/${name}.vue`,
+  path: resolve(nuxt.srcDir, `${nuxt.dir.layouts}/${name}.vue`),
   contents: `
 <script setup lang="ts"></script>
 
@@ -95,7 +100,7 @@ const layout: Template = ({ name, nuxt }) => ({
 })
 
 const page: Template = ({ name, nuxt }) => ({
-  path: `${nuxt.dir.pages}/${name}.vue`,
+  path: resolve(nuxt.srcDir, `${nuxt.dir.pages}/${name}.vue`),
   contents: `
 <script setup lang="ts"></script>
 

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,8 +1,10 @@
 import { camelCase, upperFirst } from 'scule'
+import type { NuxtOptions } from '@nuxt/schema'
 
 interface TemplateOptions {
   name: string
   args: Record<string, any>
+  nuxt: NuxtOptions
 }
 
 interface Template {
@@ -20,8 +22,8 @@ const httpMethods = [
   'trace',
   'patch',
 ]
-const api: Template = ({ name, args }) => ({
-  path: `server/api/${name}${applySuffix(args, httpMethods, 'method')}.ts`,
+const api: Template = ({ name, args, nuxt }) => ({
+  path: `${nuxt.serverDir}/api/${name}${applySuffix(args, httpMethods, 'method')}.ts`,
   contents: `
 export default defineEventHandler((event) => {
   return 'Hello ${name}'
@@ -29,8 +31,8 @@ export default defineEventHandler((event) => {
 `,
 })
 
-const plugin: Template = ({ name, args }) => ({
-  path: `plugins/${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`,
+const plugin: Template = ({ name, args, nuxt }) => ({
+  path: `${nuxt.dir.plugins}/${name}${applySuffix(args, ['client', 'server'], 'mode')}.ts`,
   contents: `
 export default defineNuxtPlugin((nuxtApp) => {})
   `,
@@ -69,15 +71,15 @@ export const composable: Template = ({ name }) => {
   }
 }
 
-const middleware: Template = ({ name, args }) => ({
-  path: `middleware/${name}${applySuffix(args, ['global'])}.ts`,
+const middleware: Template = ({ name, args, nuxt }) => ({
+  path: `${nuxt.dir.middleware}/${name}${applySuffix(args, ['global'])}.ts`,
   contents: `
 export default defineNuxtRouteMiddleware((to, from) => {})
 `,
 })
 
-const layout: Template = ({ name }) => ({
-  path: `layouts/${name}.vue`,
+const layout: Template = ({ name, nuxt }) => ({
+  path: `${nuxt.dir.layouts}/${name}.vue`,
   contents: `
 <script setup lang="ts"></script>
 
@@ -92,8 +94,8 @@ const layout: Template = ({ name }) => ({
 `,
 })
 
-const page: Template = ({ name }) => ({
-  path: `pages/${name}.vue`,
+const page: Template = ({ name, nuxt }) => ({
+  path: `${nuxt.dir.pages}/${name}.vue`,
   contents: `
 <script setup lang="ts"></script>
 

--- a/test/unit/templates.spec.ts
+++ b/test/unit/templates.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import type { NuxtOptions } from '@nuxt/schema'
 import { composable } from '../../src/utils/templates'
 
 describe('templates', () => {
   it('composables', () => {
     for (const name of ['useSomeComposable', 'someComposable', 'use-some-composable', 'use-someComposable', 'some-composable']) {
-      expect(composable({ name, args: {} }).contents.trim().split('\n')[0]).toBe('export const useSomeComposable = () => {')
+      expect(composable({ name, args: {}, nuxtOptions: { srcDir: '/src' } as NuxtOptions }).contents.trim().split('\n')[0]).toBe('export const useSomeComposable = () => {')
     }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue
* #551 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #551 

Changes the generated api template path to be resolved from `rootDir` instead of `srcDir` if `compatibilityVersion: 4`, not sure if other templates should be from `rootDir` as well, let me know.

I also changed the template paths to use the config `dir` where applicable, not sure if there's an open issue for this 🤔

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
