### PR TITLE
fix: `analyze` should include original readable filenames

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -52,8 +52,8 @@ export default defineCommand({
           build: {
             rollupOptions: {
               output: {
-                chunkFileNames: '_nuxt/[name].[hash].js',
-                entryFileNames: '_nuxt/[name].[hash].js',
+                chunkFileNames: '_nuxt/[name].js',
+                entryFileNames: '_nuxt/[name].js',
               },
             },
           },

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -48,6 +48,16 @@ export default defineCommand({
             enabled: true,
           },
         },
+        vite: {
+          build: {
+            rollupOptions: {
+              output: {
+                chunkFileNames: '_nuxt/[name].[hash].js',
+                entryFileNames: '_nuxt/[name].[hash].js',
+              },
+            },
+          },
+        },
         logLevel: ctx.args.logLevel,
       }),
     })


### PR DESCRIPTION
### 🔗 Linked issue
* #390 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
* Resolves #390 

This changes the `analyze` command to change the chunk filenames to include the original human readable filename. 

~~@manniL 
In the issue you mention removing the hash entirely, if that's preferable I can change the PR. I figured including the hash could prevent duplicate filenames (not sure if possible) and in case these are used to invalidate build cache (I have no idea 🤷)~~

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
