### PR TITLE
fix: support `--dotenv` for `analyze`

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -16,6 +16,13 @@ export const envNameArgs = {
   },
 } as const
 
+export const dotEnvArgs = {
+  dotenv: {
+    type: 'string',
+    description: 'Path to .env file',
+  },
+} as const
+
 export const legacyRootDirArgs = {
   rootDir: {
     type: 'positional',

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -8,7 +8,7 @@ import { defineCommand } from 'citty'
 import { loadKit } from '../utils/kit'
 import { clearDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
-import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -18,6 +18,7 @@ export default defineCommand({
   args: {
     ...sharedArgs,
     ...legacyRootDirArgs,
+    ...dotEnvArgs,
     name: {
       type: 'string',
       description: 'Name of the analysis',
@@ -42,6 +43,10 @@ export default defineCommand({
 
     const nuxt = await loadNuxt({
       cwd,
+      dotenv: {
+        cwd,
+        fileName: ctx.args.dotenv,
+      },
       overrides: defu(ctx.data?.overrides, {
         build: {
           analyze: {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -6,7 +6,7 @@ import { loadKit } from '../utils/kit'
 import { clearBuildDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
 import { showVersions } from '../utils/banner'
-import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -23,10 +23,7 @@ export default defineCommand({
       type: 'string',
       description: 'Nitro server preset',
     },
-    dotenv: {
-      type: 'string',
-      description: 'Path to .env file',
-    },
+    ...dotEnvArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
   },

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -17,7 +17,7 @@ import { loadKit } from '../utils/kit'
 import { importModule } from '../utils/esm'
 import { overrideEnv } from '../utils/env'
 import type { NuxtDevContext, NuxtDevIPCMessage } from '../utils/dev'
-import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
 
 const forkSupported = !isBun && !isTest
 
@@ -31,10 +31,7 @@ const command = defineCommand({
     ...envNameArgs,
     ...legacyRootDirArgs,
     ...getListhenArgs(),
-    dotenv: {
-      type: 'string',
-      description: 'Path to .env file',
-    },
+    ...dotEnvArgs,
     clear: {
       type: 'boolean',
       description: 'Clear console on restart',

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 import buildCommand from './build'
 
-import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -12,10 +12,7 @@ export default defineCommand({
     ...sharedArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
-    dotenv: {
-      type: 'string',
-      description: 'Path to .env file',
-    },
+    ...dotEnvArgs,
   },
   async run(ctx) {
     ctx.args.prerender = true

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -7,7 +7,7 @@ import { defineCommand } from 'citty'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 
-import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -15,10 +15,7 @@ export default defineCommand({
     description: 'Prepare Nuxt for development/build',
   },
   args: {
-    dotenv: {
-      type: 'string',
-      description: 'Path to .env file',
-    },
+    ...dotEnvArgs,
     ...sharedArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -8,7 +8,7 @@ import { box, colors } from 'consola/utils'
 import { defineCommand } from 'citty'
 import { loadKit } from '../utils/kit'
 
-import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
+import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -19,10 +19,7 @@ export default defineCommand({
     ...sharedArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
-    dotenv: {
-      type: 'string',
-      description: 'Path to .env file',
-    },
+    ...dotEnvArgs,
   },
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'


### PR DESCRIPTION
### 🔗 Linked issue
* #542 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #542 

Not sure if bug fix or feature, but it makes sense users want to run analyze using the same options as the build command (should analyze actually be an option/flag for the build command?). 

I haven't actually tested whether the env file is being used, not sure what an easy way is to check this, but I simply applied the flag the same way as in the build command.

This PR also moves the `--dot-env` args into `src/commands/_shared.ts` like other common/shared flags.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
