### PR TITLE
fix(cleanup): remove dev buildDir, not production

### DIFF
--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -17,7 +17,7 @@ export default defineCommand({
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
     const { loadNuxtConfig } = await loadKit(cwd)
-    const nuxtOptions = await loadNuxtConfig({ cwd })
+    const nuxtOptions = await loadNuxtConfig({ cwd, overrides: { dev: true } })
     await cleanupNuxtDirs(nuxtOptions.rootDir, nuxtOptions.buildDir)
   },
 })

--- a/src/utils/nuxt.ts
+++ b/src/utils/nuxt.ts
@@ -21,6 +21,7 @@ export async function cleanupNuxtDirs(rootDir: string, buildDir: string) {
   await rmRecursive(
     [
       buildDir,
+      '.nuxt',
       '.output',
       'dist',
       'node_modules/.vite',

--- a/src/utils/nuxt.ts
+++ b/src/utils/nuxt.ts
@@ -21,7 +21,6 @@ export async function cleanupNuxtDirs(rootDir: string, buildDir: string) {
   await rmRecursive(
     [
       buildDir,
-      '.nuxt',
       '.output',
       'dist',
       'node_modules/.vite',


### PR DESCRIPTION
### 🔗 Linked issue
* #533 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #533 

It seems like, after running the dev server when using `compatibilityVersion: 4`, loading the nuxt config will no longer give the configured `buildDir` which will instead be set to something like `/node_modules/.cache/nuxt/.nuxt`. This is not very useful as we're already clearing the `/node_modules/.cache` directory with this command.

I'm not entirely sure what causes this change, but I did find that passing `overrides: { dev: true }` to `loadNuxtConfig` returns the expected values, not sure if this has other unintended consequences, we're only using the `rootDir` and `buildDir` from the loaded config.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
