### PR TITLE
refactor: shared command descriptions and `--cwd` default

### DIFF
--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -1,32 +1,48 @@
-export const sharedArgs = {
+import type { ArgDef } from 'citty'
+
+export const cwdArgs = {
   cwd: {
     type: 'string',
-    description: 'Current working directory',
+    description: 'Specify the working directory, defaults to current directory (".")',
+    valueHint: 'directory',
+    default: '.',
   },
+} as const satisfies Record<string, ArgDef>
+
+export const sharedArgs = {
+  ...cwdArgs,
   logLevel: {
     type: 'string',
-    description: 'Log level',
+    description: 'Specify build-time log level.',
+    valueHint: 'silent|info|verbose',
   },
-} as const
+} as const satisfies Record<string, ArgDef>
 
 export const envNameArgs = {
   envName: {
     type: 'string',
     description: 'The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server)',
   },
-} as const
+} as const satisfies Record<string, ArgDef>
 
 export const dotEnvArgs = {
   dotenv: {
     type: 'string',
-    description: 'Path to .env file',
+    description: 'Path to `.env` file to load, relative to the root directory.',
   },
-} as const
+} as const satisfies Record<string, ArgDef>
 
 export const legacyRootDirArgs = {
+  // cwd falls back to rootDir's default (indirect default) to ease migration
+  cwd: {
+    ...cwdArgs.cwd,
+    description: 'Specify the working directory, falls back to ROOTDIR if unset (defaults to current directory (".") after ROOTDIR argument removal).',
+    default: undefined,
+  },
   rootDir: {
     type: 'positional',
-    description: 'Root Directory',
+    description: '(DEPRECATED) Use `--cwd` instead. Specifies the working directory, defaults to current directory (".").',
     required: false,
+    default: '.',
   },
-} as const
+} as const satisfies Record<string, ArgDef>

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -3,14 +3,13 @@ import type { ArgDef } from 'citty'
 export const cwdArgs = {
   cwd: {
     type: 'string',
-    description: 'Specify the working directory, defaults to current directory (".")',
+    description: 'Specify the working directory',
     valueHint: 'directory',
     default: '.',
   },
 } as const satisfies Record<string, ArgDef>
 
-export const sharedArgs = {
-  ...cwdArgs,
+export const logLevelArgs = {
   logLevel: {
     type: 'string',
     description: 'Specify build-time log level',
@@ -36,12 +35,12 @@ export const legacyRootDirArgs = {
   // cwd falls back to rootDir's default (indirect default) to ease migration
   cwd: {
     ...cwdArgs.cwd,
-    description: 'Specify the working directory, falls back to ROOTDIR if unset (defaults to current directory (".") after ROOTDIR argument removal)',
+    description: 'Specify the working directory (default: `.`)',
     default: undefined,
   },
   rootDir: {
     type: 'positional',
-    description: '(DEPRECATED) Use `--cwd` instead. Specifies the working directory, defaults to current directory (".")',
+    description: '(DEPRECATED) Use `--cwd` instead. Specifies the working directory (default: `.`)',
     required: false,
     default: '.',
   },

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -13,7 +13,7 @@ export const sharedArgs = {
   ...cwdArgs,
   logLevel: {
     type: 'string',
-    description: 'Specify build-time log level.',
+    description: 'Specify build-time log level',
     valueHint: 'silent|info|verbose',
   },
 } as const satisfies Record<string, ArgDef>
@@ -28,7 +28,7 @@ export const envNameArgs = {
 export const dotEnvArgs = {
   dotenv: {
     type: 'string',
-    description: 'Path to `.env` file to load, relative to the root directory.',
+    description: 'Path to `.env` file to load, relative to the root directory',
   },
 } as const satisfies Record<string, ArgDef>
 
@@ -36,12 +36,12 @@ export const legacyRootDirArgs = {
   // cwd falls back to rootDir's default (indirect default) to ease migration
   cwd: {
     ...cwdArgs.cwd,
-    description: 'Specify the working directory, falls back to ROOTDIR if unset (defaults to current directory (".") after ROOTDIR argument removal).',
+    description: 'Specify the working directory, falls back to ROOTDIR if unset (defaults to current directory (".") after ROOTDIR argument removal)',
     default: undefined,
   },
   rootDir: {
     type: 'positional',
-    description: '(DEPRECATED) Use `--cwd` instead. Specifies the working directory, defaults to current directory (".").',
+    description: '(DEPRECATED) Use `--cwd` instead. Specifies the working directory, defaults to current directory (".")',
     required: false,
     default: '.',
   },

--- a/src/commands/_shared.ts
+++ b/src/commands/_shared.ts
@@ -32,15 +32,15 @@ export const dotEnvArgs = {
 } as const satisfies Record<string, ArgDef>
 
 export const legacyRootDirArgs = {
-  // cwd falls back to rootDir's default (indirect default) to ease migration
+  // cwd falls back to rootDir's default (indirect default)
   cwd: {
     ...cwdArgs.cwd,
-    description: 'Specify the working directory (default: `.`)',
+    description: 'Specify the working directory, this takes precedence over ROOTDIR (default: `.`)',
     default: undefined,
   },
   rootDir: {
     type: 'positional',
-    description: '(DEPRECATED) Use `--cwd` instead. Specifies the working directory (default: `.`)',
+    description: 'Specifies the working directory (default: `.`)',
     required: false,
     default: '.',
   },

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -4,7 +4,7 @@ import { consola } from 'consola'
 import { defineCommand } from 'citty'
 import { loadKit } from '../utils/kit'
 import { templates } from '../utils/templates'
-import { sharedArgs } from './_shared'
+import { cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -12,7 +12,8 @@ export default defineCommand({
     description: 'Create a new template file.',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     force: {
       type: 'boolean',
       description: 'Override existing file',

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -30,7 +30,7 @@ export default defineCommand({
     },
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || '.')
+    const cwd = resolve(ctx.args.cwd)
 
     const templateName = ctx.args.template
     const template = templates[templateName]

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -33,7 +33,7 @@ export default defineCommand({
   async run(ctx) {
     overrideEnv('production')
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
     const name = ctx.args.name || 'default'
     const slug = name.trim().replace(/[^\w-]/g, '_')
 

--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -8,7 +8,7 @@ import { defineCommand } from 'citty'
 import { loadKit } from '../utils/kit'
 import { clearDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
-import { sharedArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
+import { legacyRootDirArgs, dotEnvArgs, cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -16,7 +16,8 @@ export default defineCommand({
     description: 'Build nuxt and analyze production bundle (experimental)',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...legacyRootDirArgs,
     ...dotEnvArgs,
     name: {

--- a/src/commands/build-module.ts
+++ b/src/commands/build-module.ts
@@ -3,7 +3,7 @@ import { consola } from 'consola'
 import { resolve } from 'pathe'
 import { defineCommand } from 'citty'
 import { tryResolveModule } from '../utils/esm'
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
 
 const MODULE_BUILDER_PKG = '@nuxt/module-builder'
 
@@ -13,7 +13,8 @@ export default defineCommand({
     description: `Helper command for using ${MODULE_BUILDER_PKG}`,
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...legacyRootDirArgs,
     stub: {
       type: 'boolean',

--- a/src/commands/build-module.ts
+++ b/src/commands/build-module.ts
@@ -30,7 +30,7 @@ export default defineCommand({
   },
   async run(ctx) {
     // Find local installed version
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     const hasLocal = await tryResolveModule(
       `${MODULE_BUILDER_PKG}/package.json`,

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -6,7 +6,7 @@ import { loadKit } from '../utils/kit'
 import { clearBuildDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
 import { showVersions } from '../utils/banner'
-import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
+import { envNameArgs, legacyRootDirArgs, dotEnvArgs, cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -14,7 +14,8 @@ export default defineCommand({
     description: 'Build Nuxt for production deployment',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     prerender: {
       type: 'boolean',
       description: 'Build Nuxt and prerender static routes',

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -30,7 +30,7 @@ export default defineCommand({
   async run(ctx) {
     overrideEnv('production')
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     showVersions(cwd)
 

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -3,7 +3,7 @@ import { defineCommand } from 'citty'
 import { cleanupNuxtDirs } from '../utils/nuxt'
 
 import { loadKit } from '../utils/kit'
-import { sharedArgs, legacyRootDirArgs } from './_shared'
+import { legacyRootDirArgs, cwdArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -11,7 +11,7 @@ export default defineCommand({
     description: 'Clean up generated Nuxt files and caches',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
     ...legacyRootDirArgs,
   },
   async run(ctx) {

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -15,7 +15,7 @@ export default defineCommand({
     ...legacyRootDirArgs,
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
     const { loadNuxtConfig } = await loadKit(cwd)
     const nuxtOptions = await loadNuxtConfig({ cwd, overrides: { dev: true } })
     await cleanupNuxtDirs(nuxtOptions.rootDir, nuxtOptions.buildDir)

--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -29,7 +29,7 @@ export default defineCommand({
 
     // Prepare
     overrideEnv('development')
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     // Get dev context info
     const devContext: NuxtDevContext

--- a/src/commands/dev-child.ts
+++ b/src/commands/dev-child.ts
@@ -5,7 +5,7 @@ import { isTest } from 'std-env'
 import { overrideEnv } from '../utils/env'
 import type { NuxtDevContext, NuxtDevIPCMessage } from '../utils/dev'
 import { createNuxtDevServer } from '../utils/dev'
-import { sharedArgs, envNameArgs, legacyRootDirArgs } from './_shared'
+import { envNameArgs, legacyRootDirArgs, cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -14,7 +14,8 @@ export default defineCommand({
       'Run Nuxt development server (internal command to start child process)',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
   },

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -17,7 +17,7 @@ import { loadKit } from '../utils/kit'
 import { importModule } from '../utils/esm'
 import { overrideEnv } from '../utils/env'
 import type { NuxtDevContext, NuxtDevIPCMessage } from '../utils/dev'
-import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
+import { envNameArgs, legacyRootDirArgs, dotEnvArgs, cwdArgs, logLevelArgs } from './_shared'
 
 const forkSupported = !isBun && !isTest
 
@@ -27,8 +27,8 @@ const command = defineCommand({
     description: 'Run Nuxt development server',
   },
   args: {
-    ...sharedArgs,
-    ...envNameArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...legacyRootDirArgs,
     ...getListhenArgs(),
     ...dotEnvArgs,

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -45,7 +45,7 @@ const command = defineCommand({
   async run(ctx) {
     // Prepare
     overrideEnv('development')
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
     showVersions(cwd)
     await setupDotenv({ cwd, fileName: ctx.args.dotenv })
 

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -29,6 +29,7 @@ const command = defineCommand({
   args: {
     ...cwdArgs,
     ...logLevelArgs,
+    ...envNameArgs,
     ...legacyRootDirArgs,
     ...getListhenArgs(),
     ...dotEnvArgs,

--- a/src/commands/devtools.ts
+++ b/src/commands/devtools.ts
@@ -19,7 +19,7 @@ export default defineCommand({
     ...legacyRootDirArgs,
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     if (!['enable', 'disable'].includes(ctx.args.command)) {
       console.error(`Unknown command \`${ctx.args.command}\`.`)

--- a/src/commands/devtools.ts
+++ b/src/commands/devtools.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import { execa } from 'execa'
 import { defineCommand } from 'citty'
 
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { cwdArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -10,7 +10,7 @@ export default defineCommand({
     description: 'Enable or disable devtools in a Nuxt project',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
     command: {
       type: 'positional',
       description: 'Command to run',

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty'
 import buildCommand from './build'
 
-import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
+import { envNameArgs, legacyRootDirArgs, dotEnvArgs, cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -9,7 +9,8 @@ export default defineCommand({
     description: 'Build Nuxt and prerender all routes',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
     ...dotEnvArgs,

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -17,7 +17,7 @@ import {
 import { findup } from '../utils/fs'
 
 import nuxiPkg from '../../package.json'
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { cwdArgs, legacyRootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -25,7 +25,7 @@ export default defineCommand({
     description: 'Get information about Nuxt project',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
     ...legacyRootDirArgs,
   },
   async run(ctx) {

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -30,7 +30,7 @@ export default defineCommand({
   },
   async run(ctx) {
     // Resolve rootDir
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     // Load Nuxt config
     const nuxtConfig = await getNuxtConfig(cwd)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -61,7 +61,7 @@ export default defineCommand({
     },
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || '.')
+    const cwd = resolve(ctx.args.cwd)
 
     // Get template name
     const templateName = ctx.args.template || DEFAULT_TEMPLATE_NAME

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import { installDependencies } from 'nypm'
 import type { PackageManagerName } from 'nypm'
 import { defineCommand } from 'citty'
 
-import { sharedArgs } from './_shared'
+import { cwdArgs } from './_shared'
 
 const DEFAULT_REGISTRY
   = 'https://raw.githubusercontent.com/nuxt/starter/templates/templates'
@@ -18,7 +18,7 @@ export default defineCommand({
     description: 'Initialize a fresh project',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
     dir: {
       type: 'positional',
       description: 'Project directory',

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -47,7 +47,7 @@ export default defineCommand({
     },
   },
   async setup(ctx) {
-    const cwd = resolve(ctx.args.cwd || '.')
+    const cwd = resolve(ctx.args.cwd)
     const projectPkg = await getProjectPackage(cwd)
 
     if (!projectPkg.dependencies?.nuxt && !projectPkg.devDependencies?.nuxt) {

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -11,7 +11,7 @@ import { $fetch } from 'ofetch'
 import { satisfies } from 'semver'
 import { updateConfig } from 'c12/update'
 import { colors } from 'consola/utils'
-import { sharedArgs } from '../_shared'
+import { cwdArgs, logLevelArgs } from '../_shared'
 import { runCommand } from '../../run'
 import {
   checkNuxtCompatibility,
@@ -32,7 +32,8 @@ export default defineCommand({
     description: 'Add Nuxt modules',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     moduleName: {
       type: 'positional',
       description: 'Module name',
@@ -124,7 +125,7 @@ export default defineCommand({
     }
 
     // update the types for new module
-    const args = Object.entries(ctx.args).filter(([k]) => k in sharedArgs).map(([k, v]) => `--${k}=${v}`)
+    const args = Object.entries(ctx.args).filter(([k]) => k in cwdArgs || k in logLevelArgs).map(([k, v]) => `--${k}=${v}`)
     await runCommand('prepare', args)
   },
 })

--- a/src/commands/module/search.ts
+++ b/src/commands/module/search.ts
@@ -31,7 +31,7 @@ export default defineCommand({
     },
   },
   async setup(ctx) {
-    const nuxtVersion = await getNuxtVersion(ctx.args.cwd || '.')
+    const nuxtVersion = await getNuxtVersion(ctx.args.cwd)
     return findModuleByKeywords(ctx.args._.join(' '), nuxtVersion)
   },
 })

--- a/src/commands/module/search.ts
+++ b/src/commands/module/search.ts
@@ -3,7 +3,7 @@ import consola from 'consola'
 import Fuse from 'fuse.js'
 import { upperFirst, kebabCase } from 'scule'
 import { bold, green, magenta, cyan, gray, yellow } from 'colorette'
-import { sharedArgs } from '../_shared'
+import { cwdArgs } from '../_shared'
 import { fetchModules, checkNuxtCompatibility, getNuxtVersion } from './_utils'
 
 const { format: formatNumber } = Intl.NumberFormat('en-GB', {
@@ -17,7 +17,7 @@ export default defineCommand({
     description: 'Search in Nuxt modules',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
     query: {
       type: 'positional',
       description: 'keywords to search for',

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -7,7 +7,7 @@ import { defineCommand } from 'citty'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 
-import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
+import { envNameArgs, legacyRootDirArgs, dotEnvArgs, cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -16,7 +16,8 @@ export default defineCommand({
   },
   args: {
     ...dotEnvArgs,
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
   },

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -23,7 +23,7 @@ export default defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     const {
       loadNuxt,

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -8,7 +8,7 @@ import { box, colors } from 'consola/utils'
 import { defineCommand } from 'citty'
 import { loadKit } from '../utils/kit'
 
-import { sharedArgs, envNameArgs, legacyRootDirArgs, dotEnvArgs } from './_shared'
+import { envNameArgs, legacyRootDirArgs, dotEnvArgs, cwdArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -16,7 +16,8 @@ export default defineCommand({
     description: 'Launches Nitro server for local testing after `nuxi build`.',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...envNameArgs,
     ...legacyRootDirArgs,
     ...dotEnvArgs,

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -24,7 +24,7 @@ export default defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     const { loadNuxtConfig } = await loadKit(cwd)
     const config = await loadNuxtConfig({

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -11,10 +11,6 @@ export default defineCommand({
   args: {
     ...sharedArgs,
     ...legacyRootDirArgs,
-    cwd: {
-      type: 'string',
-      description: 'Current working directory',
-    },
     dev: {
       type: 'boolean',
       description: 'Run in dev mode',
@@ -27,7 +23,7 @@ export default defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'test'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     const { runTests } = await importTestUtils()
     await runTests({

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'pathe'
 import { defineCommand } from 'citty'
 
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -9,7 +9,8 @@ export default defineCommand({
     description: 'Run tests',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...legacyRootDirArgs,
     dev: {
       type: 'boolean',

--- a/src/commands/typecheck.ts
+++ b/src/commands/typecheck.ts
@@ -23,7 +23,7 @@ export default defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     const {
       loadNuxt,

--- a/src/commands/typecheck.ts
+++ b/src/commands/typecheck.ts
@@ -9,7 +9,7 @@ import { writeTypes as writeTypesLegacy } from '@nuxt/kit'
 import { tryResolveModule } from '../utils/esm'
 import { loadKit } from '../utils/kit'
 
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -17,7 +17,8 @@ export default defineCommand({
     description: 'Runs `vue-tsc` to check types throughout your app.',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...legacyRootDirArgs,
   },
   async run(ctx) {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -14,7 +14,7 @@ import { rmRecursive, touchFile } from '../utils/fs'
 import { cleanupNuxtDirs, nuxtVersionToGitIdentifier } from '../utils/nuxt'
 
 import { loadKit } from '../utils/kit'
-import { legacyRootDirArgs, sharedArgs } from './_shared'
+import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
 
 async function getNuxtVersion(path: string): Promise<string | null> {
   try {
@@ -80,7 +80,8 @@ export default defineCommand({
     description: 'Upgrade Nuxt',
   },
   args: {
-    ...sharedArgs,
+    ...cwdArgs,
+    ...logLevelArgs,
     ...legacyRootDirArgs,
     force: {
       type: 'boolean',

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -95,7 +95,7 @@ export default defineCommand({
     },
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir || '.')
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     // Check package manager
     const packageManager = getPackageManager(cwd)


### PR DESCRIPTION
### 🔗 Linked issue
* #450
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Is this a refactor and/or docs change 🤷

I found the `ROOTDIR` and `cwd` default value or fallback value a bit confusing, these changes _should_ be functionally the same but instead handles the fallback to the shared argument configuration. Please make sure to check I'm not misunderstanding the fallback logic 😬

I'm slowly working on syncing the descriptions between the command usage `-h` output and those described on `docs/api/commands` pages, more PRs to come.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
