### PR TITLE
fix(dev): use `SIGTERM` instead of `SIGHUP` on windows

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -166,8 +166,13 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
   }
 
   const restart = async () => {
-    // Kill previous process with restart signal
-    kill('SIGHUP')
+    // Kill previous process with restart signal (not supported on Windows)
+    if (process.platform === 'win32') {
+      kill('SIGTERM')
+    }
+    else {
+      kill('SIGHUP')
+    }
     // Start new process
     childProc = fork(globalThis.__nuxt_cli__!.entry!, ['_dev', ...rawArgs], {
       execArgv: [


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/595

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`SIGHUP` is not supported on windows