### PR TITLE
fix: do not override `preset` when prerendering

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -37,10 +37,14 @@ export default defineCommand({
 
     const kit = await loadKit(cwd)
 
-    const nitroPreset = ctx.args.prerender ? 'static' : ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET
+    const resolvedNitroPreset
+      = ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET
+    const nitroPreset = ctx.args.prerender ? 'static' : resolvedNitroPreset
     if (nitroPreset) {
-      if (ctx.args.prerender && ctx.args.preset) {
-        consola.warn(`\`--prerender\` is set. Ignoring \`--preset ${ctx.args.preset}\``)
+      if (ctx.args.prerender && nitroPreset) {
+        consola.warn(
+          `\`--prerender\` is set. Ignoring \`--preset\`, \`NITRO_PRESET\`, \`SERVER_PRESET\` (${resolvedNitroPreset})`,
+        )
       }
       // TODO: Link to the docs
       consola.info(`Using Nitro server preset: \`${nitroPreset}\``)

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -61,7 +61,7 @@ export default defineCommand({
     try {
       // Use ? for backward compatibility for Nuxt <= RC.10
       nitro = kit.useNitro?.()
-      consola.info(`Using Nitro server preset: \`${nitro.options.preset}\``)
+      consola.info(`Building for Nitro preset: \`${nitro.options.preset}\``)
     }
     catch {
       //

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -41,7 +41,7 @@ export default defineCommand({
       = ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET
     const nitroPreset = ctx.args.prerender ? 'static' : resolvedNitroPreset
     if (nitroPreset) {
-      if (ctx.args.prerender && nitroPreset) {
+      if (ctx.args.prerender && resolvedNitroPreset) {
         consola.warn(
           `\`--prerender\` is set. Ignoring \`--preset\`, \`NITRO_PRESET\`, \`SERVER_PRESET\` (${resolvedNitroPreset})`,
         )

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -37,17 +37,10 @@ export default defineCommand({
 
     const kit = await loadKit(cwd)
 
-    const resolvedNitroPreset
+    let nitroPreset
       = ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET
-    const nitroPreset = ctx.args.prerender ? 'static' : resolvedNitroPreset
-    if (nitroPreset) {
-      if (ctx.args.prerender && resolvedNitroPreset) {
-        consola.warn(
-          `\`--prerender\` is set. Ignoring \`--preset\`, \`NITRO_PRESET\`, \`SERVER_PRESET\` (${resolvedNitroPreset})`,
-        )
-      }
-      // TODO: Link to the docs
-      consola.info(`Using Nitro server preset: \`${nitroPreset}\``)
+    if (ctx.args.prerender) {
+      nitroPreset ??= 'static'
     }
 
     const nuxt = await kit.loadNuxt({
@@ -61,9 +54,10 @@ export default defineCommand({
         logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
         // TODO: remove in 3.8
         _generate: ctx.args.prerender,
-        ...(ctx.args.prerender
-          ? { nitro: { static: true } }
-          : { nitro: { preset: nitroPreset } }),
+        nitro: {
+          static: ctx.args.prerender,
+          preset: nitroPreset,
+        },
         ...ctx.data?.overrides,
       },
     })

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -37,12 +37,6 @@ export default defineCommand({
 
     const kit = await loadKit(cwd)
 
-    let nitroPreset
-      = ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET
-    if (ctx.args.prerender) {
-      nitroPreset ??= 'static'
-    }
-
     const nuxt = await kit.loadNuxt({
       cwd,
       dotenv: {
@@ -56,7 +50,7 @@ export default defineCommand({
         _generate: ctx.args.prerender,
         nitro: {
           static: ctx.args.prerender,
-          preset: nitroPreset,
+          preset: ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET,
         },
         ...ctx.data?.overrides,
       },
@@ -67,6 +61,7 @@ export default defineCommand({
     try {
       // Use ? for backward compatibility for Nuxt <= RC.10
       nitro = kit.useNitro?.()
+      consola.info(`Using Nitro server preset: \`${nitro.options.preset}\``)
     }
     catch {
       //


### PR DESCRIPTION
### 🔗 Linked issue

resolves #555
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Related to #555, possibly resolves it?

We currently override any configured preset with `static`, instead we should let nitro resolve the appropriate preset by passing `static: true` since it supports several static presets.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
