### PR TITLE
fix(upgrade): detect 'bun.lock' lockfile

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -70,7 +70,7 @@ export default defineCommand({
               : 'webpack'
 
     let packageManager: keyof typeof packageManagerLocks | 'unknown' | null
-      = getPackageManager(cwd)
+      = getPackageManager(cwd)?.name ?? null
     if (packageManager) {
       packageManager += '@' + getPackageManagerVersion(packageManager)
     }

--- a/src/utils/packageManagers.ts
+++ b/src/utils/packageManagers.ts
@@ -4,23 +4,27 @@ import { resolve } from 'pathe'
 import { findup } from './fs'
 
 export const packageManagerLocks = {
-  yarn: 'yarn.lock',
-  npm: 'package-lock.json',
-  pnpm: 'pnpm-lock.yaml',
-  bun: 'bun.lockb',
+  yarn: ['yarn.lock'],
+  npm: ['package-lock.json'],
+  pnpm: ['pnpm-lock.yaml'],
+  bun: ['bun.lockb', 'bun.lock'],
 }
-
-type PackageManager = keyof typeof packageManagerLocks
 
 export function getPackageManager(rootDir: string) {
   return findup(rootDir, (dir) => {
-    for (const name in packageManagerLocks) {
-      const path = packageManagerLocks[name as PackageManager]
-      if (path && existsSync(resolve(dir, path))) {
-        return name
+    let name: keyof typeof packageManagerLocks
+    for (name in packageManagerLocks) {
+      const paths = packageManagerLocks[name]
+      for (const lockFilePath of paths) {
+        if (lockFilePath && existsSync(resolve(dir, lockFilePath))) {
+          return {
+            name,
+            lockFilePath,
+          }
+        }
       }
     }
-  }) as PackageManager | null
+  })
 }
 
 export function getPackageManagerVersion(name: string) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #613 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`nuxi info` and `nuxi upgrade` are not able to detect what package manager is being used if Bun's new text-based lockfile `bun.lock` is in use.

This PR adds this file to the list of lockfiles searched for.
