### PR TITLE
perf(module): use native `fetch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "magicast": "^0.3.5",
     "nitropack": "npm:nitropack-nightly",
     "nypm": "^0.4.1",
-    "ofetch": "^1.4.1",
     "ohash": "^1.1.4",
     "pathe": "^2.0.0",
     "perfect-debounce": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ importers:
       nypm:
         specifier: ^0.4.1
         version: 0.4.1
-      ofetch:
-        specifier: ^1.4.1
-        version: 1.4.1
       ohash:
         specifier: ^1.1.4
         version: 1.1.4

--- a/src/commands/module/_utils.ts
+++ b/src/commands/module/_utils.ts
@@ -1,4 +1,3 @@
-import { $fetch } from 'ofetch'
 import { readPackageJSON } from 'pkg-types'
 import { satisfies, coerce } from 'semver'
 
@@ -96,9 +95,7 @@ export interface NuxtModule {
 }
 
 export async function fetchModules(): Promise<NuxtModule[]> {
-  const { modules } = await $fetch<NuxtApiModulesResponse>(
-    `https://api.nuxt.com/modules?version=all`,
-  )
+  const { modules } = await fetch('https://api.nuxt.com/modules?version=all').then(r => r.json()) as NuxtApiModulesResponse
   return modules
 }
 

--- a/src/commands/module/add.ts
+++ b/src/commands/module/add.ts
@@ -7,7 +7,6 @@ import { resolve } from 'pathe'
 import { consola } from 'consola'
 import { addDependency } from 'nypm'
 import { joinURL } from 'ufo'
-import { $fetch } from 'ofetch'
 import { satisfies } from 'semver'
 import { updateConfig } from 'c12/update'
 import { colors } from 'consola/utils'
@@ -247,9 +246,9 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
     headers.Authorization = `Bearer ${meta.authToken}`
   }
 
-  const pkgDetails = await $fetch(joinURL(meta.registry, `${pkgName}`), {
+  const pkgDetails = await fetch(joinURL(meta.registry, `${pkgName}`), {
     headers,
-  })
+  }).then(r => r.json())
 
   // check if a dist-tag exists
   pkgVersion = (pkgDetails['dist-tags']?.[pkgVersion] || pkgVersion) as string


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

we'll lose the ability to automatically retry fetches, but most functionality of `ofetch` isn't required within `nuxi`