### PR TITLE
perf: do not inline `writeTypes` from `@nuxt/kit`

### DIFF
--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -1,7 +1,5 @@
 import { relative, resolve } from 'pathe'
 import { consola } from 'consola'
-// we are deliberately inlining this code as a backup in case user has `@nuxt/schema<3.7`
-import { writeTypes as writeTypesLegacy } from '@nuxt/kit'
 
 import { defineCommand } from 'citty'
 import { clearBuildDir } from '../utils/fs'
@@ -26,7 +24,7 @@ export default defineCommand({
 
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
-    const { loadNuxt, buildNuxt, writeTypes = writeTypesLegacy } = await loadKit(cwd)
+    const { loadNuxt, buildNuxt, writeTypes } = await loadKit(cwd)
     const nuxt = await loadNuxt({
       cwd,
       dotenv: {

--- a/src/commands/typecheck.ts
+++ b/src/commands/typecheck.ts
@@ -5,9 +5,6 @@ import { defineCommand } from 'citty'
 import { isBun } from 'std-env'
 import { createJiti } from 'jiti'
 
-// we are deliberately inlining this code as a backup in case user has `@nuxt/schema<3.7`
-import { writeTypes as writeTypesLegacy } from '@nuxt/kit'
-
 import { loadKit } from '../utils/kit'
 
 import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
@@ -27,7 +24,7 @@ export default defineCommand({
 
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
-    const { loadNuxt, buildNuxt, writeTypes = writeTypesLegacy } = await loadKit(cwd)
+    const { loadNuxt, buildNuxt, writeTypes } = await loadKit(cwd)
     const nuxt = await loadNuxt({
       cwd,
       overrides: {

--- a/src/utils/kit.ts
+++ b/src/utils/kit.ts
@@ -10,7 +10,6 @@ export const loadKit = async (rootDir: string): Promise<typeof import('@nuxt/kit
     const rootURL = localKit ? rootDir : (await tryResolveNuxt(rootDir)) || rootDir
     const kit: typeof import('@nuxt/kit') = await jiti.import('@nuxt/kit', { parentURL: rootURL })
     if (!kit.writeTypes) {
-      // Polyfills for schema < 3.7
       consola.warn('Using legacy Nuxt kit version. Please upgrade to Nuxt v3.7 or newer.')
     }
     return kit

--- a/src/utils/kit.ts
+++ b/src/utils/kit.ts
@@ -1,5 +1,4 @@
-// we are deliberately inlining this code as a backup in case user has `@nuxt/schema<3.7`
-import { writeTypes as writeTypesLegacy } from '@nuxt/kit'
+import { consola } from 'consola'
 import { createJiti } from 'jiti'
 
 export const loadKit = async (rootDir: string): Promise<typeof import('@nuxt/kit')> => {
@@ -9,10 +8,10 @@ export const loadKit = async (rootDir: string): Promise<typeof import('@nuxt/kit
     const localKit = jiti.esmResolve('@nuxt/kit', { try: true })
     // Otherwise, we resolve Nuxt _first_ as it is Nuxt's kit dependency that will be used
     const rootURL = localKit ? rootDir : (await tryResolveNuxt(rootDir)) || rootDir
-    let kit: typeof import('@nuxt/kit') = await jiti.import('@nuxt/kit', { parentURL: rootURL })
+    const kit: typeof import('@nuxt/kit') = await jiti.import('@nuxt/kit', { parentURL: rootURL })
     if (!kit.writeTypes) {
       // Polyfills for schema < 3.7
-      kit = { ...kit, writeTypes: writeTypesLegacy }
+      consola.warn('Using legacy Nuxt kit version. Please upgrade to Nuxt v3.7 or newer.')
     }
     return kit
   }

--- a/src/utils/kit.ts
+++ b/src/utils/kit.ts
@@ -10,7 +10,7 @@ export const loadKit = async (rootDir: string): Promise<typeof import('@nuxt/kit
     const rootURL = localKit ? rootDir : (await tryResolveNuxt(rootDir)) || rootDir
     const kit: typeof import('@nuxt/kit') = await jiti.import('@nuxt/kit', { parentURL: rootURL })
     if (!kit.writeTypes) {
-      consola.warn('Using legacy Nuxt kit version. Please upgrade to Nuxt v3.7 or newer.')
+      consola.warn('Using legacy version of `@nuxt/kit`. Please upgrade to v3.7 or newer.')
     }
     return kit
   }

--- a/src/utils/kit.ts
+++ b/src/utils/kit.ts
@@ -1,4 +1,3 @@
-import { consola } from 'consola'
 import { createJiti } from 'jiti'
 
 export const loadKit = async (rootDir: string): Promise<typeof import('@nuxt/kit')> => {
@@ -8,9 +7,14 @@ export const loadKit = async (rootDir: string): Promise<typeof import('@nuxt/kit
     const localKit = jiti.esmResolve('@nuxt/kit', { try: true })
     // Otherwise, we resolve Nuxt _first_ as it is Nuxt's kit dependency that will be used
     const rootURL = localKit ? rootDir : (await tryResolveNuxt(rootDir)) || rootDir
-    const kit: typeof import('@nuxt/kit') = await jiti.import('@nuxt/kit', { parentURL: rootURL })
+    let kit: typeof import('@nuxt/kit') = await jiti.import('@nuxt/kit', { parentURL: rootURL })
     if (!kit.writeTypes) {
-      consola.warn('Using legacy version of `@nuxt/kit`. Please upgrade to v3.7 or newer.')
+      kit = {
+        ...kit,
+        writeTypes: () => {
+          throw new Error('`writeTypes` is not available in this version of `@nuxt/kit`. Please upgrade to v3.7 or newer.')
+        },
+      }
     }
     return kit
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This finally drops the inlined `writeTypes` utility from Nuxt <3.7, which was last published 19 July 2023.