### PR TITLE
feat: additional dirs for cleanDir command

### DIFF
--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -13,11 +13,21 @@ export default defineCommand({
   args: {
     ...cwdArgs,
     ...legacyRootDirArgs,
+    cleanDir: {
+      type: 'string',
+      required: false,
+      description: 'Additional directories to clean up',
+    },
   },
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
     const { loadNuxtConfig } = await loadKit(cwd)
     const nuxtOptions = await loadNuxtConfig({ cwd, overrides: { dev: true } })
-    await cleanupNuxtDirs(nuxtOptions.rootDir, nuxtOptions.buildDir)
+
+    const customDirs = ctx.args.cleanDir
+      ? ctx.args.cleanDir.split(',').map(dir => resolve(cwd, dir.trim()))
+      : []
+
+    await cleanupNuxtDirs(nuxtOptions.rootDir, nuxtOptions.buildDir, customDirs)
   },
 })

--- a/src/utils/nuxt.ts
+++ b/src/utils/nuxt.ts
@@ -18,18 +18,24 @@ interface NuxtProjectManifest {
   }
 }
 
-export async function cleanupNuxtDirs(rootDir: string, buildDir: string) {
+export async function cleanupNuxtDirs(
+  rootDir: string,
+  buildDir: string,
+  customDirs?: string[],
+) {
   logger.info('Cleaning up generated Nuxt files and caches...')
 
-  await rmRecursive(
-    [
-      buildDir,
-      '.output',
-      'dist',
-      'node_modules/.vite',
-      'node_modules/.cache',
-    ].map(dir => resolve(rootDir, dir)),
-  )
+  const defaultDirs = [
+    buildDir,
+    '.output',
+    'dist',
+    'node_modules/.vite',
+    'node_modules/.cache',
+  ].map(dir => resolve(rootDir, dir))
+
+  const dirsToClean = [...defaultDirs, ...(customDirs || [])]
+
+  await rmRecursive(dirsToClean)
 }
 
 export function nuxtVersionToGitIdentifier(version: string) {


### PR DESCRIPTION
### 🔗 #415 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

### Add custom directory cleanup support to `nuxi cleanup`

This PR adds support for cleaning up custom directories via the `--cleanDir` argument in the `nuxi cleanup` command, as requested in #415.

### Features
- Added `--cleanDir` argument to specify additional directories to clean up
- Supports comma-separated values for cleaning multiple directories in a single command
- Paths are resolved relative to the project root
- Maintains existing functionality for default Nuxt directories

### Usage Examples
#### Single Directory
```bash
npx nuxi cleanup --cleanDir temp
```

#### Multiple Directories (comma-separated)
```bash
npx nuxi cleanup --cleanDir "temp,cache,build"
```

#### Mixed with Default Cleanup
The command will clean both the specified directories and the default Nuxt directories:
- Custom directories (from --cleanDir)
- buildDir
- .output
- dist
- node_modules/.vite
- node_modules/.cache

### Implementation Details
- Added `cleanDir` argument with `type: 'string'` to support comma-separated values
- Enhanced `cleanupNuxtDirs` to handle custom directories alongside default ones
- All paths are properly resolved relative to the project root
- Whitespace in comma-separated values is automatically trimmed

