### PR TITLE
perf(dev): avoid removing manifest immediately after creation

### DIFF
--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -130,9 +130,9 @@ class NuxtDevServer extends EventEmitter {
     res.setHeader('Content-Type', 'text/html')
     const loadingTemplate
       = this.options.loadingTemplate
-      || this._currentNuxt?.options.devServer.loadingTemplate
-      || await this._jiti.import<{ loading: () => string }>('@nuxt/ui-templates').then(r => r.loading).catch(() => {})
-      || ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
+        || this._currentNuxt?.options.devServer.loadingTemplate
+        || await this._jiti.import<{ loading: () => string }>('@nuxt/ui-templates').then(r => r.loading).catch(() => {})
+        || ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
     res.end(
       loadingTemplate({
         loading: _error?.toString() || this._loadingMessage || 'Loading...',

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -289,7 +289,6 @@ class NuxtDevServer extends EventEmitter {
     }
 
     await Promise.all([
-
       kit.writeTypes(this._currentNuxt).catch(console.error),
       kit.buildNuxt(this._currentNuxt),
     ])

--- a/packages/nuxi/src/utils/fs.ts
+++ b/packages/nuxi/src/utils/fs.ts
@@ -32,7 +32,7 @@ export async function clearDir(path: string, exclude?: string[]) {
 }
 
 export function clearBuildDir(path: string) {
-  return clearDir(path, ['cache', 'analyze'])
+  return clearDir(path, ['cache', 'analyze', 'nuxt.json'])
 }
 
 export async function rmRecursive(paths: string[]) {

--- a/packages/nuxi/src/utils/nuxt.ts
+++ b/packages/nuxi/src/utils/nuxt.ts
@@ -42,7 +42,7 @@ export function nuxtVersionToGitIdentifier(version: string) {
   return `v${version}`
 }
 
-function resolveNuxtManifest(nuxt: Nuxt): NuxtProjectManifest {
+export function resolveNuxtManifest(nuxt: Nuxt): NuxtProjectManifest {
   const manifest: NuxtProjectManifest = {
     _hash: null,
     project: {
@@ -56,19 +56,14 @@ function resolveNuxtManifest(nuxt: Nuxt): NuxtProjectManifest {
   return manifest
 }
 
-export async function writeNuxtManifest(
-  nuxt: Nuxt,
-): Promise<NuxtProjectManifest> {
-  const manifest = resolveNuxtManifest(nuxt)
+export async function writeNuxtManifest(nuxt: Nuxt, manifest = resolveNuxtManifest(nuxt)): Promise<NuxtProjectManifest> {
   const manifestPath = resolve(nuxt.options.buildDir, 'nuxt.json')
   await fsp.mkdir(dirname(manifestPath), { recursive: true })
   await fsp.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf-8')
   return manifest
 }
 
-export async function loadNuxtManifest(
-  buildDir: string,
-): Promise<NuxtProjectManifest | null> {
+export async function loadNuxtManifest(buildDir: string): Promise<NuxtProjectManifest | null> {
   const manifestPath = resolve(buildDir, 'nuxt.json')
   const manifest: NuxtProjectManifest | null = await fsp
     .readFile(manifestPath, 'utf-8')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

two small perf changes - this avoids writing a file which will immediately be removed, and also doesn't block the directory clearing until the file has been written

it also persists `nuxt.json` even when clearing the build directory