### PR TITLE
fix(upgrade): warmup `nypm` before removing `node_modules`

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 import { defineCommand } from 'citty'
 import { colors } from 'consola/utils'
-import { addDependency, detectPackageManager } from 'nypm'
+import { addDependency, detectPackageManager, removeDependency } from 'nypm'
 import { resolve } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
 
@@ -141,6 +141,9 @@ export default defineCommand({
       ) === true
     }
     if (ctx.args.force) {
+      // Trigger dynamic imports in nypm before removing node_modules
+      await removeDependency('', { silent: true })
+
       logger.info(
         `Recreating ${forceRemovals}. If you encounter any issues, revert the changes and try with \`--no-force\``,
       )


### PR DESCRIPTION
### 🔗 Linked issue
* #675
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is a silly hack/fix for #675, it works by calling `removeDependency` to trigger [a dynamic import](https://github.com/unjs/nypm/blob/main/src/_utils.ts?rgh-link-date=2025-01-17T15%3A46%3A37.000Z#L40) in `nypm` before we remove `node_modules`. Without this change the dynamic import would be triggered by `addDependency` which is after removing `node_modules` which means it will resolve to `undefined` and error/exit.

@danielroe 
This works but relies on internal behavior of `nypm` which could change/break, I'm not sure what a clean/proper way would be to fix this 😅

Resolves #675 


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
