### PR TITLE
fix(module): allow specifying version alongside module name

### DIFF
--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -223,6 +223,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   const matchedModule = modulesDB.find(
     module =>
       module.name === moduleName
+      || (pkgVersion && module.name === pkgName)
       || module.npm === pkgName
       || module.aliases?.includes(pkgName),
   )

--- a/packages/nuxi/test/unit/commands/module/add.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/add.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import * as utils from "../../../../src/commands/module/_utils";
+// import * as c12 from "c12/update";
+import commands from "../../../../src/commands/module";
+import * as runCommands from "../../../../src/run";
+
+const updateConfig = vi.fn(() => Promise.resolve());
+const addDependency = vi.fn(() => Promise.resolve());
+
+const applyMocks = () => {
+  vi.mock("c12/update", async (importOriginal) => {
+    return {
+      updateConfig,
+    };
+  });
+  vi.mock("nypm", async (importOriginal) => {
+    return {
+      addDependency,
+    };
+  });
+  vi.mock("pkg-types", async (importOriginal) => {
+    return {
+      readPackageJSON: () => {
+        return new Promise((resolve) => {
+          resolve({
+            devDependencies: {
+              nuxt: "3.0.0",
+            },
+          });
+        });
+      },
+    };
+  });
+};
+describe("module add", () => {
+  applyMocks();
+  vi.spyOn(runCommands, "runCommand").mockImplementation(vi.fn());
+  vi.spyOn(utils, "getNuxtVersion").mockResolvedValue("3.0.0");
+  vi.spyOn(utils, "fetchModules").mockResolvedValue([
+    {
+      name: "content",
+      npm: "@nuxt/content",
+      compatibility: {
+        nuxt: "3.0.0",
+      },
+    },
+  ]);
+
+
+  it("should  install Nuxt module", async () => {
+    const addCommand = await commands.subCommands.add();
+    await addCommand.setup({
+      args: {
+        cwd: "/fake-dir",
+        _: ["content"],
+      },
+    });
+
+    expect(addDependency).toHaveBeenCalledWith(["@nuxt/content@3.0.0"], {
+      cwd: "/fake-dir",
+      dev: true,
+      installPeerDependencies: true,
+    });
+  });
+
+  it("should convert versioned module to Nuxt module", async () => {
+    const addCommand = await commands.subCommands.add();
+    await addCommand.setup({
+      args: {
+        cwd: "/fake-dir",
+        _: ["content@2.9.0"],
+      },
+    });
+
+    expect(addDependency).toHaveBeenCalledWith(["@nuxt/content@2.9.0"], {
+      cwd: "/fake-dir",
+      dev: true,
+      installPeerDependencies: true,
+    });
+  });
+});

--- a/packages/nuxi/test/unit/commands/module/add.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/add.spec.ts
@@ -1,81 +1,101 @@
-import { describe, expect, it, vi } from "vitest";
-import * as utils from "../../../../src/commands/module/_utils";
-// import * as c12 from "c12/update";
-import commands from "../../../../src/commands/module";
-import * as runCommands from "../../../../src/run";
+import { describe, expect, it, vi } from 'vitest'
+import commands from '../../../../src/commands/module'
+import * as utils from '../../../../src/commands/module/_utils'
+import * as runCommands from '../../../../src/run'
 
-const updateConfig = vi.fn(() => Promise.resolve());
-const addDependency = vi.fn(() => Promise.resolve());
-
-const applyMocks = () => {
-  vi.mock("c12/update", async (importOriginal) => {
+const updateConfig = vi.fn(() => Promise.resolve())
+const addDependency = vi.fn(() => Promise.resolve())
+interface CommandsType {
+  subCommands: {
+    // biome-ignore lint/correctness/noEmptyPattern: <explanation>
+    add: () => Promise<{ setup: (args: any) => void }>
+  }
+}
+function applyMocks() {
+  vi.mock('c12/update', async () => {
     return {
       updateConfig,
-    };
-  });
-  vi.mock("nypm", async (importOriginal) => {
+    }
+  })
+  vi.mock('nypm', async () => {
     return {
       addDependency,
-    };
-  });
-  vi.mock("pkg-types", async (importOriginal) => {
+    }
+  })
+  vi.mock('pkg-types', async () => {
     return {
       readPackageJSON: () => {
         return new Promise((resolve) => {
           resolve({
             devDependencies: {
-              nuxt: "3.0.0",
+              nuxt: '3.0.0',
             },
-          });
-        });
+          })
+        })
       },
-    };
-  });
-};
-describe("module add", () => {
-  applyMocks();
-  vi.spyOn(runCommands, "runCommand").mockImplementation(vi.fn());
-  vi.spyOn(utils, "getNuxtVersion").mockResolvedValue("3.0.0");
-  vi.spyOn(utils, "fetchModules").mockResolvedValue([
+    }
+  })
+}
+describe('module add', () => {
+  applyMocks()
+  vi.spyOn(runCommands, 'runCommand').mockImplementation(vi.fn())
+  vi.spyOn(utils, 'getNuxtVersion').mockResolvedValue('3.0.0')
+  vi.spyOn(utils, 'fetchModules').mockResolvedValue([
     {
-      name: "content",
-      npm: "@nuxt/content",
+      name: 'content',
+      npm: '@nuxt/content',
       compatibility: {
-        nuxt: "3.0.0",
+        nuxt: '3.0.0',
+        requires: {},
+        versionMap: {},
+      },
+      description: '',
+      repo: '',
+      github: '',
+      website: '',
+      learn_more: '',
+      category: '',
+      type: 'community',
+      maintainers: [],
+      stats: {
+        downloads: 0,
+        stars: 0,
+        maintainers: 0,
+        contributors: 0,
+        modules: 0,
       },
     },
-  ]);
+  ])
 
-
-  it("should  install Nuxt module", async () => {
-    const addCommand = await commands.subCommands.add();
+  it('should  install Nuxt module', async () => {
+    const addCommand = await (commands as CommandsType).subCommands.add()
     await addCommand.setup({
       args: {
-        cwd: "/fake-dir",
-        _: ["content"],
+        cwd: '/fake-dir',
+        _: ['content'],
       },
-    });
+    })
 
-    expect(addDependency).toHaveBeenCalledWith(["@nuxt/content@3.0.0"], {
-      cwd: "/fake-dir",
+    expect(addDependency).toHaveBeenCalledWith(['@nuxt/content@3.0.0'], {
+      cwd: '/fake-dir',
       dev: true,
       installPeerDependencies: true,
-    });
-  });
+    })
+  })
 
-  it("should convert versioned module to Nuxt module", async () => {
-    const addCommand = await commands.subCommands.add();
+  it('should convert versioned module to Nuxt module', async () => {
+    const addCommand = await (commands as CommandsType).subCommands.add()
     await addCommand.setup({
       args: {
-        cwd: "/fake-dir",
-        _: ["content@2.9.0"],
+        cwd: '/fake-dir',
+        _: ['content@2.9.0'],
       },
-    });
+    })
 
-    expect(addDependency).toHaveBeenCalledWith(["@nuxt/content@2.9.0"], {
-      cwd: "/fake-dir",
+    expect(addDependency).toHaveBeenCalledWith(['@nuxt/content@2.9.0'], {
+      cwd: '/fake-dir',
       dev: true,
       installPeerDependencies: true,
-    });
-  });
-});
+    })
+  })
+})


### PR DESCRIPTION
fix #697 #701

### 🔗 Linked issue

resolves #697, resolves #701 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR enhance the `nuxi module add` but allowing it to find a Nuxt Module when a version is speficied.

Without this PR:
![Screenshot From 2025-01-25 01-32-15](https://github.com/user-attachments/assets/c876179c-7bb9-43dc-878f-217b83947a09)


With this PR:
![Screenshot From 2025-01-25 01-33-07](https://github.com/user-attachments/assets/ae26eff8-5732-4776-b206-195d19eb5c65)
