### PR TITLE
fix(dev): automatically set `allowedHosts` + `origin` w/ `--host`

### DIFF
--- a/packages/nuxi/src/commands/dev-child.ts
+++ b/packages/nuxi/src/commands/dev-child.ts
@@ -62,8 +62,9 @@ export default defineCommand({
     const hostname = devContext.hostname
     if (hostname) {
       ctx.data ||= {}
+      const protocol = devContext.proxy?.https ? 'https' : 'http'
       ctx.data.overrides = defu(ctx.data.overrides, {
-        devServer: { cors: { origin: [devContext.proxy?.https ? 'https://' : `http://${hostname}`] } },
+        devServer: { cors: { origin: [`${protocol}://${hostname}`] } },
         vite: { server: { allowedHosts: [hostname] } },
       })
     }

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -10,6 +10,7 @@ import process from 'node:process'
 
 import { setupDotenv } from 'c12'
 import { defineCommand } from 'citty'
+import defu from 'defu'
 import { createJiti } from 'jiti'
 import { getArgs as getListhenArgs, parseArgs as parseListhenArgs } from 'listhen/cli'
 import { resolve } from 'pathe'
@@ -70,12 +71,19 @@ const command = defineCommand({
     if (ctx.args.fork) {
       // Fork Nuxt dev process
       const devProxy = await _createDevProxy(nuxtOptions, listenOptions)
-      await _startSubprocess(devProxy, ctx.rawArgs)
+      await _startSubprocess(devProxy, ctx.rawArgs, listenOptions.hostname)
       return { listener: devProxy?.listener }
     }
     else {
       // Directly start Nuxt dev
       const { createNuxtDevServer } = await import('../utils/dev')
+      if (listenOptions.hostname) {
+        ctx.data ||= {}
+        ctx.data.overrides = defu(ctx.data.overrides, {
+          devServer: { cors: { origin: [listenOptions.https ? 'https://' : `http://${listenOptions.hostname}`] } },
+          vite: { server: { allowedHosts: [listenOptions.hostname] } },
+        })
+      }
       const devServer = await createNuxtDevServer(
         {
           cwd,
@@ -158,7 +166,7 @@ async function _createDevProxy(nuxtOptions: NuxtOptions, listenOptions: Partial<
   }
 }
 
-async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
+async function _startSubprocess(devProxy: DevProxy, rawArgs: string[], hostname?: string) {
   let childProc: ChildProcess | undefined
 
   const kill = (signal: NodeJS.Signals | number) => {
@@ -185,6 +193,7 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[]) {
       env: {
         ...process.env,
         __NUXT_DEV__: JSON.stringify({
+          hostname,
           proxy: {
             url: devProxy.listener.url,
             urls: await devProxy.listener.getURLs(),

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -79,8 +79,9 @@ const command = defineCommand({
       const { createNuxtDevServer } = await import('../utils/dev')
       if (listenOptions.hostname) {
         ctx.data ||= {}
+        const protocol = listenOptions.https ? 'https' : 'http'
         ctx.data.overrides = defu(ctx.data.overrides, {
-          devServer: { cors: { origin: [listenOptions.https ? 'https://' : `http://${listenOptions.hostname}`] } },
+          devServer: { cors: { origin: [`${protocol}://${listenOptions.hostname}`] } },
           vite: { server: { allowedHosts: [listenOptions.hostname] } },
         })
       }

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -28,6 +28,7 @@ export type NuxtDevIPCMessage =
   | { type: 'nuxt:internal:dev:rejection', message: string }
 
 export interface NuxtDevContext {
+  hostname?: string
   proxy?: {
     url?: string
     urls?: ListenURL[]


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30725

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this automatically sets the new `allowedHosts` vite option when used with an explicit `--host`