### PR TITLE
ci: fix build-head siize failure for forks

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - run: corepack enable
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:


### PR DESCRIPTION
### 🔗 Linked issue

Not a related issue but this state of Dan about the failure of the build-head from size for forks
https://github.com/nuxt/cli/pull/702#issuecomment-2614130360

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- x ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
 Adding  `repository: ${{ github.event.pull_request.head.repo.full_name }}` to comparate build size for forked branchs too
From https://github.com/actions/checkout/issues/551
