### PR TITLE
feat(dev): allow all hosts to connect to dev server for `--public`

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -1,4 +1,4 @@
-import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
+import type { NuxtOptions } from '@nuxt/schema'
 import type { ParsedArgs } from 'citty'
 import type { HTTPSOptions, ListenOptions } from 'listhen'
 import type { ChildProcess } from 'node:child_process'
@@ -17,6 +17,7 @@ import { resolve } from 'pathe'
 
 import { isBun, isTest } from 'std-env'
 import { showVersions } from '../utils/banner'
+import { _getDevServerOverrides } from '../utils/dev'
 import { overrideEnv } from '../utils/env'
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
@@ -78,22 +79,8 @@ const command = defineCommand({
       // Directly start Nuxt dev
       const { createNuxtDevServer } = await import('../utils/dev')
 
-      const defaultOverrides: Partial<NuxtConfig> = {}
-
-      // defined hostname
-      if (listenOptions.hostname) {
-        const protocol = listenOptions.https ? 'https' : 'http'
-        defaultOverrides.devServer = { cors: { origin: [`${protocol}://${listenOptions.hostname}`] } }
-        defaultOverrides.vite = { server: { allowedHosts: [listenOptions.hostname] } }
-      }
-
-      if (listenOptions.public) {
-        defaultOverrides.devServer = { cors: { origin: '*' } }
-        defaultOverrides.vite = { server: { allowedHosts: true } }
-      }
-
       ctx.data ||= {}
-      ctx.data.overrides = defu(ctx.data.overrides, defaultOverrides)
+      ctx.data.overrides = defu(ctx.data.overrides, _getDevServerOverrides(listenOptions))
       const devServer = await createNuxtDevServer(
         {
           cwd,

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -28,6 +28,7 @@ export type NuxtDevIPCMessage =
   | { type: 'nuxt:internal:dev:rejection', message: string }
 
 export interface NuxtDevContext {
+  public?: boolean
   hostname?: string
   proxy?: {
     url?: string

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -340,3 +340,21 @@ function _getAddressURL(addr: AddressInfo, https: boolean) {
   const port = addr.port || 3000
   return `${proto}://${host}:${port}/`
 }
+
+export function _getDevServerOverrides(listenOptions: Partial<Pick<ListenOptions, 'hostname' | 'public' | 'https'>>) {
+  const defaultOverrides: Partial<NuxtConfig> = {}
+
+  // defined hostname
+  if (listenOptions.hostname) {
+    const protocol = listenOptions.https ? 'https' : 'http'
+    defaultOverrides.devServer = { cors: { origin: [`${protocol}://${listenOptions.hostname}`] } }
+    defaultOverrides.vite = { server: { allowedHosts: [listenOptions.hostname] } }
+  }
+
+  if (listenOptions.public) {
+    defaultOverrides.devServer = { cors: { origin: '*' } }
+    defaultOverrides.vite = { server: { allowedHosts: true } }
+  }
+
+  return defaultOverrides
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This improves DX for dev server to allow all hosts to connect to the dev server when the `--public` flag is passed or a hostname that doesn't match `['localhost', '127.0.0.1', '::1']`.

We could also consider printing a message to warn users of the potential issues with a public dev server.