### PR TITLE
fix(nuxi): return true if adding dependency succeed

### DIFF
--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -132,18 +132,20 @@ async function addModules(modules: ResolvedModule[], { skipInstall, skipConfig, 
         cwd,
         dev: isDev,
         installPeerDependencies: true,
-      }).catch(
-        (error) => {
-          logger.error(error)
+      })
+        .then(() => true)
+        .catch(
+          (error) => {
+            logger.error(error)
 
-          const failedModulesList = notInstalledModules.map(module => colors.cyan(module.pkg)).join('\`, \`')
-          const s = notInstalledModules.length > 1 ? 's' : ''
-          return logger.prompt(`Install failed for \`${failedModulesList}\`. Do you want to continue adding the module${s} to ${colors.cyan('nuxt.config')}?`, {
-            type: 'confirm',
-            initial: false,
-          })
-        },
-      )
+            const failedModulesList = notInstalledModules.map(module => colors.cyan(module.pkg)).join('\`, \`')
+            const s = notInstalledModules.length > 1 ? 's' : ''
+            return logger.prompt(`Install failed for \`${failedModulesList}\`. Do you want to continue adding the module${s} to ${colors.cyan('nuxt.config')}?`, {
+              type: 'confirm',
+              initial: false,
+            })
+          },
+        )
 
       if (res !== true) {
         return


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Right now, when running `npx nuxi@latest module add content`, it only install the dependency but does not add it to the `nuxt.config.ts`

I believe the bug has been introduced by this change: https://github.com/nuxt/cli/pull/687/files#diff-3ac0a0d31e5ed2e2949d42ea2e33d33bf48d9663ae4031a23a2582c31cc4f2af

`nypm` does not return `true` when installing a dependency: https://github.com/unjs/nypm/blob/651ab80c383bd74dde42de06763240e14611473c/src/api.ts#L59C23-L59C36

My changes make sure that we return `true` if `nypm` did not throw any error so it can move to updating the `nuxt.config` file