### PR TITLE
feat(init): allow installing modules after clone

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -10,6 +10,7 @@ import { installDependencies } from 'nypm'
 import { relative, resolve } from 'pathe'
 import { x } from 'tinyexec'
 
+import { runCommand } from '../run'
 import { logger } from '../utils/logger'
 import { cwdArgs } from './_shared'
 
@@ -73,6 +74,12 @@ export default defineCommand({
     packageManager: {
       type: 'string',
       description: 'Package manager choice (npm, pnpm, yarn, bun)',
+    },
+    modules: {
+      type: 'string',
+      required: false,
+      description: 'Modules to install',
+      alias: 'M',
     },
   },
   async run(ctx) {
@@ -203,6 +210,12 @@ export default defineCommand({
       catch (err) {
         logger.warn(`Failed to initialize git repository: ${err}`)
       }
+    }
+
+    // Add modules when -M flag is provided
+    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(' ').filter(name => !!name)
+    if (modules.length > 0) {
+      await runCommand('module', ['add', ...modules])
     }
 
     // Display next steps

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -213,7 +213,7 @@ export default defineCommand({
     }
 
     // Add modules when -M flag is provided
-    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(',').filter(module => !!module.trim())
+    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(',').map(module => module.trim()).filter(Boolean)
     if (modules.length > 0) {
       await runCommand('module', ['add', ...modules])
     }

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -78,7 +78,7 @@ export default defineCommand({
     modules: {
       type: 'string',
       required: false,
-      description: 'Modules to install',
+      description: 'Nuxt modules to install (comma separated without spaces)',
       alias: 'M',
     },
   },
@@ -213,7 +213,7 @@ export default defineCommand({
     }
 
     // Add modules when -M flag is provided
-    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(' ').filter(name => !!name)
+    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(',').map(module => module.trim())
     if (modules.length > 0) {
       await runCommand('module', ['add', ...modules])
     }

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -213,7 +213,7 @@ export default defineCommand({
     }
 
     // Add modules when -M flag is provided
-    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(',').map(module => module.trim())
+    const modules = !ctx.args.modules ? [] : ctx.args.modules.split(',').filter(module => !!module.trim())
     if (modules.length > 0) {
       await runCommand('module', ['add', ...modules])
     }

--- a/packages/nuxi/src/run.ts
+++ b/packages/nuxi/src/run.ts
@@ -21,6 +21,7 @@ globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
 
 export const runMain = () => _runMain(main)
 
+// To provide subcommands call it as `runCommand(<command>, [<subcommand>, ...])`
 export async function runCommand(
   name: string,
   argv: string[] = process.argv.slice(2),

--- a/packages/nuxt-cli/playground/nuxt.config.ts
+++ b/packages/nuxt-cli/playground/nuxt.config.ts
@@ -1,9 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  compatibilityDate: '2024-09-05',
-  nitro: {
-    experimental: {
-      websocket: true,
-    },
-  },
+  compatibilityDate: '2024-11-01',
+  devtools: { enabled: true },
+  modules: ['@nuxtjs/tailwindcss', '@nuxt/eslint']
 })

--- a/packages/nuxt-cli/playground/nuxt.config.ts
+++ b/packages/nuxt-cli/playground/nuxt.config.ts
@@ -1,6 +1,9 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  compatibilityDate: '2024-11-01',
-  devtools: { enabled: true },
-  modules: ['@nuxtjs/tailwindcss', '@nuxt/eslint']
+  compatibilityDate: '2024-09-05',
+  nitro: {
+    experimental: {
+      websocket: true,
+    },
+  },
 })


### PR DESCRIPTION
### 🔗 Linked issue
resolves https://github.com/nuxt/cli/issues/267

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An additional flag `-M` was added for `nuxi init`  .
It accepts a string of nuxt modules, as an example : `nuxi init -M eslint,tailwind`

