### PR TITLE
fix(dev): automatically add tunnel hostnames to vite allowedHosts

### DIFF
--- a/packages/nuxi/src/commands/dev-child.ts
+++ b/packages/nuxi/src/commands/dev-child.ts
@@ -60,7 +60,7 @@ export default defineCommand({
       hostname: devContext.hostname,
       public: devContext.public,
       https: devContext.proxy?.https,
-    }))
+    }, devContext.publicURLs))
 
     // Init Nuxt dev
     const nuxtDev = await createNuxtDevServer({

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -193,6 +193,7 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[], listenArg
         __NUXT_DEV__: JSON.stringify({
           hostname: listenArgs.hostname,
           public: listenArgs.public,
+          publicURLs: await devProxy.listener.getURLs().then(r => r.map(r => r.url)),
           proxy: {
             url: devProxy.listener.url,
             urls: await devProxy.listener.getURLs(),

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -357,7 +357,7 @@ export function _getDevServerOverrides(listenOptions: Partial<Pick<ListenOptions
   if (listenOptions.hostname) {
     const protocol = listenOptions.https ? 'https' : 'http'
     defaultOverrides.devServer = { cors: { origin: [`${protocol}://${listenOptions.hostname}`, ...urls] } }
-    defaultOverrides.vite = { server: { allowedHosts: [listenOptions.hostname, ...urls.map(u => new URL(u).hostname)] } }
+    defaultOverrides.vite = defu(defaultOverrides.vite, { server: { allowedHosts: [listenOptions.hostname] } })
   }
 
   if (listenOptions.public) {

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -9,6 +9,7 @@ import EventEmitter from 'node:events'
 import process from 'node:process'
 
 import chokidar from 'chokidar'
+import { defu } from 'defu'
 import { toNodeListener } from 'h3'
 import { createJiti } from 'jiti'
 import { listen } from 'listhen'
@@ -30,6 +31,7 @@ export type NuxtDevIPCMessage =
 export interface NuxtDevContext {
   public?: boolean
   hostname?: string
+  publicURLs?: string[]
   proxy?: {
     url?: string
     urls?: ListenURL[]
@@ -177,6 +179,8 @@ class NuxtDevServer extends EventEmitter {
     }
 
     const kit = await loadKit(this.options.cwd)
+
+    this.options.overrides = defu(this.options.overrides, _getDevServerOverrides({}, await this.listener.getURLs().then(r => r.map(r => r.url))))
     this._currentNuxt = await kit.loadNuxt({
       cwd: this.options.cwd,
       dev: true,
@@ -184,15 +188,16 @@ class NuxtDevServer extends EventEmitter {
       envName: this.options.envName,
       overrides: {
         logLevel: this.options.logLevel as 'silent' | 'info' | 'verbose',
-        vite: {
-          clearScreen: this.options.clear,
-        },
         nitro: {
           devErrorHandler: (error, event) => {
             this._renderError(event.node.res, error)
           },
         },
         ...this.options.overrides,
+        vite: {
+          clearScreen: this.options.clear,
+          ...this.options.overrides.vite,
+        },
       },
     })
 
@@ -341,14 +346,18 @@ function _getAddressURL(addr: AddressInfo, https: boolean) {
   return `${proto}://${host}:${port}/`
 }
 
-export function _getDevServerOverrides(listenOptions: Partial<Pick<ListenOptions, 'hostname' | 'public' | 'https'>>) {
+export function _getDevServerOverrides(listenOptions: Partial<Pick<ListenOptions, 'hostname' | 'public' | 'https'>>, urls: string[] = []) {
   const defaultOverrides: Partial<NuxtConfig> = {}
+
+  if (urls) {
+    defaultOverrides.vite = { server: { allowedHosts: urls.map(u => new URL(u).hostname) } }
+  }
 
   // defined hostname
   if (listenOptions.hostname) {
     const protocol = listenOptions.https ? 'https' : 'http'
-    defaultOverrides.devServer = { cors: { origin: [`${protocol}://${listenOptions.hostname}`] } }
-    defaultOverrides.vite = { server: { allowedHosts: [listenOptions.hostname] } }
+    defaultOverrides.devServer = { cors: { origin: [`${protocol}://${listenOptions.hostname}`, ...urls] } }
+    defaultOverrides.vite = { server: { allowedHosts: [listenOptions.hostname, ...urls.map(u => new URL(u).hostname)] } }
   }
 
   if (listenOptions.public) {

--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -9,7 +9,7 @@ import EventEmitter from 'node:events'
 import process from 'node:process'
 
 import chokidar from 'chokidar'
-import { defu } from 'defu'
+import defu from 'defu'
 import { toNodeListener } from 'h3'
 import { createJiti } from 'jiti'
 import { listen } from 'listhen'


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31184

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this gets URLs from tunnels and automatically adds them to vite's allow-list for hosts