### PR TITLE
fix(cli): add globalThis.crypto polyfill for Node.js 18

### DIFF
--- a/packages/nuxi/src/main.ts
+++ b/packages/nuxi/src/main.ts
@@ -1,3 +1,4 @@
+import nodeCrypto from 'node:crypto'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
@@ -10,6 +11,11 @@ import { cwdArgs } from './commands/_shared'
 import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
 import { logger } from './utils/logger'
+
+// globalThis.crypto support for Node.js 18
+if (!globalThis.crypto) {
+  globalThis.crypto = nodeCrypto as unknown as Crypto
+}
 
 export const main = defineCommand({
   meta: {


### PR DESCRIPTION
(same as https://github.com/nitrojs/nitro/pull/3167)

As Node.js 18 is getting EOL, more ecosystem packages might depend on `globalThis.crypto` which in unavailable in 18 and one of the biggest differences between 18/20. 

This makes sure nuxt build/dev will be compatible in this situation.