### PR TITLE
fix(dev): use `nitro` to render errors thrown while loading

### DIFF
--- a/packages/nuxi/src/utils/dev.ts
+++ b/packages/nuxi/src/utils/dev.ts
@@ -121,7 +121,7 @@ class NuxtDevServer extends EventEmitter {
         this._handler(req, res)
       }
       else {
-        this._renderError(res)
+        this._renderLoadingScreen(res)
       }
     }
 
@@ -129,7 +129,7 @@ class NuxtDevServer extends EventEmitter {
     this.listener = undefined
   }
 
-  async _renderError(res: ServerResponse, _error?: Error) {
+  async _renderLoadingScreen(res: ServerResponse) {
     res.statusCode = 503
     res.setHeader('Content-Type', 'text/html')
     const loadingTemplate
@@ -139,7 +139,7 @@ class NuxtDevServer extends EventEmitter {
         || ((params: { loading: string }) => `<h2>${params.loading}</h2>`)
     res.end(
       loadingTemplate({
-        loading: _error?.toString() || this._loadingMessage || 'Loading...',
+        loading: this._loadingMessage || 'Loading...',
       }),
     )
   }
@@ -188,11 +188,6 @@ class NuxtDevServer extends EventEmitter {
       envName: this.options.envName,
       overrides: {
         logLevel: this.options.logLevel as 'silent' | 'info' | 'verbose',
-        nitro: {
-          devErrorHandler: (error, event) => {
-            this._renderError(event.node.res, error)
-          },
-        },
         ...this.options.overrides,
         vite: {
           clearScreen: this.options.clear,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Errors thrown while loading were hard to debug as they only were present in the title of the page

Now they look like this:

![CleanShot 2025-03-17 at 12 49 32@2x](https://github.com/user-attachments/assets/7f5bdc9b-f434-4feb-9024-512140935960)

(reproduction from https://github.com/nuxt/nuxt/issues/31222)