### PR TITLE
fix(dev): allow overriding inferred cors/allowedHosts config

### DIFF
--- a/packages/nuxi/src/commands/dev-child.ts
+++ b/packages/nuxi/src/commands/dev-child.ts
@@ -7,7 +7,7 @@ import defu from 'defu'
 import { resolve } from 'pathe'
 import { isTest } from 'std-env'
 
-import { _getDevServerOverrides, createNuxtDevServer } from '../utils/dev'
+import { _getDevServerDefaults, _getDevServerOverrides, createNuxtDevServer } from '../utils/dev'
 import { overrideEnv } from '../utils/env'
 import { logger } from '../utils/logger'
 import { cwdArgs, envNameArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
@@ -55,17 +55,20 @@ export default defineCommand({
       process.exit()
     })
 
-    ctx.data ||= {}
-    ctx.data.overrides = defu(ctx.data.overrides, _getDevServerOverrides({
-      hostname: devContext.hostname,
+    const devServerOverrides = _getDevServerOverrides({
       public: devContext.public,
+    })
+
+    const devServerDefaults = _getDevServerDefaults({
+      hostname: devContext.hostname,
       https: devContext.proxy?.https,
-    }, devContext.publicURLs))
+    }, devContext.publicURLs)
 
     // Init Nuxt dev
     const nuxtDev = await createNuxtDevServer({
       cwd,
-      overrides: ctx.data?.overrides,
+      overrides: defu(ctx.data?.overrides, devServerOverrides),
+      defaults: devServerDefaults,
       logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
       clear: !!ctx.args.clear,
       dotenv: !!ctx.args.dotenv,

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -18,7 +18,7 @@ import { satisfies } from 'semver'
 
 import { isBun, isTest } from 'std-env'
 import { showVersions } from '../utils/banner'
-import { _getDevServerOverrides } from '../utils/dev'
+import { _getDevServerDefaults, _getDevServerOverrides } from '../utils/dev'
 import { overrideEnv } from '../utils/env'
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
@@ -80,12 +80,20 @@ const command = defineCommand({
       // Directly start Nuxt dev
       const { createNuxtDevServer } = await import('../utils/dev')
 
-      ctx.data ||= {}
-      ctx.data.overrides = defu(ctx.data.overrides, _getDevServerOverrides(listenOptions))
+      const devServerOverrides = _getDevServerOverrides({
+        public: listenOptions.public,
+      })
+
+      const devServerDefaults = _getDevServerDefaults({
+        hostname: listenOptions.hostname,
+        https: listenOptions.https,
+      })
+
       const devServer = await createNuxtDevServer(
         {
           cwd,
-          overrides: ctx.data?.overrides,
+          overrides: defu(ctx.data?.overrides, devServerOverrides),
+          defaults: devServerDefaults,
           logLevel: ctx.args.logLevel as 'silent' | 'info' | 'verbose',
           clear: ctx.args.clear,
           dotenv: !!ctx.args.dotenv,


### PR DESCRIPTION
### 🔗 Linked issue

closes https://github.com/nuxt/nuxt/pull/31360
resolves https://github.com/nuxt/nuxt/issues/31318

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this respects user's configuration in `devServer.cors` + `vite.server.allowedHosts` whilst always overriding these values if `--public` or codesandbox environment is found.