### PR TITLE
fix(module): resolve semver module versions

### DIFF
--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -305,10 +305,10 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   // check if a dist-tag exists
   pkgVersion = (pkgDetails['dist-tags']?.[pkgVersion] || pkgVersion) as string
 
-  // if a the major version was provided, search for the latest version that starts with that number
-  if (pkgVersion && pkgVersion.length === 1) {
-    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion
-  }
+  // if not a full x.y.z version is provided, search for the latest version that starts with that version
+  if(pkgVersion && pkgVersion.split('.').length < 3) {
+    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion;
+  } 
 
   const pkg = pkgDetails.versions[pkgVersion]
 

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -306,9 +306,9 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   pkgVersion = (pkgDetails['dist-tags']?.[pkgVersion] || pkgVersion) as string
 
   // if not a full x.y.z version is provided, search for the latest version that starts with that version
-  if(pkgVersion && pkgVersion.split('.').length < 3) {
-    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion;
-  } 
+  if (pkgVersion && pkgVersion.split('.').length < 3) {
+    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion
+  }
 
   const pkg = pkgDetails.versions[pkgVersion]
 

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -306,10 +306,10 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   pkgVersion = (pkgDetails['dist-tags']?.[pkgVersion] || pkgVersion) as string
 
   // if a the major version was provided, search for the latest version that starts with that number
-  if(pkgVersion && pkgVersion.length === 1) {
-    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion;
-  } 
-  
+  if (pkgVersion && pkgVersion.length === 1) {
+    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion
+  }
+
   const pkg = pkgDetails.versions[pkgVersion]
 
   const pkgDependencies = Object.assign(

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -305,6 +305,11 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   // check if a dist-tag exists
   pkgVersion = (pkgDetails['dist-tags']?.[pkgVersion] || pkgVersion) as string
 
+  // if a the major version was provided, search for the latest version that starts with that number
+  if(pkgVersion && pkgVersion.length === 1) {
+    pkgVersion = Object.keys(pkgDetails.versions)?.findLast(version => version.startsWith(pkgVersion as string)) || pkgVersion;
+  } 
+  
   const pkg = pkgDetails.versions[pkgVersion]
 
   const pkgDependencies = Object.assign(

--- a/packages/nuxi/test/unit/commands/module/add.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/add.spec.ts
@@ -42,36 +42,41 @@ function applyMocks() {
       $fetch: vi.fn(() => Promise.resolve({
         'name': '@nuxt/content',
         'npm': '@nuxt/content',
-        'devDependencies': {
-          nuxt: v3,
+        devDependencies: {
+          nuxt: v3
         },
         'dist-tags': { latest: v3 },
-        'versions': {
+        versions: {
           [v3]: {
-            devDependencies: {
-              nuxt: v3,
-            },
-          },
-          '2.9.0': {
-            devDependencies: {
-              nuxt: v3,
-            },
-          },
-          '2.13.1': {
-            devDependencies: {
-              nuxt: v3,
-            },
+          devDependencies: {
+            nuxt: v3
+          }
+        },
+        '3.1.1':{
+          devDependencies: {
+            nuxt: v3
           },
         },
-      })),
+        '2.9.0':{
+          devDependencies: {
+            nuxt: v3
+          },
+        },
+        '2.13.1' :{
+          devDependencies: {
+            nuxt: v3
+          }
+        }
+        }
+      }))
     }
   })
 }
 describe('module add', () => {
   beforeAll(async () => {
-    const response = await fetch('https://registry.npmjs.org/@nuxt/content')
-    const json = await response.json()
-    v3 = json['dist-tags'].latest
+    const response = await fetch('https://registry.npmjs.org/@nuxt/content');
+    const json = await response.json();
+    v3 = json['dist-tags'].latest;
   })
   applyMocks()
   vi.spyOn(runCommands, 'runCommand').mockImplementation(vi.fn())
@@ -135,7 +140,7 @@ describe('module add', () => {
     })
   })
 
-  it('should convert major onlly version to full semver', async () => {
+  it('should convert major only version to full semver', async () => {
     const addCommand = await (commands as CommandsType).subCommands.add()
     await addCommand.setup({
       args: {
@@ -149,5 +154,21 @@ describe('module add', () => {
       dev: true,
       installPeerDependencies: true,
     })
-  })
+  });
+
+  it('should convert not full version to full semver', async () => {
+    const addCommand = await (commands as CommandsType).subCommands.add()
+    await addCommand.setup({
+      args: {
+        cwd: '/fake-dir',
+        _: ['content@3.1'],
+      },
+    })
+
+    expect(addDependency).toHaveBeenCalledWith(['@nuxt/content@3.1.1'], {
+      cwd: '/fake-dir',
+      dev: true,
+      installPeerDependencies: true,
+    })
+  });
 })

--- a/packages/nuxi/test/unit/commands/module/add.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/add.spec.ts
@@ -42,41 +42,41 @@ function applyMocks() {
       $fetch: vi.fn(() => Promise.resolve({
         'name': '@nuxt/content',
         'npm': '@nuxt/content',
-        devDependencies: {
-          nuxt: v3
+        'devDependencies': {
+          nuxt: v3,
         },
         'dist-tags': { latest: v3 },
-        versions: {
+        'versions': {
           [v3]: {
-          devDependencies: {
-            nuxt: v3
-          }
-        },
-        '3.1.1':{
-          devDependencies: {
-            nuxt: v3
+            devDependencies: {
+              nuxt: v3,
+            },
+          },
+          '3.1.1': {
+            devDependencies: {
+              nuxt: v3,
+            },
+          },
+          '2.9.0': {
+            devDependencies: {
+              nuxt: v3,
+            },
+          },
+          '2.13.1': {
+            devDependencies: {
+              nuxt: v3,
+            },
           },
         },
-        '2.9.0':{
-          devDependencies: {
-            nuxt: v3
-          },
-        },
-        '2.13.1' :{
-          devDependencies: {
-            nuxt: v3
-          }
-        }
-        }
-      }))
+      })),
     }
   })
 }
 describe('module add', () => {
   beforeAll(async () => {
-    const response = await fetch('https://registry.npmjs.org/@nuxt/content');
-    const json = await response.json();
-    v3 = json['dist-tags'].latest;
+    const response = await fetch('https://registry.npmjs.org/@nuxt/content')
+    const json = await response.json()
+    v3 = json['dist-tags'].latest
   })
   applyMocks()
   vi.spyOn(runCommands, 'runCommand').mockImplementation(vi.fn())
@@ -154,7 +154,7 @@ describe('module add', () => {
       dev: true,
       installPeerDependencies: true,
     })
-  });
+  })
 
   it('should convert not full version to full semver', async () => {
     const addCommand = await (commands as CommandsType).subCommands.add()
@@ -170,5 +170,5 @@ describe('module add', () => {
       dev: true,
       installPeerDependencies: true,
     })
-  });
+  })
 })

--- a/packages/nuxi/test/unit/commands/module/add.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/add.spec.ts
@@ -42,36 +42,36 @@ function applyMocks() {
       $fetch: vi.fn(() => Promise.resolve({
         'name': '@nuxt/content',
         'npm': '@nuxt/content',
-        devDependencies: {
-          nuxt: v3
+        'devDependencies': {
+          nuxt: v3,
         },
         'dist-tags': { latest: v3 },
-        versions: {
+        'versions': {
           [v3]: {
-          devDependencies: {
-            nuxt: v3
-          }
-        },
-        '2.9.0':{
-          devDependencies: {
-            nuxt: v3
+            devDependencies: {
+              nuxt: v3,
+            },
+          },
+          '2.9.0': {
+            devDependencies: {
+              nuxt: v3,
+            },
+          },
+          '2.13.1': {
+            devDependencies: {
+              nuxt: v3,
+            },
           },
         },
-        '2.13.1' :{
-          devDependencies: {
-            nuxt: v3
-          }
-        }
-        }
-      }))
+      })),
     }
   })
 }
 describe('module add', () => {
   beforeAll(async () => {
-    const response = await fetch('https://registry.npmjs.org/@nuxt/content');
-    const json = await response.json();
-    v3 = json['dist-tags'].latest;
+    const response = await fetch('https://registry.npmjs.org/@nuxt/content')
+    const json = await response.json()
+    v3 = json['dist-tags'].latest
   })
   applyMocks()
   vi.spyOn(runCommands, 'runCommand').mockImplementation(vi.fn())


### PR DESCRIPTION
### 🔗 Linked issue

Fix for https://github.com/nuxt/cli/issues/697
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The code verify if the `pkgVersion` is only a single number to then perform a search for the highest major version.


Previously PR fix part of the problem but not allow to install full package from a single major version.
This PR enhance the `nuxi module add` to allowing it to find a Nuxt Module full version when only a major is specified.
Without this PR:
<img width="1028" alt="Screenshot 2025-03-19 at 17 20 44" src="https://github.com/user-attachments/assets/b124befa-215e-4da0-9f3d-bc0868067bca" />

With this PR:

<img width="1305" alt="Screenshot 2025-03-20 at 06 53 52" src="https://github.com/user-attachments/assets/e4425789-9799-4d45-9fc2-5c519a885e2c" />


Regression:
> default installation not affected
<img width="1023" alt="Screenshot 2025-03-19 at 17 19 53" src="https://github.com/user-attachments/assets/fa1f862b-e82d-47b8-a045-4c6f58da073c" />


-----------------------------------------------------------------------
