### PR TITLE
feat(init): default to install with current package manager

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -184,7 +184,7 @@ export default defineCommand({
     const currentPackageManager = detectCurrentPackageManager()
     // Resolve package manager
     const packageManagerArg = ctx.args.packageManager as PackageManagerName
-    const packageMangerSelectOptions = packageManagerOptions.map(pm => ({
+    const packageManagerSelectOptions = packageManagerOptions.map(pm => ({
       label: pm,
       value: pm,
       hint: currentPackageManager === pm ? 'current' : undefined,
@@ -193,7 +193,7 @@ export default defineCommand({
       ? packageManagerArg
       : await logger.prompt('Which package manager would you like to use?', {
         type: 'select',
-        options: packageMangerSelectOptions,
+        options: packageManagerSelectOptions,
         initial: currentPackageManager,
         cancel: 'reject',
       }).catch(() => process.exit(1))

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -1,6 +1,5 @@
 import type { SelectPromptOptions } from 'consola'
 import type { DownloadTemplateResult } from 'giget'
-
 import type { PackageManagerName } from 'nypm'
 
 import { existsSync } from 'node:fs'

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -2,17 +2,18 @@ import type { SelectPromptOptions } from 'consola'
 import type { DownloadTemplateResult } from 'giget'
 
 import type { PackageManagerName } from 'nypm'
-import { existsSync } from 'node:fs'
 
+import { existsSync } from 'node:fs'
 import process from 'node:process'
+
 import { defineCommand } from 'citty'
 import { colors } from 'consola/utils'
 import { downloadTemplate, startShell } from 'giget'
 import { installDependencies } from 'nypm'
 import { $fetch } from 'ofetch'
 import { join, relative, resolve } from 'pathe'
-
 import { hasTTY } from 'std-env'
+
 import { x } from 'tinyexec'
 import { runCommand } from '../run'
 import { nuxtIcon, themeColor } from '../utils/ascii'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR detects the pm used when running the nuxi init (create nuxt) and sets it as the default for the pm selection.

![image](https://github.com/user-attachments/assets/3087a7a3-3b8a-4b62-92e1-235665c5cfcf)

Tested all (!deno) pms locally.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
