### PR TITLE
fix: remove color from `nuxi` tag in logger

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -285,7 +285,7 @@ async function _startSubprocess(devProxy: DevProxy, rawArgs: string[], listenArg
         restart()
       }
       else if (message.type === 'nuxt:internal:dev:rejection') {
-        logger.withTag('nuxi').info(`Restarting Nuxt due to error: \`${message.message}\``)
+        logger.info(`Restarting Nuxt due to error: \`${message.message}\``)
         restart()
       }
     })

--- a/packages/nuxi/src/utils/logger.ts
+++ b/packages/nuxi/src/utils/logger.ts
@@ -1,4 +1,3 @@
 import { consola } from 'consola'
-import { colors } from 'consola/utils'
 
-export const logger = consola.withTag(colors.whiteBright(colors.bold(colors.bgGreenBright('nuxi'))))
+export const logger = consola.withTag('nuxi')

--- a/packages/nuxi/src/utils/logger.ts
+++ b/packages/nuxi/src/utils/logger.ts
@@ -1,4 +1,4 @@
 import { consola } from 'consola'
 import { colors } from 'consola/utils'
 
-export const logger = consola.withTag(colors.whiteBright(colors.bold(colors.bgGreenBright(' nuxi '))))
+export const logger = consola.withTag(colors.whiteBright(colors.bold(colors.bgGreenBright('nuxi'))))


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the spaces around `nuxi` in the logger to make it consistent with `nuxt` and other modules.

Here's an example of the logs when running `postinstall`:

**Before**
```diff
(base) nestor@MacBookPro woonuxt % ni
Lockfile is up to date, resolution step is skipped
Already up to date
. postinstall$ nuxt prepare
│ [nuxt:tailwindcss] ℹ Using default Tailwind CSS file
│ ℹ Nuxt Icon server bundle mode is set to local
│ ✔ Nuxt Icon discovered local-installed 2 collections: heroicons, ion
│ [nuxt] ℹ Running with compatibility version 4
│ [ nuxi ] ✔ Types generated in .nuxt
└─ Done in 13s
Done in 15.6s using pnpm v10.8.0
```

**After**
```
(base) nestor@MacBookPro woonuxt % ni
Lockfile is up to date, resolution step is skipped
Already up to date
. postinstall$ nuxt prepare
│ [nuxt:tailwindcss] ℹ Using default Tailwind CSS file
│ ℹ Nuxt Icon server bundle mode is set to local
│ ✔ Nuxt Icon discovered local-installed 2 collections: heroicons, ion
│ [nuxt] ℹ Running with compatibility version 4
│ [nuxi] ✔ Types generated in .nuxt
└─ Done in 13.1s
Done in 15.7s using pnpm v10.8.0
```

Feel free to close or request changes as you see fit.