### PR TITLE
fix(dev): respect `devServer.host` if set in layer

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -65,7 +65,7 @@ const command = defineCommand({
       'host': {
         ...listhenArgs.host,
         alias: ['h'],
-        description: 'Host to listen on (default: `NUXT_HOST || NITRO_HOST || HOST || nuxtOptions._layers?.[0]?.devServer?.host`)',
+        description: 'Host to listen on (default: `NUXT_HOST || NITRO_HOST || HOST || nuxtOptions.devServer?.host`)',
       },
       'clipboard': { ...listhenArgs.clipboard, default: false },
       'https.domains': {
@@ -328,8 +328,7 @@ function _resolveListenOptions(
       ?? process.env.NUXT_HOST
       ?? process.env.NITRO_HOST
       ?? process.env.HOST
-      // TODO: Default host in schema should be undefined instead of ''
-      ?? nuxtOptions._layers?.[0]?.config?.devServer?.host
+      ?? (nuxtOptions.devServer?.host || undefined /* for backwards compatibility with previous '' default */)
       ?? undefined
 
   const _public: boolean | undefined = args.public


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/854

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

we were only respecting 'top' layer host config for some reason - this allows any layer to set the default host (as well as port)