### PR TITLE
fix(upgrade): dedupe packages after update

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -168,11 +168,6 @@ export default defineCommand({
       await dedupeDependencies({ recreateLockfile: true })
     }
 
-    if (method === 'dedupe') {
-      logger.info('Try deduping dependencies...')
-      await dedupeDependencies()
-    }
-
     const versionType = ctx.args.channel === 'nightly' ? 'nightly' : 'latest stable'
     logger.info(`Installing ${versionType} Nuxt ${nuxtVersion} release...`)
 
@@ -181,6 +176,11 @@ export default defineCommand({
       packageManager,
       dev: nuxtDependencyType === 'devDependencies',
     })
+
+    if (method === 'dedupe') {
+      logger.info('Try deduping dependencies...')
+      await dedupeDependencies()
+    }
 
     // Clean up after upgrade
     let buildDir: string = '.nuxt'

--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -161,13 +161,6 @@ export default defineCommand({
       },
     ).catch(() => process.exit(1))
 
-    if (method === 'force') {
-      logger.info(
-        `Recreating ${forceRemovals}. If you encounter any issues, revert the changes and try with \`--no-force\``,
-      )
-      await dedupeDependencies({ recreateLockfile: true })
-    }
-
     const versionType = ctx.args.channel === 'nightly' ? 'nightly' : 'latest stable'
     logger.info(`Installing ${versionType} Nuxt ${nuxtVersion} release...`)
 
@@ -176,6 +169,13 @@ export default defineCommand({
       packageManager,
       dev: nuxtDependencyType === 'devDependencies',
     })
+
+    if (method === 'force') {
+      logger.info(
+        `Recreating ${forceRemovals}. If you encounter any issues, revert the changes and try with \`--no-force\``,
+      )
+      await dedupeDependencies({ recreateLockfile: true })
+    }
 
     if (method === 'dedupe') {
       logger.info('Try deduping dependencies...')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This Pr fixes `nuxi updade --dedupe` by deduping after nuxt updates

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
