### PR TITLE
fix: do not prompt for modules if an empty list is provided

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -85,6 +85,7 @@ export default defineCommand({
       type: 'string',
       required: false,
       description: 'Nuxt modules to install (comma separated without spaces)',
+      negativeDescription: 'Skip module installation prompt',
       alias: 'M',
     },
   },
@@ -249,9 +250,10 @@ export default defineCommand({
     const modulesToAdd: string[] = []
 
     // Get modules from arg (if provided)
-    if (ctx.args.modules) {
+    if (ctx.args.modules !== undefined) {
       modulesToAdd.push(
-        ...ctx.args.modules.split(',').map(module => module.trim()).filter(Boolean),
+        // ctx.args.modules is false when --no-modules is used
+        ...(ctx.args.modules || '').split(',').map(module => module.trim()).filter(Boolean),
       )
     }
     // ...or offer to install official modules (if not offline)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/cli/issues/887

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When `--modules` is not used, `ctx.args.modules` will be `undefined` and when `--modules ''`  or `--modules` is used, it will be an empty string. With this change, we will only prompt in the `undefined` case, allowing users to explicitly skip the prompt if they want.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
