### PR TITLE
test: accurately benchmark forked mode

### DIFF
--- a/packages/nuxt-cli/test/bench/dev.bench.ts
+++ b/packages/nuxt-cli/test/bench/dev.bench.ts
@@ -15,7 +15,7 @@ describe(`dev [${os.platform()}]`, async () => {
   await rm(join(fixtureDir, '.nuxt'), { recursive: true, force: true })
 
   bench('starts dev server', async () => {
-    const { result } = await runCommand('dev', [fixtureDir], {
+    const { result } = await runCommand('dev', [fixtureDir, '--fork'], {
       overrides: {
         builder: {
           bundle: (nuxt: Nuxt) => {


### PR DESCRIPTION
### 📚 Description

we were previously benchmarking fork + no-fork modes, but in fact we have defaulted to disabling fork in test environments so this was inaccurate