### PR TITLE
perf: enable node compile cache

### DIFF
--- a/packages/nuxi/bin/nuxi.mjs
+++ b/packages/nuxi/bin/nuxi.mjs
@@ -8,7 +8,9 @@ import { fileURLToPath } from 'node:url'
 // https://github.com/nodejs/node/pull/54501
 if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   try {
-    nodeModule.enableCompileCache()
+    const { directory } = nodeModule.enableCompileCache()
+    // allow child process to share the same cache directory
+    process.env.NODE_COMPILE_CACHE ||= directory
   }
   catch {
     // Ignore errors

--- a/packages/nuxi/bin/nuxi.mjs
+++ b/packages/nuxi/bin/nuxi.mjs
@@ -1,12 +1,27 @@
 #!/usr/bin/env node
 
+import nodeModule from 'node:module'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { runMain } from '../dist/index.mjs'
+
+// https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
+// https://github.com/nodejs/node/pull/54501
+if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    nodeModule.enableCompileCache()
+  }
+  catch {
+    // Ignore errors
+  }
+}
 
 globalThis.__nuxt_cli__ = {
   startTime: Date.now(),
   entry: fileURLToPath(import.meta.url),
   devEntry: fileURLToPath(new URL('../dist/dev/index.mjs', import.meta.url)),
 }
+
+// eslint-disable-next-line antfu/no-top-level-await
+const { runMain } = await import('../dist/index.mjs')
 
 runMain()

--- a/packages/nuxt-cli/bin/nuxi.mjs
+++ b/packages/nuxt-cli/bin/nuxi.mjs
@@ -8,7 +8,9 @@ import { fileURLToPath } from 'node:url'
 // https://github.com/nodejs/node/pull/54501
 if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
   try {
-    nodeModule.enableCompileCache()
+    const { directory } = nodeModule.enableCompileCache()
+    // allow child process to share the same cache directory
+    process.env.NODE_COMPILE_CACHE ||= directory
   }
   catch {
     // Ignore errors

--- a/packages/nuxt-cli/bin/nuxi.mjs
+++ b/packages/nuxt-cli/bin/nuxi.mjs
@@ -1,12 +1,27 @@
 #!/usr/bin/env node
 
+import nodeModule from 'node:module'
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { runMain } from '../dist/index.mjs'
+
+// https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
+// https://github.com/nodejs/node/pull/54501
+if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    nodeModule.enableCompileCache()
+  }
+  catch {
+    // Ignore errors
+  }
+}
 
 globalThis.__nuxt_cli__ = {
   startTime: Date.now(),
   entry: fileURLToPath(import.meta.url),
   devEntry: fileURLToPath(new URL('../dist/dev/index.mjs', import.meta.url)),
 }
+
+// eslint-disable-next-line antfu/no-top-level-await
+const { runMain } = await import('../dist/index.mjs')
 
 runMain()


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this enables the node compile cache following [the pattern in jiti](https://github.com/unjs/jiti/blob/b396aec45847a32677417ea9dfc78098b6d45c23/lib/jiti-cli.mjs#L17)

thanks @pi0 for the tip ❤️ 