### PR TITLE
perf(dev): use native `fs.watch` to watch `dist`, config and `.env`

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -18,7 +18,6 @@
     "packages/nuxt-cli": {
       "ignoreDependencies": [
         "c12",
-        "chokidar",
         "clipboardy",
         "confbox",
         "consola",

--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -45,7 +45,6 @@
     "@types/node": "^22.15.31",
     "@types/semver": "^7.7.0",
     "c12": "^3.0.4",
-    "chokidar": "^4.0.3",
     "citty": "^0.1.6",
     "clipboardy": "^4.0.0",
     "confbox": "^0.2.2",

--- a/packages/nuxt-cli/package.json
+++ b/packages/nuxt-cli/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "c12": "^3.0.4",
-    "chokidar": "^4.0.3",
     "citty": "^0.1.6",
     "clipboardy": "^4.0.0",
     "confbox": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       c12:
         specifier: ^3.0.4
         version: 3.0.4(magicast@0.3.5)
-      chokidar:
-        specifier: ^4.0.3
-        version: 4.0.3
       citty:
         specifier: ^0.1.6
         version: 0.1.6
@@ -223,9 +220,6 @@ importers:
       c12:
         specifier: ^3.0.4
         version: 3.0.4(magicast@0.3.5)
-      chokidar:
-        specifier: ^4.0.3
-        version: 4.0.3
       citty:
         specifier: ^0.1.6
         version: 0.1.6


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this makes nuxt/cli a bit more minimal, given the very limited needs we have for watching in the cli itself.