### PR TITLE
feat(typecheck): support ts projects

### DIFF
--- a/packages/nuxi/src/commands/typecheck.ts
+++ b/packages/nuxi/src/commands/typecheck.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { defineCommand } from 'citty'
 import { resolveModulePath } from 'exsolve'
 import { resolve } from 'pathe'
+import { readTSConfig } from 'pkg-types'
 import { isBun } from 'std-env'
 import { x } from 'tinyexec'
 
@@ -41,13 +42,16 @@ export default defineCommand({
     await buildNuxt(nuxt)
     await nuxt.close()
 
+    const supportsProjects = await readTSConfig(cwd).then(r => !!(r.references?.length))
+    const typeCheckArgs = supportsProjects ? ['-b', '--noEmit'] : ['--noEmit']
+
     // Prefer local install if possible
     const [resolvedTypeScript, resolvedVueTsc] = await Promise.all([
       resolveModulePath('typescript', { try: true }),
       resolveModulePath('vue-tsc/bin/vue-tsc.js', { try: true }),
     ])
     if (resolvedTypeScript && resolvedVueTsc) {
-      await x(fileURLToPath(resolvedVueTsc), ['--noEmit'], {
+      await x(fileURLToPath(resolvedVueTsc), typeCheckArgs, {
         throwOnError: true,
         nodeOptions: {
           stdio: 'inherit',
@@ -66,7 +70,7 @@ export default defineCommand({
           },
         )
 
-        await x('bunx', 'vue-tsc --noEmit'.split(' '), {
+        await x('bunx', ['vue-tsc', ...typeCheckArgs], {
           throwOnError: true,
           nodeOptions: {
             stdio: 'inherit',
@@ -77,7 +81,7 @@ export default defineCommand({
       else {
         await x(
           'npx',
-          '-p vue-tsc -p typescript vue-tsc --noEmit'.split(' '),
+          ['-p', 'vue-tsc', '-p', 'typescript', 'vue-tsc', ...typeCheckArgs],
           {
             throwOnError: true,
             nodeOptions: { stdio: 'inherit', cwd },

--- a/packages/nuxi/src/commands/typecheck.ts
+++ b/packages/nuxi/src/commands/typecheck.ts
@@ -1,5 +1,4 @@
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
 
 import { defineCommand } from 'citty'
 import { resolveModulePath } from 'exsolve'
@@ -51,7 +50,7 @@ export default defineCommand({
       resolveModulePath('vue-tsc/bin/vue-tsc.js', { try: true }),
     ])
     if (resolvedTypeScript && resolvedVueTsc) {
-      await x(fileURLToPath(resolvedVueTsc), typeCheckArgs, {
+      await x(resolvedVueTsc, typeCheckArgs, {
         throwOnError: true,
         nodeOptions: {
           stdio: 'inherit',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/323
resolves https://github.com/nuxt/cli/issues/926

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

with the upcoming v4 nuxt release, and https://github.com/nuxt/nuxt/issues/32343, it's now possible to typecheck all three contexts (node/app/nitro) of a nuxt project with a single command.

Make sure you are running v4 alpha 3 or newer, and follow the steps here: https://nuxt.com/docs/4.x/getting-started/upgrade#typescript-configuration-changes