### PR TITLE
fix: prioritise `@nuxt/kit` from `nuxt` dependencies

### DIFF
--- a/packages/nuxi/src/utils/kit.ts
+++ b/packages/nuxi/src/utils/kit.ts
@@ -3,13 +3,7 @@ import { resolveModulePath } from 'exsolve'
 
 export async function loadKit(rootDir: string): Promise<typeof import('@nuxt/kit')> {
   try {
-    // Without PNP (or if users have a local install of kit, we bypass resolving from Nuxt)
-    let kitPath = resolveModulePath('@nuxt/kit', { try: true, from: rootDir })
-    if (!kitPath) {
-      // Otherwise, we resolve Nuxt _first_ as it is Nuxt's kit dependency that will be used
-      const nuxtPath = tryResolveNuxt(rootDir)
-      kitPath = resolveModulePath('@nuxt/kit', { from: nuxtPath || rootDir })
-    }
+    const kitPath = resolveModulePath('@nuxt/kit', { from: tryResolveNuxt(rootDir) || rootDir })
 
     let kit: typeof import('@nuxt/kit') = await import(pathToFileURL(kitPath).href)
     if (!kit.writeTypes) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

currently we might pick an older version of nuxt/kit if a module has installed it and it's available locally.

this ensures we prefer the version of kit matching _nuxt_. (newer versions of kit, if installed, might be deduplicated by package manager but should 'flow down', so this is safer - and should also be more performant)