### PR TITLE
fix(dev): ensure we listen on port if `_PORT` is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:types": "tsc --noEmit",
     "test:knip": "knip",
     "test:dist": "pnpm -r test:dist",
-    "test:unit": "vitest --coverage"
+    "test:unit": "vitest --coverage --run && pnpm --filter nuxt-cli-playground test --run"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.16.2",

--- a/packages/nuxi/src/dev/index.ts
+++ b/packages/nuxi/src/dev/index.ts
@@ -42,7 +42,7 @@ class IPC {
 
 const ipc = new IPC()
 
-export async function initialize(devContext: NuxtDevContext, ctx: InitializeOptions = {}, listenOptions?: true | Partial<ListenOptions>) {
+export async function initialize(devContext: NuxtDevContext, ctx: InitializeOptions = {}, _listenOptions?: true | Partial<ListenOptions>) {
   const devServerOverrides = resolveDevServerOverrides({
     public: devContext.public,
   })
@@ -51,6 +51,11 @@ export async function initialize(devContext: NuxtDevContext, ctx: InitializeOpti
     hostname: devContext.hostname,
     https: devContext.proxy?.https,
   }, devContext.publicURLs)
+
+  // _PORT is used by `@nuxt/test-utils` to launch the dev server on a specific port
+  const listenOptions = _listenOptions === true || process.env._PORT
+    ? { port: process.env._PORT ?? 0, hostname: '127.0.0.1', showURL: false }
+    : _listenOptions
 
   // Init Nuxt dev
   const devServer = await createNuxtDevServer({
@@ -61,7 +66,6 @@ export async function initialize(devContext: NuxtDevContext, ctx: InitializeOpti
     clear: !!devContext.args.clear,
     dotenv: { cwd: devContext.cwd, fileName: devContext.args.dotenv },
     envName: devContext.args.envName,
-    port: process.env._PORT ?? undefined,
     devContext,
   }, listenOptions)
 

--- a/playground/test/e2e/build.spec.ts
+++ b/playground/test/e2e/build.spec.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+})
+
+describe('built server', () => {
+  it('should start and return HTML', async () => {
+    const html = await $fetch('/')
+
+    expect(html).toContain('Welcome to the Nuxt CLI playground')
+  })
+})

--- a/playground/test/e2e/dev.spec.ts
+++ b/playground/test/e2e/dev.spec.ts
@@ -1,14 +1,14 @@
-// import { fileURLToPath } from 'node:url'
-// import { $fetch, setup } from '@nuxt/test-utils'
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '@nuxt/test-utils'
 import { describe, expect, it } from 'vitest'
 
-// await setup({
-//   rootDir: fileURLToPath(new URL('../..', import.meta.url)),
-//   dev: true,
-// })
+await setup({
+  rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+  dev: true,
+})
 
 describe('dev server', () => {
-  it.skip('should start and return HTML', async () => {
+  it('should start and return HTML', async () => {
     const html = await $fetch('/')
 
     expect(html).toContain('Welcome to the Nuxt CLI playground')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,13 @@
 import codspeed from '@codspeed/vitest-plugin'
-import { defineConfig } from 'vitest/config'
+import { defaultExclude, defineConfig } from 'vitest/config'
 
 export default defineConfig({
   plugins: [codspeed()],
   test: {
     coverage: {},
+    exclude: [
+      ...defaultExclude,
+      'playground/**',
+    ],
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression from https://github.com/nuxt/cli/pull/921, this ensures if `_PORT` is set that we don't create a socket but instead listen on that port.