### PR TITLE
fix(dev): expose port/host to `options.devServer`

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -149,6 +149,7 @@ const command = defineCommand({
         url: devProxy.listener.url,
         urls,
         https: devProxy.listener.https,
+        addr: devProxy.listener.address,
       },
       // if running with nuxt v4 or `NUXT_SOCKET=1`, we use the socket listener
       // otherwise pass 'true' to listen on a random port instead

--- a/packages/nuxi/src/dev/socket.ts
+++ b/packages/nuxi/src/dev/socket.ts
@@ -59,11 +59,7 @@ export async function createSocketListener(handler: RequestListener, ssl = false
   const url = formatSocketURL(socketPath, ssl)
   return {
     url,
-    address: {
-      socketPath,
-      address: 'localhost',
-      port: 3000,
-    },
+    address: { socketPath },
     async close() {
       try {
         server.removeAllListeners()

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -55,6 +55,7 @@ export interface NuxtDevContext {
     url?: string
     urls?: ListenURL[]
     https?: boolean | HTTPSOptions
+    addr?: AddressInfo
   }
 }
 
@@ -125,7 +126,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   handler: RequestListener
   listener: Pick<Listener, 'server' | 'getURLs' | 'https' | 'url' | 'close'> & {
     _url?: string
-    address: { socketPath: string, port: number, address: string } | AddressInfo
+    address: { socketPath: string } | AddressInfo
   }
 
   constructor(private options: NuxtDevServerOptions) {
@@ -313,7 +314,12 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
     // Sync internal server info to the internals
     // It is important for vite-node to use the internal URL but public proto
-    const addr = this.listener.address
+    const addr = {
+      port: 3000,
+      address: 'localhost',
+      ...this.options.devContext.proxy?.addr,
+      ...this.listener.address,
+    }
     this._currentNuxt.options.devServer.host = addr.address
     this._currentNuxt.options.devServer.port = addr.port
     this._currentNuxt.options.devServer.url = 'socketPath' in addr

--- a/packages/nuxt-cli/test/e2e/dev.spec.ts
+++ b/packages/nuxt-cli/test/e2e/dev.spec.ts
@@ -1,0 +1,26 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getPort } from 'get-port-please'
+import { x } from 'tinyexec'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/dev', import.meta.url))
+
+describe('dev server', () => {
+  it('should expose dev server address to nuxt options', { timeout: 50_000 }, async () => {
+    const host = '127.0.0.1'
+    const port = await getPort({ host, port: 3031 })
+    await x('nuxt', ['dev', `--host=${host}`, `--port=${port}`], {
+      nodeOptions: { cwd: fixtureDir },
+      throwOnError: true,
+    })
+    const options = await readFile(join(fixtureDir, '.nuxt', 'dev-server.json'), 'utf-8').then(JSON.parse)
+    expect(options).toMatchObject({
+      https: false,
+      host,
+      port,
+      url: `http://${host}:${port}/`,
+    })
+  })
+})

--- a/packages/nuxt-cli/test/fixtures/dev/modules/log-dev-server-options.ts
+++ b/packages/nuxt-cli/test/fixtures/dev/modules/log-dev-server-options.ts
@@ -1,0 +1,18 @@
+import { writeFile } from 'node:fs/promises'
+import process from 'node:process'
+import { defineNuxtModule, useNuxt } from 'nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'nuxt-cli-test-module',
+  },
+  setup() {
+    const nuxt = useNuxt()
+
+    nuxt.hook('build:before', async () => {
+      await writeFile('.nuxt/dev-server.json', JSON.stringify(nuxt.options.devServer))
+      await nuxt.close()
+      process.exit(0)
+    })
+  },
+})

--- a/packages/nuxt-cli/test/fixtures/dev/package.json
+++ b/packages/nuxt-cli/test/fixtures/dev/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fixtures-dev",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev:prepare": "nuxt prepare",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "nuxt": "^4.0.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,12 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0)
 
+  packages/nuxt-cli/test/fixtures/dev:
+    dependencies:
+      nuxt:
+        specifier: ^4.0.0
+        version: 4.0.0(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@22.16.3)(@vue/compiler-sfc@3.5.17)(db0@0.3.2)(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.0)(terser@5.43.1)(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(terser@5.43.1)(yaml@2.8.0))(yaml@2.8.0)
+
   playground:
     dependencies:
       nuxt:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - packages/*
+  - packages/nuxt-cli/test/fixtures/*
   - playground


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

regression from adopting internal sockets - we were no longer exposing host/port to nuxt.options.devServer

I plan to refactor this further but this is a first step (with test)