### PR TITLE
fix(dev): only close config watchers when process exits

### DIFF
--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -181,6 +181,11 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   async init() {
     await this.load()
     this._watchConfig()
+
+    process.on('exit', () => {
+      this._distWatcher?.close()
+      this._configWatcher?.()
+    })
   }
 
   async load(reload?: boolean, reason?: string) {
@@ -198,8 +203,6 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   }
 
   async close() {
-    this._distWatcher?.close()
-    this._configWatcher?.()
     if (this._currentNuxt) {
       await this._currentNuxt.close()
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


a regression - nuxt was only restarting the first time the config file was changed