### PR TITLE
fix(upgrade): update default Nuxt version to v4

### DIFF
--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -49,7 +49,7 @@ async function getNightlyVersion(packageNames: string[]): Promise<{ npmPackages:
     {
       type: 'select',
       options: ['3.x', '4.x'] as const,
-      default: '3.x',
+      default: '4.x',
       cancel: 'reject',
     },
   ).catch(() => process.exit(1))
@@ -64,7 +64,7 @@ async function getRequiredNewVersion(packageNames: string[], channel: string): P
     return getNightlyVersion(packageNames)
   }
 
-  return { npmPackages: packageNames.map(p => `${p}@latest`), nuxtVersion: '3' }
+  return { npmPackages: packageNames.map(p => `${p}@latest`), nuxtVersion: '4' }
 }
 
 export default defineCommand({


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This should fix #979 by setting Nuxt 4 as the default version. However, I'm not sure about the nightly version update or if anything else needs to be updated elsewhere.