### PR TITLE
feat: add `-e` alias for `--extends`

### DIFF
--- a/packages/nuxi/src/commands/_shared.ts
+++ b/packages/nuxi/src/commands/_shared.ts
@@ -36,6 +36,7 @@ export const extendsArgs = {
     type: 'string',
     description: 'Extend from a Nuxt layer',
     valueHint: 'layer-name',
+    alias: ['e'],
   },
 } as const satisfies Record<string, ArgDef>
 


### PR DESCRIPTION
So we can have: `nuxt dev -e docus` 🚀 