### PR TITLE
fix(init): use amended directory when adding modules

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -10,7 +10,7 @@ import { colors } from 'consola/utils'
 import { downloadTemplate, startShell } from 'giget'
 import { installDependencies } from 'nypm'
 import { $fetch } from 'ofetch'
-import { join, relative, resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import { hasTTY } from 'std-env'
 
 import { x } from 'tinyexec'

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -357,7 +357,7 @@ export default defineCommand({
       const args: string[] = [
         'add',
         ...modulesToAdd,
-        `--cwd=${join(ctx.args.cwd, ctx.args.dir)}`,
+        `--cwd=${templateDownloadPath}`,
         ctx.args.install ? '' : '--skipInstall',
         ctx.args.logLevel ? `--logLevel=${ctx.args.logLevel}` : '',
       ].filter(Boolean)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

I could not find one, let me know if I should open one.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously, when the user selected a directory that already existed, and was then prompted to choose a different directory, and then selected a different directory, and also chose official modules to add, the official modules would be added to the initial directory, not the newly chosen one.
