### PR TITLE
fix(ci): Give correct permissions to PR size compare workflow

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,7 +1,7 @@
 name: size
 on:
   # this action will error unless run in a pr context
-  pull_request:
+  pull_request_target:
     branches:
       - main
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Only with `pull_request_target` does the action actually have the ability to make PR comments.

Please note: `pull_request_target` is dangerous in general. In this case, each job has restricted permissions defined, so it can be safely used here without a risk of anyone pushing unauthorized code. (`pull-requests: write` does not allow merging a PR).

You can't see the issue in this PR, because the new permissions will only apply after this PR is merged, but GitHub doesn't run the old action because it changed. You can see it in the checks tab of my other PR #998.