### PR TITLE
feat(build,dev): add vite and vue version to banner

### DIFF
--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -23,6 +23,16 @@ export function showVersions(cwd: string) {
   }
   const nuxtVersion = getPkgVersion('nuxt') || getPkgVersion('nuxt-nightly') || getPkgVersion('nuxt3') || getPkgVersion('nuxt-edge')
   const nitroVersion = getPkgVersion('nitropack') || getPkgVersion('nitropack-nightly') || getPkgVersion('nitropack-edge')
+  const viteVersion = getPkgVersion('rolldown-vite') || getPkgVersion('vite') || null
+  const isRolldown = viteVersion?.includes('rolldown')
+  const vueVersion = getPkgVersion('vue') || null
 
-  logger.log(gray(green(`Nuxt ${bold(nuxtVersion)}`) + (nitroVersion ? ` with Nitro ${bold(nitroVersion)}` : '')))
+  logger.log(
+    green(`Nuxt ${bold(nuxtVersion)}`)
+    + gray(' (with: ')
+    + (nitroVersion ? gray(`Nitro ${bold(nitroVersion)}`) : '')
+    + (viteVersion ? gray(`, ${isRolldown ? 'Rolldown-Vite' : 'Vite'} ${bold(viteVersion)}`) : '')
+    + (vueVersion ? gray(`, Vue ${bold(vueVersion)}`) : '')
+    + gray(')'),
+  )
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "dev": "nuxi dev",
     "dev:prepare": "nuxt prepare",
     "test": "vitest"
   },


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/33071

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Add version of `vite` (also `rolldown-vite`) and `vue` to the cli banner

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
