### PR TITLE
perf(create-nuxt): refactor for improved tree-shaking

### DIFF
--- a/packages/nuxi/src/commands/_utils.ts
+++ b/packages/nuxi/src/commands/_utils.ts
@@ -1,0 +1,26 @@
+import { type commands } from '.';
+
+// Inlined list of nuxi commands to avoid including `commands` in bundle if possible
+export const nuxiCommands = [
+  'add',
+  'analyze',
+  'build',
+  'cleanup',
+  '_dev',
+  'dev',
+  'devtools',
+  'generate',
+  'info',
+  'init',
+  'module',
+  'prepare',
+  'preview',
+  'start',
+  'test',
+  'typecheck',
+  'upgrade',
+] as const satisfies (keyof typeof commands)[];
+
+export function isNuxiCommand(command: string) {
+  return (nuxiCommands as string[]).includes(command);
+}

--- a/packages/nuxi/src/commands/index.ts
+++ b/packages/nuxi/src/commands/index.ts
@@ -21,3 +21,29 @@ export const commands = {
   typecheck: () => import('./typecheck').then(_rDefault),
   upgrade: () => import('./upgrade').then(_rDefault),
 } as const
+
+
+// Inlined to avoid importing commands as it has sideeffects
+export const nuxiCommands = [
+  'add',
+  'analyze',
+  'build',
+  'cleanup',
+  '_dev',
+  'dev',
+  'devtools',
+  'generate',
+  'info',
+  'init',
+  'module',
+  'prepare',
+  'preview',
+  'start',
+  'test',
+  'typecheck',
+  'upgrade',
+] as const satisfies (keyof typeof commands)[]
+
+export function isNuxiCommand(command: string) {
+  return (nuxiCommands as string[]).includes(command)
+}

--- a/packages/nuxi/src/commands/index.ts
+++ b/packages/nuxi/src/commands/index.ts
@@ -23,27 +23,3 @@ export const commands = {
 } as const
 
 
-// Inlined to avoid importing commands as it has sideeffects
-export const nuxiCommands = [
-  'add',
-  'analyze',
-  'build',
-  'cleanup',
-  '_dev',
-  'dev',
-  'devtools',
-  'generate',
-  'info',
-  'init',
-  'module',
-  'prepare',
-  'preview',
-  'start',
-  'test',
-  'typecheck',
-  'upgrade',
-] as const satisfies (keyof typeof commands)[]
-
-export function isNuxiCommand(command: string) {
-  return (nuxiCommands as string[]).includes(command)
-}

--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -16,6 +16,7 @@ import { hasTTY } from 'std-env'
 
 import { x } from 'tinyexec'
 import { runCommand } from '../run'
+import addModuleCommand from './module/add'
 import { nuxtIcon, themeColor } from '../utils/ascii'
 import { logger } from '../utils/logger'
 import { cwdArgs, logLevelArgs } from './_shared'
@@ -435,14 +436,13 @@ export default defineCommand({
     // Add modules
     if (modulesToAdd.length > 0) {
       const args: string[] = [
-        'add',
         ...modulesToAdd,
         `--cwd=${templateDownloadPath}`,
         ctx.args.install ? '' : '--skipInstall',
         ctx.args.logLevel ? `--logLevel=${ctx.args.logLevel}` : '',
       ].filter(Boolean)
 
-      await runCommand('module', args)
+      await runCommand(addModuleCommand, args)
     }
 
     // Display next steps

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -22,6 +22,7 @@ import { logger } from '../../utils/logger'
 import { getNuxtVersion } from '../../utils/versions'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import { checkNuxtCompatibility, fetchModules, getRegistryFromContent } from './_utils'
+import prepareCommand from '../prepare'
 
 interface RegistryMeta {
   registry: string
@@ -95,7 +96,7 @@ export default defineCommand({
     if (!ctx.args.skipInstall) {
       const args = Object.entries(ctx.args).filter(([k]) => k in cwdArgs || k in logLevelArgs).map(([k, v]) => `--${k}=${v}`)
 
-      await runCommand('prepare', args)
+      await runCommand(prepareCommand, args)
     }
   },
 })

--- a/packages/nuxi/src/index.ts
+++ b/packages/nuxi/src/index.ts
@@ -1,2 +1,2 @@
-export { main } from './main'
-export { runCommand, runMain } from './run'
+export { main, runMain} from './main'
+export { runCommand } from './run'

--- a/packages/nuxi/src/main.ts
+++ b/packages/nuxi/src/main.ts
@@ -2,7 +2,7 @@ import nodeCrypto from 'node:crypto'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
-import { defineCommand } from 'citty'
+import { defineCommand, runMain as _runMain } from 'citty'
 import { provider } from 'std-env'
 
 import { description, name, version } from '../package.json'
@@ -71,3 +71,5 @@ export const main = defineCommand({
     }
   },
 })
+
+export const runMain = () => _runMain(main)

--- a/packages/nuxi/src/run.ts
+++ b/packages/nuxi/src/run.ts
@@ -3,8 +3,7 @@ import { fileURLToPath } from 'node:url'
 
 import { runCommand as _runCommand, ArgsDef, CommandDef } from 'citty'
 
-import { isNuxiCommand } from './commands'
-import { main } from './main'
+import { isNuxiCommand } from './commands/_utils'
 
 globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
   // Programmatic usage fallback

--- a/packages/nuxi/src/run.ts
+++ b/packages/nuxi/src/run.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-import { runCommand as _runCommand, runMain as _runMain, ArgsDef, CommandDef } from 'citty'
+import { runCommand as _runCommand, ArgsDef, CommandDef } from 'citty'
 
 import { isNuxiCommand } from './commands'
 import { main } from './main'
@@ -16,8 +16,6 @@ globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
     new URL('../dev/index.mjs', import.meta.url),
   ),
 }
-
-export const runMain = () => _runMain(main)
 
 // To provide subcommands call it as `runCommand(<command>, [<subcommand>, ...])`
 export async function runCommand<T extends ArgsDef = ArgsDef>(


### PR DESCRIPTION
- **chore(deps): update devdependency rollup-plugin-visualizer to v6 (#890)**
- **chore(deps): lock file maintenance (#893)**
- **chore(deps): update all non-major dependencies (#892)**
- **chore(deps): update all non-major dependencies (#894)**
- **chore(deps): update nuxt framework to ^3.17.5 (#898)**
- **feat(dev): add debug timing log**
- **ci: run tests on macos as well**
- **chore: add script to test nuxt-cli**
- **test: switch from deprecated vitest syntax**
- **test: add dev server benchmarks (#901)**
- **test: accurately benchmark forked mode (#903)**
- **test: close servers (#904)**
- **perf(dev): improve cold start of dev server (#902)**
- **fix(init): allow skipping modules prompt with `--no-modules` (#888)**
- **chore: remove stray symbolic links**
- **chore: de-dupe nuxt dependency (#905)**
- **chore(deps): update autofix-ci/action digest to 635ffb0 (#906)**
- **fix(init): ask before showing modules selector (#895)**
- **fix(init): skip modules that are dependencies of other modules (#879)**
- **chore(deps): update all non-major dependencies (#907)**
- **fix(module): fix parsing bug for `.npmrc` files with comments (#881)**
- **perf: enable node compile cache (#911)**
- **refactor(dev): directly emit address (+ type server)**
- **perf(dev): use native `fs.watch` to watch `dist`, config and `.env` (#913)**
- **fix: correctly polyfill `globalThis.crypto`**
- **chore(deps): update all non-major dependencies (#914)**
- **chore(deps): update resolutions eslint-plugin-jsdoc to v51 (#915)**
- **chore: move `playground/` to root (#917)**
- **chore(deps): update devdependency @types/node to ^22.15.32 (#918)**
- **ci: run tests against node 20**
- **fix(dev): always create dist dir before watching it**
- **[autofix.ci] apply automated fixes**
- **chore(deps): update all non-major dependencies (#924)**
- **ci: remove forced corepack installation**
- **chore(deps): update resolutions eslint-plugin-jsdoc to v51.2.2 (#925)**
- **feat(typecheck): support ts projects (#928)**
- **fix: prioritise `@nuxt/kit` from `nuxt` dependencies (#929)**
- **perf(typecheck): resolve typescript alongside preparing nuxt types**
- **chore: skip non-existent authors**
- **chore: use fetch api**
- **perf(dev): use socket to proxy connections to dev server (#921)**
- **fix(dev): avoid recursive fs watching**
- **fix(dev): set xfwd headers (#931)**
- **chore(deps): update nuxt framework to ^3.17.6 (#934)**
- **fix: only set `NODE_COMPILE_CACHE` if cache can be enabled**
- **chore: update dev container**
- **test: add additional e2e command tests (#935)**
- **perf(dev): use `exsolve` to resolve + import legacy loading template (#936)**
- **chore(deps): update all non-major dependencies (#938)**
- **fix(dev): ensure we listen on port if `_PORT` is set (#940)**
- **feat: add `--extends` option to allow extending nuxt layers (#933)**
- **fix(typecheck): proxy `overrides` to `loadNuxt` (#942)**
- **chore(deps): update all non-major dependencies (#939)**
- **fix(dev): handle undefined `process.title` (#946)**
- **fix(dev): don't use sockets if provider is stackblitz (#949)**
- **chore(deps): upgrade `get-port-please`**
- **refactor(dev): use `get-port-please` to produce socket addresses (#952)**
- **chore(deps): lock file maintenance (#955)**
- **chore(deps): update all non-major dependencies (#954)**
- **chore(deps): update nuxt framework to ^3.17.7 (#953)**
- **v3.26.0**
- **refactor: simplify `formatSocketURL` logic**
- **fix(dev): temporarily refactor to use previous socket url handling (#957)**
- **v3.26.1**
- **fix: update default template name to `v4`**
- **v3.26.2**
- **chore(deps): update nuxt framework to v4 (major) (#961)**
- **ci: do not fail fast in matrix**
- **fix(dev): only close config watchers when process exits (#971)**
- **fix(dev): call close watchers when cleaning up init (#972)**
- **fix(dev): work around rollup build bug**
- **fix(dev): expose port/host to `options.devServer` (#970)**
- **fix(dev): use `get-port-please` to handle socket paths (#973)**
- **fix(dev): use 'SIGTERM' to kill process on deno (#974)**
- **v3.26.3**
- **fix(dev): await `devServer.close`**
- **chore(deps): lock file maintenance (#978)**
- **fix(dev): add exception handlers for initial restart (#975)**
- **chore(deps): update all non-major dependencies (#977)**
- **v3.26.4**
- **fix(upgrade): update default Nuxt version to v4 (#981)**
- **chore(deps): update nuxt framework to ^4.0.1 (#982)**
- **chore(deps): update resolutions eslint-plugin-unicorn to v60 (#983)**
- **feat: add `-e` alias for `--extends` (#986)**
- **fix(add): create layers relative to `rootDir`**
- **v3.27.0**
- **chore(deps): update all non-major dependencies (#988)**
- **chore(deps): update devdependency @antfu/eslint-config to v5 (#989)**
- **chore(deps): update resolutions eslint-plugin-jsdoc to v52 (#990)**
- **chore(deps): update nuxt framework to ^4.0.2 (#993)**
- **chore(deps): update nuxt framework to ^4.0.3 (#997)**
- **ci: run size compare workflow on `pull_request_target` (#999)**
- **fix(dev): handle array of dotenv file names**
- **fix(init): use amended directory when adding modules (#998)**
- **fix(init): skip modules that are dependencies of the selected template (#910)**
- **chore(deps): update all non-major dependencies (#995)**
- **chore: import `join`**
- **feat(init): add `--nightly` flag (#650)**
- **fix(init): default nightly install to `latest`**
- **fix(dev): end websocket connections gracefully (#1001)**
- **fix(upgrade): do not use cache when getting nuxt version (#1002)**
- **v3.28.0**
- **chore(deps): update actions/download-artifact action to v5 (#1005)**
- **ci: run tests on last node LTS**
- **chore(deps): update all non-major dependencies (#1004)**
- **chore(deps): update actions/checkout digest to 08eba0b (#1007)**
- **chore(deps): update actions/checkout action to v5 (#1009)**
- **chore(deps): lock file maintenance (#1012)**
- **chore(deps): update resolutions eslint-plugin-jsdoc to v54 (#1011)**
- **chore(deps): update all non-major dependencies (#1008)**
- **ci: always publish nightly releases via pkg-pr-new**
- **ci: use npm trusted publishing**
- **chore(deps): update dependency perfect-debounce to v2 (#1016)**
- **chore(deps): update all non-major dependencies (#1015)**
- **chore(deps): update devdependency vue to ^3.5.20 (#1017)**
- **chore(deps): update all non-major dependencies (#1018)**
- **chore(deps): update all non-major dependencies (#1023)**
- **chore(deps): update pnpm to v10.15.1 (#1024)**
- **chore(deps): update actions/setup-node action to v5 (#1032)**
- **chore(deps): update all non-major dependencies (#1031)**
- **chore(deps): update resolutions eslint-plugin-unicorn to v61 (#1034)**
- **ci: add codspeed mode**
- **chore(deps): update resolutions eslint-plugin-unicorn to v61.0.2 (#1035)**
- **chore(deps): update nuxt framework to ^4.1.1 (#1026)**
- **feat(upgrade): add `v3`, `v4`, `v3-nightly` and `v4-nightly` channels (#1019)**
- **chore(deps): update codspeedhq/action action to v4 (#1033)**
- **chore(deps): update all non-major dependencies (#1036)**
- **chore(deps): update resolutions eslint-plugin-jsdoc to v55 (#1038)**
- **chore(deps): update all non-major dependencies (#1040)**
- **chore(deps): update all non-major dependencies (#1042)**
- **chore(deps): update resolutions eslint-plugin-jsdoc to v57 (#1041)**
- **ci: add provenance action to check for downgrades in provenance**
- **refactor(nuxi): accept command definition on `runCommand`**
- **refactor(nuxi): collocate exported `runMain` with main**
- **refactor(nuxi): extract command utils file**

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
