### PR TITLE
fix: Triggering a loop restart issue when saving the nuxt.config.ts file

### DIFF
--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -160,7 +160,9 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
   async load(reload?: boolean, reason?: string) {
     try {
+      this.closeWatchers();
       await this._load(reload, reason)
+      this._watchConfig();
       this._loadingError = undefined
     }
     catch (error) {


### PR DESCRIPTION
### 🔗 Linked issue

refer: 
https://github.com/nuxt/bridge/issues/1591
https://github.com/nuxt/bridge/issues/1623

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'm migrating my Nuxt2 app to Bridge and I'm running into two issues.

First, I received a response in issue 1591, stating that this issue is caused by versions later than nuxi@3.6.0. So I rolled back to nuxi@3.6.0, which then caused another issue: https://github.com/nuxt/bridge/issues/1623 The app is only reloaded when nuxt.config.js is first saved. I found the answer in the source code: during onReload , the close method is not executed, so the watchConfig method is only executed during the initial startup and init .

Second issue: After using the latest version of Nuxi, I encountered the issue https://github.com/nuxt/bridge/issues/1591. After saving the nuxt.config.js file, the dev server would restart infinitely. I eventually discovered the cause: it was due to the different build environments for Nuxt 2 and Nuxt 3. In Nuxt 2's "kit.buildNuxt" step in the "load" method, Nuxt 2 first cleared the .nuxt directory and then regenerated the artifacts, but Nuxt 3+ didn't do this. As a result, modifications to the dist directory in Nuxt 2 triggered the watcher "this._distWatcher = watch(distDir)", causing the app to restart and then begin a loop. The fix is ​​actually quite simple: simply execute the "close" method before the "_load" method and then re-execute the "watchConfig" method afterward.

Finally, this is a fix specifically for the bridge environment; I don't know if it will make it into the main version of Nuxi.
<img width="872" height="394" alt="image" src="https://github.com/user-attachments/assets/710bc708-c7b1-4d80-b6d3-903ebfe4b162" />
<img width="806" height="445" alt="image" src="https://github.com/user-attachments/assets/419459b7-1934-4ae6-a447-bd819cb9b7d4" />
<img width="378" height="143" alt="image" src="https://github.com/user-attachments/assets/acfd708a-93ca-4777-9b83-1687073307f3" />
<img width="885" height="451" alt="image" src="https://github.com/user-attachments/assets/60eac303-b476-48fd-818b-31e4b857d5e1" />

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
