### PR TITLE
fix(preview): move `port` argument alias to command definition

### DIFF
--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -25,7 +25,7 @@ const command = defineCommand({
     ...envNameArgs,
     ...extendsArgs,
     ...legacyRootDirArgs,
-    port: getListhenArgs().port,
+    port: { ...getListhenArgs().port, alias: ['p'] },
     ...dotEnvArgs,
   },
   async run(ctx) {
@@ -144,7 +144,6 @@ type ArgsT = Exclude<
 
 function _resolveListenOptions(args: ParsedArgs<ArgsT>) {
   const _port = args.port
-    ?? args.p
     ?? process.env.NUXT_PORT
     ?? process.env.NITRO_PORT
     ?? process.env.PORT


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The `preview` command supports passing `-p` but this is hidden from the user.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
