### PR TITLE
fix(dev): handle multiple set-cookie headers correctly (#1075)

### DIFF
--- a/packages/nuxt-cli/test/fixtures/dev/server/api/test-cookies.ts
+++ b/packages/nuxt-cli/test/fixtures/dev/server/api/test-cookies.ts
@@ -1,0 +1,29 @@
+import { defineEventHandler, setCookie } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const expiryDate = new Date(Date.now() + 7200000) // 2 hours
+
+  setCookie(event, 'XSRF-TOKEN', 'eyJpdiI6IlpDZ2JlTzdIY', {
+    expires: expiryDate,
+    path: '/',
+    domain: 'localhost',
+    secure: false,
+    sameSite: 'lax',
+  })
+
+  setCookie(event, 'app-session', 'eyJpdiI6InpGNmxwR0t', {
+    expires: expiryDate,
+    path: '/',
+    domain: 'localhost',
+    httpOnly: true,
+    secure: false,
+    sameSite: 'lax',
+  })
+
+  setCookie(event, 'user-pref', 'dark-mode', {
+    expires: expiryDate,
+    path: '/',
+  })
+
+  return { ok: true, cookies: 3 }
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #1075
Fixes nuxt/nuxt#33430

### Summary
The dev server was only sending the last cookie when multiple `setCookie()` calls were made in a server route. This violated [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265) which requires each cookie to be sent in a separate `Set-Cookie` header and explicitly forbids combining them with commas.

### Root Cause
1. **`sendWebResponse`**: Used `headers.entries()` which only returns a single combined value for `set-cookie` due to Web Standards Headers API limitations, even when multiple cookies exist
2. **`fetchWithNodeHttp`**: Incorrectly joined multiple cookie headers with `.join(', ')`, causing browsers to reject them when cookies contained `Expires` dates (which include commas)

### Solution
- Use `getSetCookie()` method (part of the Fetch API spec) to retrieve all cookies as separate array entries
- Use `appendHeader()` instead of `setHeader()` to add each cookie individually to the Node.js response
- Skip `set-cookie` when iterating through other headers to avoid duplicates

### Changes
- ✅ Fix `sendWebResponse` to handle multiple cookies via `getSetCookie()`
- ✅ Fix `fetchWithNodeHttp` to append cookies individually (no comma joining)
- ✅ Add E2E test verifying 3 separate cookies are sent correctly
- ✅ All existing tests pass

### Testing
```bash
pnpm test:unit