### PR TITLE
fix(dev): only override `NODE_ENV` override when initialising server

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -12,7 +12,6 @@ import { isBun, isTest } from 'std-env'
 
 import { initialize } from '../dev'
 import { ForkPool } from '../dev/pool'
-import { overrideEnv } from '../utils/env'
 import { debug, logger } from '../utils/logger'
 import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
 
@@ -74,7 +73,6 @@ const command = defineCommand({
   },
   async run(ctx) {
     // Prepare
-    overrideEnv('development')
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
     const listenOverrides = resolveListenOverrides(ctx.args)

--- a/packages/nuxi/src/dev/index.ts
+++ b/packages/nuxi/src/dev/index.ts
@@ -4,12 +4,10 @@ import type { NuxtDevContext, NuxtDevIPCMessage, NuxtParentIPCMessage } from './
 
 import process from 'node:process'
 import defu from 'defu'
+import { overrideEnv } from '../utils/env.ts'
 import { NuxtDevServer } from './utils'
 
 const start = Date.now()
-
-// Prepare
-process.env.NODE_ENV = 'development'
 
 interface InitializeOptions {
   data?: {
@@ -55,6 +53,8 @@ interface InitializeReturn {
 }
 
 export async function initialize(devContext: NuxtDevContext, ctx: InitializeOptions = {}): Promise<InitializeReturn> {
+  overrideEnv('development')
+
   const devServer = new NuxtDevServer({
     cwd: devContext.cwd,
     overrides: defu(


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, all `.ts` files are loaded on `nuxi` startup. This entails `dev/index.ts` to set the initial `NODE_ENV` to `development` and as a result, other commands that do not override this value end up using it, ignoring user-defined `NODE_ENV` (from the system or `.env` file).

I moved this logic into the `initialize` function so this override happens only for the `dev` command.

### 🛝 Example

Consider a CI workflow where you are preparing for deployment:

- Set `NODE_ENV=production`
- Install only production dependencies (`npm install --omit=dev`, `bun install --production`, etc.)
- Run `nuxi prepare` to generate types (or simply wait for `postinstall` script)

If your `nuxt.config.ts` contains logic meant only for development (which relies on dev dependencies, for example), checking `process.env['NODE_ENV'] === 'development'` inside the config will return true even though you explicitly set it to `production`.

### ✴️ Potential weakness

`ipc` is still initialized on `nuxi` startup no matter what command is executed later. However, I don't see any issues with this, even in situations where the user defines `NODE_ENV=production` or leaves it empty. All tests passed.
