### PR TITLE
feat(info): fallback if clipboard copy failed

### DIFF
--- a/packages/nuxi/src/commands/info.ts
+++ b/packages/nuxi/src/commands/info.ts
@@ -11,10 +11,10 @@ import { copy as copyToClipboard } from 'copy-paste'
 import { detectPackageManager } from 'nypm'
 import { resolve } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
+
 import { isBun, isDeno, isMinimal } from 'std-env'
 
 import { version as nuxiVersion } from '../../package.json'
-
 import { getBuilder } from '../utils/banner'
 import { formatInfoBox } from '../utils/formatting'
 import { tryResolveNuxt } from '../utils/kit'
@@ -145,18 +145,23 @@ export default defineCommand({
 
     const copied = !isMinimal && await new Promise(resolve => copyToClipboard(copyStr, err => resolve(!err)))
 
-    box(
-      `\n${boxStr}`,
-      ` Nuxt project info ${copied ? colors.gray('(copied to clipboard) ') : ''}`,
-      {
-        contentAlign: 'left',
-        titleAlign: 'left',
-        width: 'auto',
-        titlePadding: 2,
-        contentPadding: 2,
-        rounded: true,
-      },
-    )
+    if (copied) {
+      box(
+        `\n${boxStr}`,
+        ` Nuxt project info ${colors.gray('(copied to clipboard) ')}`,
+        {
+          contentAlign: 'left',
+          titleAlign: 'left',
+          width: 'auto',
+          titlePadding: 2,
+          contentPadding: 2,
+          rounded: true,
+        },
+      )
+    }
+    else {
+      logger.info(`Nuxt project info:\n${copyStr}`, { withGuide: false })
+    }
 
     const isNuxt3 = !isLegacy
     const isBridge = !isNuxt3 && infoObj['Build modules']?.includes('bridge')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If the clipboard is not available, we should fall back to a copyable console output. This would make it easier to copy manually.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
