### PR TITLE
fix(dev): preserve user-defined HMR port in vite:extend hook

### DIFF
--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -343,7 +343,6 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
           config.server.hmr = {
             protocol: undefined,
             ...(config.server.hmr as Exclude<typeof config.server.hmr, boolean>),
-            port: undefined,
             host: undefined,
             server: this.listener.server,
           }


### PR DESCRIPTION
## Summary

Remove `port: undefined` override that was clobbering user-specified HMR port, causing port conflicts in monorepo setups.

## Changes

```diff
config.server.hmr = {
  protocol: undefined,
  ...(config.server.hmr as Exclude<typeof config.server.hmr, boolean>),
- port: undefined,
  host: undefined,
  server: this.listener.server,
}
```

The spread operator already preserves the port from user config, so explicitly setting `port: undefined` was unnecessary and broke custom port configuration.

## Related

- nuxt/cli#1170
- nuxt/nuxt#33929