### PR TITLE
fix(init): silence dependency install logs

### DIFF
--- a/packages/nuxi/src/commands/init.ts
+++ b/packages/nuxi/src/commands/init.ts
@@ -371,6 +371,7 @@ export default defineCommand({
                 name: selectedPackageManager,
                 command: selectedPackageManager,
               },
+              silent: true,
             })
             return 'Dependencies installed'
           },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

<table>
<tr>
 <td>
 Before
 <td>
After
<tr>
 <td>
<img width="2380" height="1314" alt="CleanShot 2026-01-02 at 11 00 13@2x" src="https://github.com/user-attachments/assets/6f2f4aec-f9cb-498d-a79d-adae742020f1" />

 <td>
<img width="1628" height="1340" alt="CleanShot 2026-01-02 at 11 01 13@2x" src="https://github.com/user-attachments/assets/e6dd5bdf-889d-4948-9caf-23b4b691801b" />

</table>

It's also fine when  there is an error.

<img width="2416" height="992" alt="CleanShot 2026-01-02 at 11 04 45@2x" src="https://github.com/user-attachments/assets/f14ef461-9538-4fac-bc12-c34cbf20b775" />



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
