### PR TITLE
fix(nuxi): pass --dotenv argument to showVersions in build command

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -44,7 +44,7 @@ export default defineCommand({
 
     const kit = await loadKit(cwd)
 
-    await showVersions(cwd, kit)
+    await showVersions(cwd, kit, ctx.args.dotenv)
     const nuxt = await kit.loadNuxt({
       cwd,
       dotenv: {

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -41,8 +41,11 @@ export function showVersionsFromConfig(cwd: string, config: NuxtOptions) {
   )
 }
 
-export async function showVersions(cwd: string, kit: typeof import('@nuxt/kit')) {
-  const config = await kit.loadNuxtConfig({ cwd })
+export async function showVersions(cwd: string, kit: typeof import('@nuxt/kit'), dotenv?: string) {
+  const config = await kit.loadNuxtConfig({
+    cwd,
+    dotenv: dotenv ? { cwd, fileName: dotenv } : undefined,
+  })
 
   return showVersionsFromConfig(cwd, config)
 }


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: https://github.com/nuxt/nuxt/issues/33806

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description                                                                                                                                                                                                 

When using `--dotenv .env.production` with `nuxt build`, custom environment files were not being applied to `runtimeConfig` values.                                                                                    
                                                                                                                                                                                                                         
## The Problem                                                                                                                                                                                                         
                                                                                                                                                                                                                         
`showVersions()` in `banner.ts` calls `loadNuxtConfig({ cwd })` **without** the `--dotenv` option to display the version banner before the build starts.                                                               
                                                                                                                                                                                                                         
This causes the config to be loaded with only the default `.env` file (or none), and `process.env.NUXT_*` variables from custom env files are `undefined` at that point.                                               
                                                                                                                                                                                                                         
When `loadNuxt()` is called afterwards with the correct dotenv options, the config values are already resolved with the wrong (empty) values.                                                                          
                                                                                                                                                                                                                         
### Why `.ts` worked but `.js` didn't                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                         
- **`.ts` files**: jiti transforms and evaluates with `moduleCache: false` - no caching                                                                                                                                
- **`.js` ESM files**: jiti delegates to Node.js native `import()` - Node.js caches the module                                                                                                                         
                                                                                                                                                                                                                         
When the first `loadNuxtConfig()` call happens without dotenv, `process.env` is empty. For `.js` files, Node.js caches the module with empty values. The subsequent `loadNuxt()` call with correct dotenv options gets the cached module - the new `process.env` values are ignored.                                                         
                                                                                                                                                                                                                         
## The Fix                                                                                                                                                                                                             
                                                                                                                                                                                                                         
Pass `ctx.args.dotenv` to `showVersions()` so the first config load already uses the correct environment file.                                                                                                         
                                                                                                                                                                                                                         
- `banner.ts`: Add optional `dotenv` parameter to `showVersions()`                                                                                                                                                     
- `build.ts`: Pass `ctx.args.dotenv` to `showVersions()`                        
