### PR TITLE
feat(module): add agent skills installation

### DIFF
--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -74,6 +74,7 @@
     "tsdown": "^0.19.0",
     "typescript": "^5.9.3",
     "ufo": "^1.6.3",
+    "unagent": "^0.0.5",
     "unplugin-purge-polyfills": "^0.1.0",
     "vitest": "^3.2.4",
     "youch": "^4.1.0-beta.13"

--- a/packages/nuxi/src/commands/module/_skills.ts
+++ b/packages/nuxi/src/commands/module/_skills.ts
@@ -80,11 +80,16 @@ export async function installModuleSkills(sources: ModuleSkillSource[]): Promise
         info._spinner?.stop(`${mode} ${skillNames} → ${agentNames}`)
       }
       else {
-        info._spinner?.stop('No skills found')
+        info._spinner?.stop('No skills to install')
       }
     },
     onError: (source: SkillSource, error: string) => {
       const info = source as ModuleSkillSource & { _spinner: ReturnType<typeof spinner> }
+      const isAlreadyInstalled = error.includes('Cannot overwrite directory') || error.includes('EEXIST')
+      if (isAlreadyInstalled) {
+        info._spinner?.stop('Already installed')
+        return
+      }
       info._spinner?.stop('Failed to install skills')
       logger.warn(`Skill installation failed for ${info.moduleName}: ${error}`)
     },

--- a/packages/nuxi/src/commands/module/_skills.ts
+++ b/packages/nuxi/src/commands/module/_skills.ts
@@ -63,8 +63,9 @@ export async function installModuleSkills(sources: ModuleSkillSource[], options:
     return
   }
 
-  const targetAgents = options.agents?.length
-    ? installedAgents.filter(agent => options.agents!.includes(agent.id))
+  const requested = options.agents?.length ? new Set(options.agents) : null
+  const targetAgents = requested
+    ? installedAgents.filter(agent => requested.has(agent.id))
     : installedAgents
 
   if (targetAgents.length === 0) {
@@ -73,6 +74,7 @@ export async function installModuleSkills(sources: ModuleSkillSource[], options:
   }
 
   const agentNames = formatDetectedAgentIds(targetAgents)
+  const effectiveAgentIds = requested ? targetAgents.map(agent => agent.id) : undefined
 
   const callbacks: BatchInstallCallbacks = {
     onStart: (source: SkillSource) => {
@@ -115,7 +117,7 @@ export async function installModuleSkills(sources: ModuleSkillSource[], options:
         source: source.source,
         skills: source.skills,
         mode: source.mode ?? 'copy',
-        agents: options.agents?.length ? options.agents : undefined,
+        agents: effectiveAgentIds,
       })
       if (result.installed.length > 0)
         callbacks.onSuccess?.(source, result)

--- a/packages/nuxi/src/commands/module/_skills.ts
+++ b/packages/nuxi/src/commands/module/_skills.ts
@@ -1,0 +1,85 @@
+import { spinner } from '@clack/prompts'
+import { join } from 'pathe'
+import { x } from 'tinyexec'
+
+// Types from @nuxt/schema (PR 1) - defined locally until schema is updated
+interface ModuleAgentSkillsConfig {
+  url: string
+  skills?: string[]
+}
+
+interface ModuleAgentsConfig {
+  skills?: ModuleAgentSkillsConfig
+}
+
+interface ModuleMeta {
+  name?: string
+  agents?: ModuleAgentsConfig
+}
+
+export interface ModuleSkillInfo {
+  url: string
+  skills?: string[]
+  moduleName: string
+}
+
+export async function detectModuleSkills(moduleNames: string[], cwd: string): Promise<ModuleSkillInfo[]> {
+  const result: ModuleSkillInfo[] = []
+
+  for (const pkgName of moduleNames) {
+    const meta = await getModuleMeta(pkgName, cwd)
+    if (meta?.agents?.skills?.url) {
+      result.push({
+        url: meta.agents.skills.url,
+        skills: meta.agents.skills.skills,
+        moduleName: pkgName,
+      })
+    }
+  }
+  return result
+}
+
+async function getModuleMeta(pkgName: string, cwd: string): Promise<ModuleMeta | null> {
+  try {
+    const modulePath = join(cwd, 'node_modules', pkgName)
+    const mod = await import(modulePath)
+    return await mod?.default?.getMeta?.()
+  }
+  catch {
+    return null
+  }
+}
+
+export async function installSkills(infos: ModuleSkillInfo[], cwd: string): Promise<void> {
+  for (const info of infos) {
+    const skills = info.skills ?? []
+    const label = skills.length > 0 ? `Installing ${skills.join(', ')}...` : `Installing skills from ${info.url}...`
+
+    const s = spinner()
+    s.start(label)
+
+    try {
+      const args = ['skills', 'add', info.url, '-y']
+      if (skills.length > 0) {
+        args.push('--skill', ...skills)
+      }
+
+      await x('npx', args, {
+        nodeOptions: { cwd, stdio: 'pipe' },
+      })
+
+      s.stop('Installed to detected agents')
+    }
+    catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error)
+      s.stop('Failed to install skills')
+      console.warn(`Skill installation failed: ${msg}`)
+    }
+  }
+}
+
+export function getSkillNames(infos: ModuleSkillInfo[]): string {
+  return infos
+    .flatMap(i => i.skills?.length ? i.skills : ['all'])
+    .join(', ')
+}

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -205,7 +205,8 @@ async function addModules(modules: ResolvedModule[], { skipInstall, skipConfig, 
         workspace: packageManager?.name === 'pnpm' && existsSync(resolve(cwd, 'pnpm-workspace.yaml')),
       }).then(() => true).catch(
         async (error) => {
-          logger.error(error)
+          const message = error instanceof Error ? error.message : String(error)
+          logger.error(message)
 
           const failedModulesList = notInstalledModules.map(module => colors.cyan(module.pkg)).join(', ')
           const s = notInstalledModules.length > 1 ? 's' : ''

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -10,7 +10,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 
 import process from 'node:process'
-import { cancel, confirm, isCancel, select, spinner } from '@clack/prompts'
+import { cancel, confirm, groupMultiselect, isCancel, note, select, spinner } from '@clack/prompts'
 import { updateConfig } from 'c12/update'
 import { defineCommand } from 'citty'
 import { colors } from 'consola/utils'
@@ -20,7 +20,8 @@ import { resolve } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
 import { satisfies } from 'semver'
 import { joinURL } from 'ufo'
-import { formatSkillNames, getBundledSkillSources } from 'unagent'
+import type { DetectedAgent } from 'unagent'
+import { detectInstalledAgents, formatSkillNames, getAgentDisplayNames, getBundledSkillSources } from 'unagent'
 
 import { runCommand } from '../../run'
 import { logger } from '../../utils/logger'
@@ -44,6 +45,93 @@ interface ResolvedModule {
 }
 type UnresolvedModule = false
 type ModuleResolution = ResolvedModule | UnresolvedModule
+
+type InstallMode = 'auto' | 'copy' | 'symlink'
+const SKILL_VALUE_SEPARATOR = '::'
+const SKILL_ALL_TOKEN = '*'
+
+function formatAgentList(agents: DetectedAgent[]): string {
+  if (agents.length === 0)
+    return 'none'
+  return getAgentDisplayNames(agents).join(', ')
+}
+
+function formatSkillPlan(agents: DetectedAgent[], sources: ModuleSkillSource[]): string {
+  const lines = [
+    `Agents: ${formatAgentList(agents)}`,
+    'Mode: auto (symlink local, copy remote)',
+    'Skills:',
+    ...sources.map((source) => {
+      const skills = source.skills?.length ? source.skills.join(', ') : 'all'
+      return `- ${source.moduleName}: ${skills}`
+    }),
+  ]
+  return lines.join('\n')
+}
+
+function buildSkillGroups(sources: ModuleSkillSource[]) {
+  const groups: Record<string, Array<{ label: string, value: string, hint?: string }>> = {}
+  const initialValues: string[] = []
+
+  for (const source of sources) {
+    const skills = source.skills?.length ? source.skills : null
+    const options = skills
+      ? skills.map(skill => ({ label: skill, value: `${source.moduleName}${SKILL_VALUE_SEPARATOR}${skill}` }))
+      : [{ label: 'all', value: `${source.moduleName}${SKILL_VALUE_SEPARATOR}${SKILL_ALL_TOKEN}`, hint: 'includes all skills' }]
+    groups[source.moduleName] = options
+    initialValues.push(...options.map(option => option.value))
+  }
+
+  return { groups, initialValues }
+}
+
+function applySkillSelection(sources: ModuleSkillSource[], selectedValues: string[]) {
+  const selectedByModule = new Map<string, { all: boolean, skills: Set<string> }>()
+
+  for (const value of selectedValues) {
+    const [moduleName, skillName] = value.split(SKILL_VALUE_SEPARATOR)
+    const entry = selectedByModule.get(moduleName) || { all: false, skills: new Set<string>() }
+    if (skillName === SKILL_ALL_TOKEN)
+      entry.all = true
+    else if (skillName)
+      entry.skills.add(skillName)
+    selectedByModule.set(moduleName, entry)
+  }
+
+  const selectedSources: ModuleSkillSource[] = []
+  for (const source of sources) {
+    const selected = selectedByModule.get(source.moduleName)
+    if (!selected)
+      continue
+    if (selected.all) {
+      selectedSources.push({ ...source, skills: undefined })
+      continue
+    }
+    const sourceSkills = source.skills?.length ? source.skills : []
+    const filtered = sourceSkills.filter(skill => selected.skills.has(skill))
+    if (filtered.length === 0)
+      continue
+    selectedSources.push({ ...source, skills: filtered })
+  }
+
+  return selectedSources
+}
+
+function applyInstallMode(sources: ModuleSkillSource[], mode: InstallMode) {
+  if (mode === 'auto')
+    return { sources, forcedCopy: false }
+
+  let forcedCopy = false
+  const next = sources.map((source) => {
+    if (mode === 'symlink' && !source.isLocal) {
+      forcedCopy = true
+      return { ...source, mode: 'copy' as const }
+    }
+    return { ...source, mode }
+  })
+
+  return { sources: next, forcedCopy }
+}
 
 export default defineCommand({
   meta: {
@@ -137,18 +225,92 @@ export default defineCommand({
       }
 
       if (skillInfos.length > 0) {
-        const shouldInstall = await confirm({
-          message: `Install agent skill(s): ${formatSkillNames(skillInfos)}?`,
-          initialValue: true,
-        })
+        const detectedAgents = detectInstalledAgents()
+        if (detectedAgents.length === 0) {
+          logger.warn('No AI coding agents detected')
+        }
+        else {
+          note(formatSkillPlan(detectedAgents, skillInfos), 'Planned install')
 
-        if (!isCancel(shouldInstall) && shouldInstall) {
-          try {
-            await installModuleSkills(skillInfos)
-          }
-          catch (error) {
-            const message = error instanceof Error ? error.message : String(error)
-            logger.warn(`Failed to install agent skills: ${message}`)
+          const action = await select({
+            message: `Install agent skill(s): ${formatSkillNames(skillInfos)}?`,
+            options: [
+              { value: 'yes', label: 'Yes', hint: 'Install with planned settings' },
+              { value: 'config', label: 'Change configuration', hint: 'Choose agent, mode, and skills' },
+              { value: 'no', label: 'No', hint: 'Skip installing skills' },
+            ],
+            initialValue: 'yes',
+          })
+
+          if (!isCancel(action) && action !== 'no') {
+            let selectedSources = skillInfos
+            let selectedAgents: string[] | undefined
+            let selectedMode: InstallMode = 'auto'
+
+            if (action === 'config') {
+              const agentChoice = await select({
+                message: 'Which AI agent should receive the skills?',
+                options: [
+                  { value: '__all__', label: 'All detected agents', hint: 'default' },
+                  ...detectedAgents.map(agent => ({
+                    value: agent.id,
+                    label: `${agent.config.name} (${agent.id})`,
+                  })),
+                ],
+                initialValue: '__all__',
+              })
+
+              if (isCancel(agentChoice))
+                return
+
+              if (agentChoice !== '__all__')
+                selectedAgents = [agentChoice]
+
+              const modeChoice = await select({
+                message: 'Install mode:',
+                options: [
+                  { value: 'auto', label: 'Auto', hint: 'symlink local, copy remote' },
+                  { value: 'copy', label: 'Copy', hint: 'copy into agent skill dir' },
+                  { value: 'symlink', label: 'Symlink', hint: 'link to source (local only)' },
+                ],
+                initialValue: 'auto',
+              })
+
+              if (isCancel(modeChoice))
+                return
+
+              selectedMode = modeChoice as InstallMode
+
+              const { groups, initialValues } = buildSkillGroups(skillInfos)
+              const skillSelection = await groupMultiselect({
+                message: 'Select skills to install:',
+                options: groups,
+                initialValues,
+                required: false,
+              })
+
+              if (isCancel(skillSelection))
+                return
+
+              selectedSources = applySkillSelection(skillInfos, skillSelection as string[])
+              if (selectedSources.length === 0) {
+                logger.info('No skills selected')
+                return
+              }
+            }
+
+            const modeResult = applyInstallMode(selectedSources, selectedMode)
+            selectedSources = modeResult.sources
+            if (modeResult.forcedCopy)
+              logger.warn('Symlink mode applies only to local skills; remote skills will be copied.')
+
+            try {
+              await installModuleSkills(selectedSources, { agents: selectedAgents })
+            }
+            catch (error) {
+              const message = error instanceof Error ? error.message : String(error)
+              logger.warn(`Failed to install agent skills: ${message}`)
+            }
           }
         }
       }

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -128,7 +128,7 @@ export default defineCommand({
         const remoteOnly = metaSkills.filter(s => !bundledModules.has(s.moduleName))
         skillInfos = [...bundledSkills, ...remoteOnly]
 
-        checkSpinner.stop(skillInfos.length > 0 ? `Found ${skillInfos.length} skill(s)` : 'No skills found')
+        checkSpinner.stop(skillInfos.length > 0 ? `Found ${skillInfos.length} skill(s)` : 'Skills scan complete')
       }
       catch (error) {
         const message = error instanceof Error ? error.message : String(error)
@@ -214,10 +214,8 @@ async function addModules(modules: ResolvedModule[], { skipInstall, skipConfig, 
             || message.includes('ERR_PACKAGE_PATH_NOT_EXPORTED')
             || message.includes('Cannot find module')
           )
-          if (isPackageJsonError && modulesInstalled) {
-            logger.warn(`Peer dependency scan skipped: ${message}`)
+          if (isPackageJsonError && modulesInstalled)
             return true
-          }
           logger.error(message)
 
           const failedModulesList = notInstalledModules.map(module => colors.cyan(module.pkg)).join(', ')

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -206,9 +206,15 @@ async function addModules(modules: ResolvedModule[], { skipInstall, skipConfig, 
       }).then(() => true).catch(
         async (error) => {
           const message = error instanceof Error ? error.message : String(error)
-          const isExportsPackageJsonError = message.includes('Package subpath \'./package.json\' is not defined by "exports"')
+          const modulesInstalled = notInstalledModules.every(module =>
+            existsSync(resolve(cwd, 'node_modules', module.pkgName)),
+          )
+          const isPackageJsonError = message.includes('package.json') && (
+            message.includes('Package subpath \'./package.json\' is not defined by "exports"')
             || message.includes('ERR_PACKAGE_PATH_NOT_EXPORTED')
-          if (isExportsPackageJsonError) {
+            || message.includes('Cannot find module')
+          )
+          if (isPackageJsonError && modulesInstalled) {
             logger.warn(`Peer dependency scan skipped: ${message}`)
             return true
           }

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -1,6 +1,6 @@
 import type { FileHandle } from 'node:fs/promises'
 import type { PackageJson } from 'pkg-types'
-import type { BundledSkillSource } from 'unagent'
+import type { BundledSkillSource, DetectedAgent } from 'unagent'
 import type { ModuleSkillSource } from './_skills'
 
 import type { NuxtModule } from './_utils'
@@ -20,7 +20,6 @@ import { resolve } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
 import { satisfies } from 'semver'
 import { joinURL } from 'ufo'
-import type { DetectedAgent } from 'unagent'
 import { detectInstalledAgents, formatSkillNames, getAgentDisplayNames, getBundledSkillSources } from 'unagent'
 
 import { runCommand } from '../../run'

--- a/packages/nuxi/src/commands/module/add.ts
+++ b/packages/nuxi/src/commands/module/add.ts
@@ -206,6 +206,12 @@ async function addModules(modules: ResolvedModule[], { skipInstall, skipConfig, 
       }).then(() => true).catch(
         async (error) => {
           const message = error instanceof Error ? error.message : String(error)
+          const isExportsPackageJsonError = message.includes('Package subpath \'./package.json\' is not defined by "exports"')
+            || message.includes('ERR_PACKAGE_PATH_NOT_EXPORTED')
+          if (isExportsPackageJsonError) {
+            logger.warn(`Peer dependency scan skipped: ${message}`)
+            return true
+          }
           logger.error(message)
 
           const failedModulesList = notInstalledModules.map(module => colors.cyan(module.pkg)).join(', ')

--- a/packages/nuxi/src/commands/module/index.ts
+++ b/packages/nuxi/src/commands/module/index.ts
@@ -9,5 +9,6 @@ export default defineCommand({
   subCommands: {
     add: () => import('./add').then(r => r.default || r),
     search: () => import('./search').then(r => r.default || r),
+    skills: () => import('./skills').then(r => r.default || r),
   },
 })

--- a/packages/nuxi/src/commands/module/skills.ts
+++ b/packages/nuxi/src/commands/module/skills.ts
@@ -66,7 +66,7 @@ export default defineCommand({
       }
 
       for (const [agent, skills] of byAgent) {
-        logger.info(`\n${colors.bold(agent)}:`)
+        logger.info(`${colors.bold(agent)}:`)
         for (const skill of skills)
           logger.info(`  ${colors.cyan(skill.name)} ${colors.dim(skill.path)}`)
       }

--- a/packages/nuxi/src/commands/module/skills.ts
+++ b/packages/nuxi/src/commands/module/skills.ts
@@ -1,4 +1,4 @@
-import type { BundledSkillSource, InstalledSkill, UninstallSkillResult } from 'unagent'
+import type { BundledSkillSource, DetectedAgent, InstalledSkill, UninstallSkillResult } from 'unagent'
 import type { ModuleSkillSource } from './_skills'
 import process from 'node:process'
 import { groupMultiselect, isCancel, note, select, spinner } from '@clack/prompts'
@@ -6,7 +6,6 @@ import { defineCommand } from 'citty'
 import { colors } from 'consola/utils'
 import { resolve } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
-import type { DetectedAgent } from 'unagent'
 import { detectInstalledAgents, formatSkillNames, getAgentDisplayNames, getBundledSkillSources, listInstalledSkills, uninstallSkill } from 'unagent'
 
 import { logger } from '../../utils/logger'

--- a/packages/nuxi/src/commands/module/skills.ts
+++ b/packages/nuxi/src/commands/module/skills.ts
@@ -44,6 +44,11 @@ export default defineCommand({
       }
       catch (error) {
         const message = error instanceof Error ? error.message : String(error)
+        const isMissingSkillPath = message.includes('ENOENT') || message.includes('no such file or directory')
+        if (isMissingSkillPath) {
+          logger.warn(`Skipping invalid skill entry: ${message}`)
+          return
+        }
         logger.error(`Failed to list installed skills: ${message}`)
         process.exit(1)
       }
@@ -147,7 +152,7 @@ export default defineCommand({
 
     checkSpinner.stop(allSkills.length > 0
       ? `Found skills in ${allSkills.length} package(s)`
-      : 'No agent skills found')
+      : 'Skills scan complete')
 
     if (allSkills.length === 0)
       return

--- a/packages/nuxi/src/commands/module/skills.ts
+++ b/packages/nuxi/src/commands/module/skills.ts
@@ -1,0 +1,172 @@
+import type { BundledSkillSource, InstalledSkill, UninstallSkillResult } from 'unagent'
+import type { ModuleSkillSource } from './_skills'
+import process from 'node:process'
+import { confirm, isCancel, spinner } from '@clack/prompts'
+import { defineCommand } from 'citty'
+import { colors } from 'consola/utils'
+import { resolve } from 'pathe'
+import { readPackageJSON } from 'pkg-types'
+import { formatSkillNames, getAgentDisplayNames, getBundledSkillSources, listInstalledSkills, uninstallSkill } from 'unagent'
+
+import { logger } from '../../utils/logger'
+import { cwdArgs, logLevelArgs } from '../_shared'
+import { detectModuleSkills, installModuleSkills } from './_skills'
+import { fetchModules } from './_utils'
+
+export default defineCommand({
+  meta: {
+    name: 'skills',
+    description: 'Manage agent skills from installed modules',
+  },
+  args: {
+    ...cwdArgs,
+    ...logLevelArgs,
+    install: { type: 'boolean', alias: 'i', description: 'Install skills without prompting' },
+    list: { type: 'boolean', alias: 'l', description: 'List installed skills' },
+    remove: { type: 'string', alias: 'r', description: 'Remove a skill by name' },
+  },
+  async setup(ctx) {
+    const cwd = resolve(ctx.args.cwd)
+
+    // Show detected agents
+    const agents = getAgentDisplayNames()
+    if (agents.length === 0) {
+      logger.warn('No AI coding agents detected')
+      return
+    }
+    logger.info(`Detected agents: ${colors.cyan(agents.join(', '))}`)
+
+    // --list: Show installed skills
+    if (ctx.args.list) {
+      let installed: InstalledSkill[] = []
+      try {
+        installed = listInstalledSkills()
+      }
+      catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.error(`Failed to list installed skills: ${message}`)
+        process.exit(1)
+      }
+
+      if (installed.length === 0) {
+        logger.info('No skills installed')
+        return
+      }
+
+      const byAgent = new Map<string, InstalledSkill[]>()
+      for (const skill of installed) {
+        const list = byAgent.get(skill.agent) || []
+        list.push(skill)
+        byAgent.set(skill.agent, list)
+      }
+
+      for (const [agent, skills] of byAgent) {
+        logger.info(`\n${colors.bold(agent)}:`)
+        for (const skill of skills)
+          logger.info(`  ${colors.cyan(skill.name)} ${colors.dim(skill.path)}`)
+      }
+      return
+    }
+
+    // --remove: Remove a skill
+    if (ctx.args.remove) {
+      const skillName = ctx.args.remove
+      logger.info(`Removing skill: ${colors.cyan(skillName)}`)
+      let result: UninstallSkillResult
+      try {
+        result = await uninstallSkill({ skill: skillName })
+      }
+      catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.error(`Failed to remove skill: ${skillName} (${message})`)
+        process.exit(1)
+      }
+
+      if (result.success && result.removed.length > 0) {
+        const removedAgents = result.removed.map((r: { agent: string }) => r.agent).join(', ')
+        logger.success(`Removed ${skillName} from ${removedAgents}`)
+      }
+      else {
+        for (const err of result.errors)
+          logger.warn(`${err.agent}: ${err.error}`)
+        logger.error(`Failed to remove skill: ${skillName}`)
+        process.exit(1)
+      }
+      return
+    }
+
+    // Default: Scan and install skills
+    const pkg = await readPackageJSON(cwd).catch(() => null)
+    if (!pkg) {
+      logger.error('No package.json found')
+      process.exit(1)
+    }
+
+    const checkSpinner = spinner()
+    checkSpinner.start('Scanning for agent skills...')
+
+    // 1. Scan node_modules for bundled skills
+    let bundledSkills: ModuleSkillSource[] = []
+    try {
+      const bundledSources: BundledSkillSource[] = getBundledSkillSources(cwd)
+      bundledSkills = bundledSources.map((s: BundledSkillSource) => ({
+        source: s.source,
+        skills: s.skills,
+        label: s.packageName,
+        moduleName: s.packageName,
+        isLocal: true,
+        mode: 'symlink' as const,
+      }))
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.warn(`Failed to scan bundled skills: ${message}`)
+    }
+
+    // 2. Check module meta for remote skills
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies }
+    const depNames = Object.keys(allDeps)
+    const knownModules = await fetchModules().catch(() => [])
+    const knownModuleNames = new Set(knownModules.map(m => m.npm))
+    const moduleNames = depNames.filter(name =>
+      knownModuleNames.has(name) || name.startsWith('@nuxt/') || name.startsWith('nuxt-'),
+    )
+    let metaSkills: ModuleSkillSource[] = []
+    try {
+      metaSkills = await detectModuleSkills(moduleNames, cwd)
+    }
+    catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.warn(`Failed to scan module meta skills: ${message}`)
+    }
+
+    // Combine results, preferring bundled (local) over remote
+    const bundledModules = new Set(bundledSkills.map(s => s.moduleName))
+    const remoteOnly = metaSkills.filter(s => !bundledModules.has(s.moduleName))
+    const allSkills = [...bundledSkills, ...remoteOnly]
+
+    checkSpinner.stop(allSkills.length > 0
+      ? `Found skills in ${allSkills.length} package(s)`
+      : 'No agent skills found')
+
+    if (allSkills.length === 0)
+      return
+
+    // Show what was found
+    for (const info of allSkills) {
+      const skills = info.skills?.length ? info.skills.join(', ') : 'all'
+      const source = info.isLocal ? colors.dim('(bundled)') : colors.dim('(remote)')
+      logger.info(`  ${colors.cyan(info.moduleName)}: ${skills} ${source}`)
+    }
+
+    const shouldInstall = ctx.args.install || await confirm({
+      message: `Install agent skill(s): ${formatSkillNames(allSkills)}?`,
+      initialValue: true,
+    })
+
+    if (isCancel(shouldInstall) || !shouldInstall)
+      return
+
+    await installModuleSkills(allSkills)
+  },
+})

--- a/packages/nuxi/test/unit/commands/module/_skills.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/_skills.spec.ts
@@ -1,0 +1,102 @@
+import process from 'node:process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { installModuleSkills } from '../../../../src/commands/module/_skills'
+import { logger } from '../../../../src/utils/logger'
+
+const {
+  detectInstalledAgents,
+  formatDetectedAgentIds,
+  installSkill,
+  spinnerStart,
+  spinnerStop,
+  log,
+} = vi.hoisted(() => {
+  return {
+    detectInstalledAgents: vi.fn(() => [{ id: 'codex', config: { name: 'OpenAI Codex CLI', skillsDir: 'skills' } }]),
+    formatDetectedAgentIds: vi.fn(() => 'OpenAI Codex CLI (codex)'),
+    installSkill: vi.fn(async () => ({ installed: [{ skill: 'foo', agent: 'codex', path: '/tmp/foo' }], errors: [] })),
+    spinnerStart: vi.fn(),
+    spinnerStop: vi.fn(),
+    log: {
+      error: vi.fn(),
+      info: vi.fn(),
+      message: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+    },
+  }
+})
+
+vi.mock('@clack/prompts', async () => {
+  return {
+    log,
+    spinner: () => ({
+      start: spinnerStart,
+      stop: spinnerStop,
+    }),
+  }
+})
+
+vi.mock('unagent', async () => {
+  return {
+    detectInstalledAgents,
+    formatDetectedAgentIds,
+    installSkill,
+  }
+})
+
+describe('installModuleSkills', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    detectInstalledAgents.mockReturnValue([{ id: 'codex', config: { name: 'OpenAI Codex CLI', skillsDir: 'skills' } }])
+    installSkill.mockResolvedValue({ installed: [{ skill: 'foo', agent: 'codex', path: '/tmp/foo' }], errors: [] })
+  })
+
+  it('sanitizes unknown agent ids', async () => {
+    await expect(installModuleSkills([{
+      source: '/tmp/source',
+      label: 'some-module',
+      moduleName: 'some-module',
+      isLocal: true,
+      mode: 'symlink',
+    } as any], { agents: ['codex', 'unknown'] })).resolves.toBeUndefined()
+
+    expect(installSkill).toHaveBeenCalledTimes(1)
+    expect(installSkill).toHaveBeenCalledWith(expect.objectContaining({
+      agents: ['codex'],
+    }))
+  })
+
+  it('does not install when no matching agent ids are provided', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn')
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+
+    await expect(installModuleSkills([{
+      source: '/tmp/source',
+      label: 'some-module',
+      moduleName: 'some-module',
+      isLocal: false,
+      mode: 'copy',
+    } as any], { agents: ['unknown'] })).resolves.toBeUndefined()
+
+    expect(installSkill).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith('No matching AI coding agents detected')
+    expect(exitSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes agents as undefined when no filtering is requested', async () => {
+    await expect(installModuleSkills([{
+      source: '/tmp/source',
+      label: 'some-module',
+      moduleName: 'some-module',
+      isLocal: false,
+      mode: 'copy',
+    } as any])).resolves.toBeUndefined()
+
+    expect(installSkill).toHaveBeenCalledTimes(1)
+    expect(installSkill).toHaveBeenCalledWith(expect.objectContaining({
+      agents: undefined,
+    }))
+  })
+})

--- a/packages/nuxi/test/unit/commands/module/skills.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/skills.spec.ts
@@ -106,23 +106,23 @@ describe('module skills', () => {
     installModuleSkills.mockResolvedValue(undefined)
   })
 
-  it('handles --list failures without uncaught stack traces', async () => {
+  it('skips invalid skill entries on --list', async () => {
     listInstalledSkills.mockImplementationOnce(() => {
       throw new Error('ENOENT: no such file or directory')
     })
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
       throw new Error(`process.exit:${code}`)
     }) as never)
-    const errorSpy = vi.spyOn(logger, 'error')
+    const warnSpy = vi.spyOn(logger, 'warn')
 
     await expect(runSkillsCommand({
       cwd: '/fake-dir',
       _: [],
       list: true,
-    })).rejects.toThrow('process.exit:1')
+    })).resolves.toBeUndefined()
 
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to list installed skills'))
-    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping invalid skill entry'))
+    expect(exitSpy).not.toHaveBeenCalled()
   })
 
   it('continues default scan when bundled/meta scanners fail', async () => {

--- a/packages/nuxi/test/unit/commands/module/skills.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/skills.spec.ts
@@ -1,0 +1,168 @@
+import type { UninstallSkillResult } from 'unagent'
+import process from 'node:process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import skillsCommand from '../../../../src/commands/module/skills'
+import { logger } from '../../../../src/utils/logger'
+
+const {
+  confirm,
+  detectModuleSkills,
+  fetchModules,
+  formatSkillNames,
+  getAgentDisplayNames,
+  getBundledSkillSources,
+  installModuleSkills,
+  isCancel,
+  listInstalledSkills,
+  readPackageJSON,
+  spinnerStart,
+  spinnerStop,
+  uninstallSkill,
+  log,
+} = vi.hoisted(() => {
+  return {
+    confirm: vi.fn(async () => true),
+    detectModuleSkills: vi.fn(async () => []),
+    fetchModules: vi.fn(async () => []),
+    formatSkillNames: vi.fn(() => 'all'),
+    getAgentDisplayNames: vi.fn(() => ['OpenAI Codex CLI (codex)']),
+    getBundledSkillSources: vi.fn(() => []),
+    installModuleSkills: vi.fn(async () => undefined),
+    isCancel: vi.fn(() => false),
+    listInstalledSkills: vi.fn(() => []),
+    readPackageJSON: vi.fn(async () => ({ dependencies: { nuxt: '^3.0.0' } })),
+    spinnerStart: vi.fn(),
+    spinnerStop: vi.fn(),
+    uninstallSkill: vi.fn(async () => ({ success: true, removed: [{ skill: 'foo', agent: 'codex', path: '/tmp/foo' }], errors: [] })),
+    log: {
+      error: vi.fn(),
+      info: vi.fn(),
+      message: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+    },
+  }
+})
+
+vi.mock('@clack/prompts', async () => {
+  return {
+    confirm,
+    isCancel,
+    log,
+    spinner: () => ({
+      start: spinnerStart,
+      stop: spinnerStop,
+    }),
+  }
+})
+
+vi.mock('pkg-types', async () => {
+  return {
+    readPackageJSON,
+  }
+})
+
+vi.mock('unagent', async () => {
+  return {
+    formatSkillNames,
+    getAgentDisplayNames,
+    getBundledSkillSources,
+    listInstalledSkills,
+    uninstallSkill,
+  }
+})
+
+vi.mock('../../../../src/commands/module/_skills', async () => {
+  return {
+    detectModuleSkills,
+    installModuleSkills,
+  }
+})
+
+vi.mock('../../../../src/commands/module/_utils', async () => {
+  return {
+    fetchModules,
+  }
+})
+
+function runSkillsCommand(args: Record<string, unknown>) {
+  return (skillsCommand as { setup: (ctx: { args: Record<string, unknown> }) => Promise<void> }).setup({ args })
+}
+
+describe('module skills', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getAgentDisplayNames.mockReturnValue(['OpenAI Codex CLI (codex)'])
+    listInstalledSkills.mockReturnValue([])
+    getBundledSkillSources.mockReturnValue([])
+    fetchModules.mockResolvedValue([])
+    detectModuleSkills.mockResolvedValue([])
+    readPackageJSON.mockResolvedValue({ dependencies: { nuxt: '^3.0.0' } })
+    uninstallSkill.mockResolvedValue({
+      success: true,
+      removed: [{ skill: 'foo', agent: 'codex', path: '/tmp/foo' }],
+      errors: [],
+    } satisfies UninstallSkillResult)
+    installModuleSkills.mockResolvedValue(undefined)
+  })
+
+  it('handles --list failures without uncaught stack traces', async () => {
+    listInstalledSkills.mockImplementationOnce(() => {
+      throw new Error('ENOENT: no such file or directory')
+    })
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`process.exit:${code}`)
+    }) as never)
+    const errorSpy = vi.spyOn(logger, 'error')
+
+    await expect(runSkillsCommand({
+      cwd: '/fake-dir',
+      _: [],
+      list: true,
+    })).rejects.toThrow('process.exit:1')
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to list installed skills'))
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+
+  it('continues default scan when bundled/meta scanners fail', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn')
+    getBundledSkillSources.mockImplementationOnce(() => {
+      throw new Error('bundled scan failed')
+    })
+    detectModuleSkills.mockRejectedValueOnce(new Error('meta scan failed'))
+
+    await expect(runSkillsCommand({
+      cwd: '/fake-dir',
+      _: [],
+      install: true,
+    })).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to scan bundled skills'))
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to scan module meta skills'))
+    expect(installModuleSkills).not.toHaveBeenCalled()
+  })
+
+  it('handles --remove failures with clean exit', async () => {
+    uninstallSkill.mockResolvedValueOnce({
+      success: false,
+      removed: [],
+      errors: [{ skill: 'missing-skill', agent: 'codex', error: 'Skill not installed' }],
+    } as any)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code: number) => {
+      throw new Error(`process.exit:${code}`)
+    }) as never)
+    const warnSpy = vi.spyOn(logger, 'warn')
+    const errorSpy = vi.spyOn(logger, 'error')
+
+    await expect(runSkillsCommand({
+      cwd: '/fake-dir',
+      _: [],
+      remove: 'missing-skill',
+    })).rejects.toThrow('process.exit:1')
+
+    expect(warnSpy).toHaveBeenCalledWith('codex: Skill not installed')
+    expect(errorSpy).toHaveBeenCalledWith('Failed to remove skill: missing-skill')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/nuxi/test/unit/commands/module/skills.spec.ts
+++ b/packages/nuxi/test/unit/commands/module/skills.spec.ts
@@ -5,8 +5,11 @@ import skillsCommand from '../../../../src/commands/module/skills'
 import { logger } from '../../../../src/utils/logger'
 
 const {
-  confirm,
+  select,
+  groupMultiselect,
+  note,
   detectModuleSkills,
+  detectInstalledAgents,
   fetchModules,
   formatSkillNames,
   getAgentDisplayNames,
@@ -21,8 +24,11 @@ const {
   log,
 } = vi.hoisted(() => {
   return {
-    confirm: vi.fn(async () => true),
+    select: vi.fn(async () => 'yes'),
+    groupMultiselect: vi.fn(async () => []),
+    note: vi.fn(),
     detectModuleSkills: vi.fn(async () => []),
+    detectInstalledAgents: vi.fn(() => [{ id: 'codex', config: { name: 'OpenAI Codex CLI', skillsDir: 'skills' } }]),
     fetchModules: vi.fn(async () => []),
     formatSkillNames: vi.fn(() => 'all'),
     getAgentDisplayNames: vi.fn(() => ['OpenAI Codex CLI (codex)']),
@@ -46,9 +52,11 @@ const {
 
 vi.mock('@clack/prompts', async () => {
   return {
-    confirm,
+    groupMultiselect,
     isCancel,
     log,
+    note,
+    select,
     spinner: () => ({
       start: spinnerStart,
       stop: spinnerStop,
@@ -64,6 +72,7 @@ vi.mock('pkg-types', async () => {
 
 vi.mock('unagent', async () => {
   return {
+    detectInstalledAgents,
     formatSkillNames,
     getAgentDisplayNames,
     getBundledSkillSources,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       ufo:
         specifier: ^1.6.3
         version: 1.6.3
+      unagent:
+        specifier: ^0.0.5
+        version: 0.0.5(unstorage@1.17.4(db0@0.3.4)(ioredis@5.9.2))
       unplugin-purge-polyfills:
         specifier: ^0.1.0
         version: 0.1.0
@@ -5213,6 +5216,7 @@ packages:
   tar@7.5.4:
     resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   terser@5.46.0:
     resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
@@ -5350,6 +5354,20 @@ packages:
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
+
+  unagent@0.0.5:
+    resolution: {integrity: sha512-k6uvvmeBCeI9i2vKCDBUNTHjRDyvAavc7yno+M9t/HplD51QzuEYPUxVVu8uYPUIFGDNcJ28jT8e71ihRusFUA==}
+    peerDependencies:
+      '@cloudflare/sandbox': '>=0.1.0'
+      '@vercel/sandbox': '>=0.1.0'
+      unstorage: '>=1.10.0'
+    peerDependenciesMeta:
+      '@cloudflare/sandbox':
+        optional: true
+      '@vercel/sandbox':
+        optional: true
+      unstorage:
+        optional: true
 
   unconfig-core@7.4.2:
     resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
@@ -11312,6 +11330,15 @@ snapshots:
   ufo@1.6.3: {}
 
   ultrahtml@1.6.0: {}
+
+  unagent@0.0.5(unstorage@1.17.4(db0@0.3.4)(ioredis@5.9.2)):
+    dependencies:
+      hookable: 5.5.3
+      pathe: 2.0.3
+      std-env: 3.10.0
+      yaml: 2.8.2
+    optionalDependencies:
+      unstorage: 1.17.4(db0@0.3.4)(ioredis@5.9.2)
 
   unconfig-core@7.4.2:
     dependencies:


### PR DESCRIPTION
- After `nuxt module add`, check if module exposes agent skills via `meta.agents.skills`
- Prompt user to install skills using `npx skills add`

```bash
PROJECT=/tmp/MiniBank
CACHEBUST="$(date +%s)"
NUXI_PKG_PR_URL="https://pkg.pr.new/nuxi@1201?cachebust=${CACHEBUST}"
BETTER_AUTH_PKG_PR_URL="https://pkg.pr.new/onmax/nuxt-better-auth/@onmax/nuxt-better-auth@89"

rm -rf "$PROJECT"

pnpm dlx nuxi@latest init "$PROJECT" \
  --template minimal \
  --packageManager pnpm \
  --gitInit false \
  --install=false \
  --no-modules

cd "$PROJECT"

pnpm install

pnpm add -D "$NUXI_PKG_PR_URL"

pnpm nuxi module add @nuxt/ui
pnpm nuxi module add @nuxt/icon

pnpm add "$BETTER_AUTH_PKG_PR_URL"
pnpm nuxi module add @onmax/nuxt-better-auth --skipInstall

pnpm nuxi module skills
pnpm nuxi module skills --list || true
```

## Related
- Depends on nuxt/nuxt#34187 (schema types)
