### PR TITLE
fix(nuxi): keep cwd at project root during preview

### DIFF
--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -1,23 +1,30 @@
-import { existsSync, promises as fsp } from 'node:fs'
-import { dirname } from 'node:path'
-import process from 'node:process'
+import { existsSync, promises as fsp } from "node:fs";
+import { dirname } from "node:path";
+import process from "node:process";
 
-import { box, outro } from '@clack/prompts'
-import { setupDotenv } from 'c12'
-import { defineCommand } from 'citty'
-import { colors } from 'consola/utils'
-import { resolve } from 'pathe'
-import { x } from 'tinyexec'
+import { box, outro } from "@clack/prompts";
+import { setupDotenv } from "c12";
+import { defineCommand } from "citty";
+import { colors } from "consola/utils";
+import { join, resolve } from "pathe";
+import { x } from "tinyexec";
 
-import { loadKit } from '../utils/kit'
-import { logger } from '../utils/logger'
-import { relativeToProcess } from '../utils/paths'
-import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { loadKit } from "../utils/kit";
+import { logger } from "../utils/logger";
+import { relativeToProcess } from "../utils/paths";
+import {
+  cwdArgs,
+  dotEnvArgs,
+  envNameArgs,
+  extendsArgs,
+  legacyRootDirArgs,
+  logLevelArgs,
+} from "./_shared";
 
 const command = defineCommand({
   meta: {
-    name: 'preview',
-    description: 'Launches Nitro server for local testing after `nuxi build`.',
+    name: "preview",
+    description: "Launches Nitro server for local testing after `nuxi build`.",
   },
   args: {
     ...cwdArgs,
@@ -26,18 +33,18 @@ const command = defineCommand({
     ...extendsArgs,
     ...legacyRootDirArgs,
     port: {
-      type: 'string',
-      description: 'Port to listen on',
-      alias: ['p'],
+      type: "string",
+      description: "Port to listen on",
+      alias: ["p"],
     },
     ...dotEnvArgs,
   },
   async run(ctx) {
-    process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+    process.env.NODE_ENV = process.env.NODE_ENV || "production";
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir);
 
-    const { loadNuxt } = await loadKit(cwd)
+    const { loadNuxt } = await loadKit(cwd);
 
     const resolvedOutputDir = await new Promise<string>((res) => {
       loadNuxt({
@@ -52,101 +59,114 @@ const command = defineCommand({
           ...(ctx.args.extends && { extends: ctx.args.extends }),
           modules: [
             function (_, nuxt) {
-              nuxt.hook('nitro:init', (nitro) => {
-                res(resolve(nuxt.options.srcDir || cwd, nitro.options.output.dir || '.output', 'nitro.json'))
-              })
+              nuxt.hook("nitro:init", (nitro) => {
+                res(
+                  resolve(
+                    nuxt.options.srcDir || cwd,
+                    nitro.options.output.dir || ".output",
+                    "nitro.json",
+                  ),
+                );
+              });
             },
           ],
         },
-      }).then(nuxt => nuxt.close()).catch(() => '')
-    })
+      })
+        .then((nuxt) => nuxt.close())
+        .catch(() => "");
+    });
 
-    const defaultOutput = resolve(cwd, '.output', 'nitro.json') // for backwards compatibility
+    const defaultOutput = resolve(cwd, ".output", "nitro.json"); // for backwards compatibility
 
-    const nitroJSONPaths = [resolvedOutputDir, defaultOutput].filter(Boolean)
-    const nitroJSONPath = nitroJSONPaths.find(p => existsSync(p))
+    const nitroJSONPaths = [resolvedOutputDir, defaultOutput].filter(Boolean);
+    const nitroJSONPath = nitroJSONPaths.find((p) => existsSync(p));
     if (!nitroJSONPath) {
       logger.error(
-        `Cannot find ${colors.cyan('nitro.json')}. Did you run ${colors.cyan('nuxi build')} first? Search path:\n${nitroJSONPaths.join('\n')}`,
-      )
-      process.exit(1)
+        `Cannot find ${colors.cyan("nitro.json")}. Did you run ${colors.cyan("nuxi build")} first? Search path:\n${nitroJSONPaths.join("\n")}`,
+      );
+      process.exit(1);
     }
-    const outputPath = dirname(nitroJSONPath)
-    const nitroJSON = JSON.parse(await fsp.readFile(nitroJSONPath, 'utf-8'))
+    const outputPath = dirname(nitroJSONPath);
+    const nitroJSON = JSON.parse(await fsp.readFile(nitroJSONPath, "utf-8"));
 
     if (!nitroJSON.commands.preview) {
-      logger.error('Preview is not supported for this build.')
-      process.exit(1)
+      logger.error("Preview is not supported for this build.");
+      process.exit(1);
     }
 
     const info = [
-      ['Node.js:', `v${process.versions.node}`],
-      ['Nitro preset:', nitroJSON.preset],
-      ['Working directory:', relativeToProcess(outputPath)],
-    ] as const
-    const _infoKeyLen = Math.max(...info.map(([label]) => label.length))
+      ["Node.js:", `v${process.versions.node}`],
+      ["Nitro preset:", nitroJSON.preset],
+      ["Working directory:", relativeToProcess(cwd)],
+    ] as const;
+    const _infoKeyLen = Math.max(...info.map(([label]) => label.length));
 
-    logger.message('')
+    logger.message("");
     box(
       [
-        '',
-        'You are previewing a Nuxt app. In production, do not use this CLI. ',
+        "",
+        "You are previewing a Nuxt app. In production, do not use this CLI. ",
         `Instead, run ${colors.cyan(nitroJSON.commands.preview)} directly.`,
-        '',
+        "",
         ...info.map(
           ([label, value]) =>
-            `${label.padEnd(_infoKeyLen, ' ')} ${colors.cyan(value)}`,
+            `${label.padEnd(_infoKeyLen, " ")} ${colors.cyan(value)}`,
         ),
-        '',
-      ].join('\n'),
-      colors.yellow(' Previewing Nuxt app '),
+        "",
+      ].join("\n"),
+      colors.yellow(" Previewing Nuxt app "),
       {
-        contentAlign: 'left',
-        titleAlign: 'left',
-        width: 'auto',
+        contentAlign: "left",
+        titleAlign: "left",
+        width: "auto",
         titlePadding: 2,
         contentPadding: 2,
         rounded: true,
         withGuide: true,
         formatBorder: (text: string) => colors.yellow(text),
       },
-    )
+    );
 
-    const envFileName = ctx.args.dotenv || '.env'
+    const envFileName = ctx.args.dotenv || ".env";
 
-    const envExists = existsSync(resolve(cwd, envFileName))
+    const envExists = existsSync(resolve(cwd, envFileName));
 
     if (envExists) {
       logger.info(
         `Loading ${colors.cyan(envFileName)}. This will not be loaded when running the server in production.`,
-      )
-      await setupDotenv({ cwd, fileName: envFileName })
+      );
+      await setupDotenv({ cwd, fileName: envFileName });
+    } else if (ctx.args.dotenv) {
+      logger.error(`Cannot find ${colors.cyan(envFileName)}.`);
     }
-    else if (ctx.args.dotenv) {
-      logger.error(`Cannot find ${colors.cyan(envFileName)}.`)
-    }
 
-    const port = ctx.args.port
-      ?? process.env.NUXT_PORT
-      ?? process.env.NITRO_PORT
-      ?? process.env.PORT
+    const port =
+      ctx.args.port ??
+      process.env.NUXT_PORT ??
+      process.env.NITRO_PORT ??
+      process.env.PORT;
 
-    outro(`Running ${colors.cyan(nitroJSON.commands.preview)} in ${colors.cyan(relativeToProcess(outputPath))}`)
+    outro(
+      `Running ${colors.cyan(nitroJSON.commands.preview)} in ${colors.cyan(relativeToProcess(cwd))}`,
+    );
 
-    const [command, ...commandArgs] = nitroJSON.commands.preview.split(' ')
-    await x(command, commandArgs, {
+    const [cmd, ...cmdArgs] = nitroJSON.commands.preview.split(" ");
+    const resolvedCmdArgs = cmdArgs.map((arg: string) =>
+      existsSync(join(outputPath, arg)) ? join(outputPath, arg) : arg,
+    );
+    await x(cmd, resolvedCmdArgs, {
       throwOnError: true,
       nodeOptions: {
-        stdio: 'inherit',
-        cwd: outputPath,
+        stdio: "inherit",
+        cwd,
         env: {
           ...process.env,
           NUXT_PORT: port,
           NITRO_PORT: port,
         },
       },
-    })
+    });
   },
-})
+});
 
-export default command
+export default command;

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -1,17 +1,17 @@
-import { existsSync, promises as fsp } from "node:fs";
-import { dirname } from "node:path";
-import process from "node:process";
+import { existsSync, promises as fsp } from 'node:fs'
+import { dirname } from 'node:path'
+import process from 'node:process'
 
-import { box, outro } from "@clack/prompts";
-import { setupDotenv } from "c12";
-import { defineCommand } from "citty";
-import { colors } from "consola/utils";
-import { join, resolve } from "pathe";
-import { x } from "tinyexec";
+import { box, outro } from '@clack/prompts'
+import { setupDotenv } from 'c12'
+import { defineCommand } from 'citty'
+import { colors } from 'consola/utils'
+import { join, resolve } from 'pathe'
+import { x } from 'tinyexec'
 
-import { loadKit } from "../utils/kit";
-import { logger } from "../utils/logger";
-import { relativeToProcess } from "../utils/paths";
+import { loadKit } from '../utils/kit'
+import { logger } from '../utils/logger'
+import { relativeToProcess } from '../utils/paths'
 import {
   cwdArgs,
   dotEnvArgs,
@@ -19,12 +19,12 @@ import {
   extendsArgs,
   legacyRootDirArgs,
   logLevelArgs,
-} from "./_shared";
+} from './_shared'
 
 const command = defineCommand({
   meta: {
-    name: "preview",
-    description: "Launches Nitro server for local testing after `nuxi build`.",
+    name: 'preview',
+    description: 'Launches Nitro server for local testing after `nuxi build`.',
   },
   args: {
     ...cwdArgs,
@@ -33,18 +33,18 @@ const command = defineCommand({
     ...extendsArgs,
     ...legacyRootDirArgs,
     port: {
-      type: "string",
-      description: "Port to listen on",
-      alias: ["p"],
+      type: 'string',
+      description: 'Port to listen on',
+      alias: ['p'],
     },
     ...dotEnvArgs,
   },
   async run(ctx) {
-    process.env.NODE_ENV = process.env.NODE_ENV || "production";
+    process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir);
+    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
-    const { loadNuxt } = await loadKit(cwd);
+    const { loadNuxt } = await loadKit(cwd)
 
     const resolvedOutputDir = await new Promise<string>((res) => {
       loadNuxt({
@@ -59,105 +59,106 @@ const command = defineCommand({
           ...(ctx.args.extends && { extends: ctx.args.extends }),
           modules: [
             function (_, nuxt) {
-              nuxt.hook("nitro:init", (nitro) => {
+              nuxt.hook('nitro:init', (nitro) => {
                 res(
                   resolve(
                     nuxt.options.srcDir || cwd,
-                    nitro.options.output.dir || ".output",
-                    "nitro.json",
+                    nitro.options.output.dir || '.output',
+                    'nitro.json',
                   ),
-                );
-              });
+                )
+              })
             },
           ],
         },
       })
-        .then((nuxt) => nuxt.close())
-        .catch(() => "");
-    });
+        .then(nuxt => nuxt.close())
+        .catch(() => '')
+    })
 
-    const defaultOutput = resolve(cwd, ".output", "nitro.json"); // for backwards compatibility
+    const defaultOutput = resolve(cwd, '.output', 'nitro.json') // for backwards compatibility
 
-    const nitroJSONPaths = [resolvedOutputDir, defaultOutput].filter(Boolean);
-    const nitroJSONPath = nitroJSONPaths.find((p) => existsSync(p));
+    const nitroJSONPaths = [resolvedOutputDir, defaultOutput].filter(Boolean)
+    const nitroJSONPath = nitroJSONPaths.find(p => existsSync(p))
     if (!nitroJSONPath) {
       logger.error(
-        `Cannot find ${colors.cyan("nitro.json")}. Did you run ${colors.cyan("nuxi build")} first? Search path:\n${nitroJSONPaths.join("\n")}`,
-      );
-      process.exit(1);
+        `Cannot find ${colors.cyan('nitro.json')}. Did you run ${colors.cyan('nuxi build')} first? Search path:\n${nitroJSONPaths.join('\n')}`,
+      )
+      process.exit(1)
     }
-    const outputPath = dirname(nitroJSONPath);
-    const nitroJSON = JSON.parse(await fsp.readFile(nitroJSONPath, "utf-8"));
+    const outputPath = dirname(nitroJSONPath)
+    const nitroJSON = JSON.parse(await fsp.readFile(nitroJSONPath, 'utf-8'))
 
     if (!nitroJSON.commands.preview) {
-      logger.error("Preview is not supported for this build.");
-      process.exit(1);
+      logger.error('Preview is not supported for this build.')
+      process.exit(1)
     }
 
     const info = [
-      ["Node.js:", `v${process.versions.node}`],
-      ["Nitro preset:", nitroJSON.preset],
-      ["Working directory:", relativeToProcess(cwd)],
-    ] as const;
-    const _infoKeyLen = Math.max(...info.map(([label]) => label.length));
+      ['Node.js:', `v${process.versions.node}`],
+      ['Nitro preset:', nitroJSON.preset],
+      ['Working directory:', relativeToProcess(cwd)],
+    ] as const
+    const _infoKeyLen = Math.max(...info.map(([label]) => label.length))
 
-    logger.message("");
+    logger.message('')
     box(
       [
-        "",
-        "You are previewing a Nuxt app. In production, do not use this CLI. ",
+        '',
+        'You are previewing a Nuxt app. In production, do not use this CLI. ',
         `Instead, run ${colors.cyan(nitroJSON.commands.preview)} directly.`,
-        "",
+        '',
         ...info.map(
           ([label, value]) =>
-            `${label.padEnd(_infoKeyLen, " ")} ${colors.cyan(value)}`,
+            `${label.padEnd(_infoKeyLen, ' ')} ${colors.cyan(value)}`,
         ),
-        "",
-      ].join("\n"),
-      colors.yellow(" Previewing Nuxt app "),
+        '',
+      ].join('\n'),
+      colors.yellow(' Previewing Nuxt app '),
       {
-        contentAlign: "left",
-        titleAlign: "left",
-        width: "auto",
+        contentAlign: 'left',
+        titleAlign: 'left',
+        width: 'auto',
         titlePadding: 2,
         contentPadding: 2,
         rounded: true,
         withGuide: true,
         formatBorder: (text: string) => colors.yellow(text),
       },
-    );
+    )
 
-    const envFileName = ctx.args.dotenv || ".env";
+    const envFileName = ctx.args.dotenv || '.env'
 
-    const envExists = existsSync(resolve(cwd, envFileName));
+    const envExists = existsSync(resolve(cwd, envFileName))
 
     if (envExists) {
       logger.info(
         `Loading ${colors.cyan(envFileName)}. This will not be loaded when running the server in production.`,
-      );
-      await setupDotenv({ cwd, fileName: envFileName });
-    } else if (ctx.args.dotenv) {
-      logger.error(`Cannot find ${colors.cyan(envFileName)}.`);
+      )
+      await setupDotenv({ cwd, fileName: envFileName })
+    }
+    else if (ctx.args.dotenv) {
+      logger.error(`Cannot find ${colors.cyan(envFileName)}.`)
     }
 
-    const port =
-      ctx.args.port ??
-      process.env.NUXT_PORT ??
-      process.env.NITRO_PORT ??
-      process.env.PORT;
+    const port
+      = ctx.args.port
+        ?? process.env.NUXT_PORT
+        ?? process.env.NITRO_PORT
+        ?? process.env.PORT
 
     outro(
       `Running ${colors.cyan(nitroJSON.commands.preview)} in ${colors.cyan(relativeToProcess(cwd))}`,
-    );
+    )
 
-    const [cmd, ...cmdArgs] = nitroJSON.commands.preview.split(" ");
+    const [cmd, ...cmdArgs] = nitroJSON.commands.preview.split(' ')
     const resolvedCmdArgs = cmdArgs.map((arg: string) =>
       existsSync(join(outputPath, arg)) ? join(outputPath, arg) : arg,
-    );
+    )
     await x(cmd, resolvedCmdArgs, {
       throwOnError: true,
       nodeOptions: {
-        stdio: "inherit",
+        stdio: 'inherit',
         cwd,
         env: {
           ...process.env,
@@ -165,8 +166,8 @@ const command = defineCommand({
           NITRO_PORT: port,
         },
       },
-    });
+    })
   },
-});
+})
 
-export default command;
+export default command


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/cli#1368

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

`nuxt preview` was spawning the server with `cwd` set to the `.output` directory, 
which means `process.cwd()` inside server handlers returns `.output` instead of 
the project root. This is inconsistent with running `node .output/server/index.mjs` 
directly, which keeps the cwd at project root.

The fix keeps `cwd` as the project root when spawning the preview server, and 
resolves the server entrypoint args to absolute paths using `outputPath` so they 
work without needing a chdir.