### PR TITLE
feat(cli): locks for agents running dev and build commands

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -9,7 +9,7 @@ import { showVersions } from '../utils/banner'
 import { overrideEnv } from '../utils/env'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
-import { checkLock, formatLockError, writeLock } from '../utils/lockfile'
+import { acquireLock, formatLockError } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile'
 import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs, profileArgs } from './_shared'
@@ -47,7 +47,7 @@ export default defineCommand({
       await startCpuProfile()
     }
 
-    let lockCleanup: (() => void) | undefined
+    let releaseLock: (() => void) | undefined
     try {
       intro(colors.cyan('Building Nuxt for production...'))
 
@@ -81,12 +81,15 @@ export default defineCommand({
         },
       })
 
-      // Check for an existing process using the lock file (agent-only)
-      const existing = checkLock(nuxt.options.buildDir)
-      if (existing) {
-        console.error(formatLockError(existing, cwd))
-        process.exit(1)
+      const lock = acquireLock(nuxt.options.buildDir, {
+        command: 'build',
+        cwd,
+      })
+      if (lock.existing) {
+        logger.error(formatLockError(lock.existing))
+        throw new Error(`Another Nuxt ${lock.existing.command} is already running (PID ${lock.existing.pid}).`)
       }
+      releaseLock = lock.release
 
       let nitro: ReturnType<typeof kit.useNitro> | undefined
       // In Bridge, if Nitro is not enabled, useNitro will throw an error
@@ -102,13 +105,6 @@ export default defineCommand({
       }
 
       await clearBuildDir(nuxt.options.buildDir)
-
-      // Write lock after clearing build dir so it doesn't get deleted
-      lockCleanup = await writeLock(nuxt.options.buildDir, {
-        pid: process.pid,
-        command: 'build',
-        startedAt: Date.now(),
-      })
 
       await kit.writeTypes(nuxt)
 
@@ -137,7 +133,7 @@ export default defineCommand({
       }
     }
     finally {
-      lockCleanup?.()
+      releaseLock?.()
       if (profileArg) {
         await stopCpuProfile(cwd, 'build')
       }

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -9,6 +9,7 @@ import { showVersions } from '../utils/banner'
 import { overrideEnv } from '../utils/env'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
+import { checkLock, formatLockError, writeLock } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile'
 import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs, profileArgs } from './_shared'
@@ -46,6 +47,7 @@ export default defineCommand({
       await startCpuProfile()
     }
 
+    let lockCleanup: (() => void) | undefined
     try {
       intro(colors.cyan('Building Nuxt for production...'))
 
@@ -77,6 +79,18 @@ export default defineCommand({
             },
           }),
         },
+      })
+
+      // Check for an existing process using the lock file (agent-only)
+      const existing = checkLock(nuxt.options.buildDir)
+      if (existing) {
+        console.error(formatLockError(existing, cwd))
+        process.exit(1)
+      }
+      lockCleanup = await writeLock(nuxt.options.buildDir, {
+        pid: process.pid,
+        command: 'build',
+        startedAt: Date.now(),
       })
 
       let nitro: ReturnType<typeof kit.useNitro> | undefined
@@ -121,6 +135,7 @@ export default defineCommand({
       }
     }
     finally {
+      lockCleanup?.()
       if (profileArg) {
         await stopCpuProfile(cwd, 'build')
       }

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -87,11 +87,6 @@ export default defineCommand({
         console.error(formatLockError(existing, cwd))
         process.exit(1)
       }
-      lockCleanup = await writeLock(nuxt.options.buildDir, {
-        pid: process.pid,
-        command: 'build',
-        startedAt: Date.now(),
-      })
 
       let nitro: ReturnType<typeof kit.useNitro> | undefined
       // In Bridge, if Nitro is not enabled, useNitro will throw an error
@@ -107,6 +102,13 @@ export default defineCommand({
       }
 
       await clearBuildDir(nuxt.options.buildDir)
+
+      // Write lock after clearing build dir so it doesn't get deleted
+      lockCleanup = await writeLock(nuxt.options.buildDir, {
+        pid: process.pid,
+        command: 'build',
+        startedAt: Date.now(),
+      })
 
       await kit.writeTypes(nuxt)
 

--- a/packages/nuxi/src/dev/index.ts
+++ b/packages/nuxi/src/dev/index.ts
@@ -138,6 +138,7 @@ export async function initialize(devContext: NuxtDevContext, ctx: InitializeOpti
         devServer.listener.close(),
         devServer.close(),
       ])
+      devServer.releaseLock()
     },
     onReady: (callback: (address: string) => void) => {
       if (address) {

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -25,6 +25,7 @@ import { joinURL } from 'ufo'
 import { showVersionsFromConfig } from '../utils/banner'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
+import { checkLock, formatLockError, writeLock } from '../utils/lockfile'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
 import { withNodePath } from '../utils/paths'
 import { renderError } from './error'
@@ -131,6 +132,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   #fileChangeTracker = new FileChangeTracker()
   #cwd: string
   #websocketConnections = new Set<any>()
+  #lockCleanup?: () => void
 
   loadDebounced: (reload?: boolean, reason?: string) => void
   handler: RequestListener
@@ -193,6 +195,14 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     this.emit('loading', this.#loadingMessage)
 
     await this.#loadNuxtInstance()
+
+    // Check for an existing process using the lock file (agent-only)
+    const buildDir = this.#currentNuxt!.options.buildDir
+    const existing = checkLock(buildDir)
+    if (existing) {
+      console.error(formatLockError(existing, this.options.cwd))
+      process.exit(1)
+    }
 
     if (this.options.showBanner) {
       showVersionsFromConfig(this.options.cwd, this.#currentNuxt!.options)
@@ -459,10 +469,24 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
     // Emit ready with the server URL
     const proto = this.listener.https ? 'https' : 'http'
-    this.emit('ready', `${proto}://127.0.0.1:${addr.port}`)
+    const serverUrl = `${proto}://127.0.0.1:${addr.port}`
+
+    // Write lock file so other processes know a dev server is running (agent-only)
+    this.#lockCleanup?.()
+    this.#lockCleanup = await writeLock(this.#currentNuxt.options.buildDir, {
+      pid: process.pid,
+      command: 'dev',
+      port: addr.port,
+      hostname: addr.address,
+      url: serverUrl,
+      startedAt: Date.now(),
+    })
+
+    this.emit('ready', serverUrl)
   }
 
   async close(): Promise<void> {
+    this.#lockCleanup?.()
     if (this.#currentNuxt) {
       await this.#currentNuxt.close()
     }

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -486,10 +486,14 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   }
 
   async close(): Promise<void> {
-    this.#lockCleanup?.()
     if (this.#currentNuxt) {
       await this.#currentNuxt.close()
     }
+  }
+
+  /** Release the lock file. Call only on final shutdown, not during reloads. */
+  releaseLock(): void {
+    this.#lockCleanup?.()
   }
 
   #closeWebSocketConnections(): void {

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -25,7 +25,7 @@ import { joinURL } from 'ufo'
 import { showVersionsFromConfig } from '../utils/banner'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
-import { checkLock, formatLockError, writeLock } from '../utils/lockfile'
+import { acquireLock, formatLockError, updateLock } from '../utils/lockfile'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
 import { withNodePath } from '../utils/paths'
 import { renderError } from './error'
@@ -67,6 +67,7 @@ interface NuxtDevServerOptions {
 
 // https://regex101.com/r/7HkR5c/1
 const RESTART_RE = /^(?:nuxt\.config\.[a-z0-9]+|\.nuxtignore|\.nuxtrc|\.config\/nuxt(?:\.config)?\.[a-z0-9]+)$/
+const TRAILING_SLASH_RE = /\/$/
 
 export class FileChangeTracker {
   private mtimes = new Map<string, number>()
@@ -196,13 +197,18 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
     await this.#loadNuxtInstance()
 
-    // Check for an existing process using the lock file (agent-only)
+    // Acquire lock before binding a listener so parallel agent invocations
+    // fail fast without starting a second server (agent-only).
     const buildDir = this.#currentNuxt!.options.buildDir
-    const existing = checkLock(buildDir)
-    if (existing) {
-      console.error(formatLockError(existing, this.options.cwd))
-      process.exit(1)
+    const lock = acquireLock(buildDir, {
+      command: 'dev',
+      cwd: this.options.cwd,
+    })
+    if (lock.existing) {
+      console.error(formatLockError(lock.existing))
+      throw new Error(`Another Nuxt ${lock.existing.command} is already running (PID ${lock.existing.pid}).`)
     }
+    this.#lockCleanup = lock.release
 
     if (this.options.showBanner) {
       showVersionsFromConfig(this.options.cwd, this.#currentNuxt!.options)
@@ -468,18 +474,16 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     }
 
     // Emit ready with the server URL
-    const proto = this.listener.https ? 'https' : 'http'
-    const serverUrl = `${proto}://127.0.0.1:${addr.port}`
+    const serverUrl = getAddressURL(addr, !!this.listener.https).replace(TRAILING_SLASH_RE, '')
 
-    // Write lock file so other processes know a dev server is running (agent-only)
-    this.#lockCleanup?.()
-    this.#lockCleanup = await writeLock(this.#currentNuxt.options.buildDir, {
-      pid: process.pid,
+    // Update our existing lock with port/url info now that the listener is up.
+    // Overwrites in place (no release/reacquire window) on reload.
+    updateLock(this.#currentNuxt.options.buildDir, {
       command: 'dev',
+      cwd: this.options.cwd,
       port: addr.port,
       hostname: addr.address,
       url: serverUrl,
-      startedAt: Date.now(),
     })
 
     this.emit('ready', serverUrl)

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -134,6 +134,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   #cwd: string
   #websocketConnections = new Set<any>()
   #lockCleanup?: () => void
+  #lockedBuildDir?: string
 
   loadDebounced: (reload?: boolean, reason?: string) => void
   handler: RequestListener
@@ -199,16 +200,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
     // Acquire lock before binding a listener so parallel agent invocations
     // fail fast without starting a second server (agent-only).
-    const buildDir = this.#currentNuxt!.options.buildDir
-    const lock = acquireLock(buildDir, {
-      command: 'dev',
-      cwd: this.options.cwd,
-    })
-    if (lock.existing) {
-      console.error(formatLockError(lock.existing))
-      throw new Error(`Another Nuxt ${lock.existing.command} is already running (PID ${lock.existing.pid}).`)
-    }
-    this.#lockCleanup = lock.release
+    this.#acquireDevLock(this.#currentNuxt!.options.buildDir)
 
     if (this.options.showBanner) {
       showVersionsFromConfig(this.options.cwd, this.#currentNuxt!.options)
@@ -476,9 +468,13 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     // Emit ready with the server URL
     const serverUrl = getAddressURL(addr, !!this.listener.https).replace(TRAILING_SLASH_RE, '')
 
-    // Update our existing lock with port/url info now that the listener is up.
-    // Overwrites in place (no release/reacquire window) on reload.
-    updateLock(this.#currentNuxt.options.buildDir, {
+    // Re-acquire if buildDir changed (nuxt.config edits can move it on reload);
+    // otherwise just overwrite port/url in place.
+    const currentBuildDir = this.#currentNuxt.options.buildDir
+    if (this.#lockedBuildDir !== currentBuildDir) {
+      this.#acquireDevLock(currentBuildDir)
+    }
+    updateLock(currentBuildDir, {
       command: 'dev',
       cwd: this.options.cwd,
       port: addr.port,
@@ -498,6 +494,25 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   /** Release the lock file. Call only on final shutdown, not during reloads. */
   releaseLock(): void {
     this.#lockCleanup?.()
+    this.#lockCleanup = undefined
+    this.#lockedBuildDir = undefined
+  }
+
+  #acquireDevLock(buildDir: string): void {
+    const lock = acquireLock(buildDir, {
+      command: 'dev',
+      cwd: this.options.cwd,
+    })
+    if (lock.existing) {
+      console.error(formatLockError(lock.existing))
+      throw new Error(`Another Nuxt ${lock.existing.command} is already running (PID ${lock.existing.pid}).`)
+    }
+    // Swap atomically: install the new release before freeing the old one so
+    // we're never unlocked in between.
+    const previousRelease = this.#lockCleanup
+    this.#lockCleanup = lock.release
+    this.#lockedBuildDir = buildDir
+    previousRelease?.()
   }
 
   #closeWebSocketConnections(): void {

--- a/packages/nuxi/src/utils/fs.ts
+++ b/packages/nuxi/src/utils/fs.ts
@@ -20,7 +20,7 @@ export async function clearDir(path: string, exclude?: string[]) {
 }
 
 export function clearBuildDir(path: string) {
-  return clearDir(path, ['cache', 'analyze', 'nuxt.json'])
+  return clearDir(path, ['cache', 'analyze', 'nuxt.json', 'nuxt.lock'])
 }
 
 export async function rmRecursive(paths: string[]) {

--- a/packages/nuxi/src/utils/lockfile.ts
+++ b/packages/nuxi/src/utils/lockfile.ts
@@ -1,149 +1,190 @@
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { mkdir } from 'node:fs/promises'
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
-import { dirname, join } from 'pathe'
+import { join } from 'pathe'
 import { isAgent } from 'std-env'
 
 interface LockInfo {
   pid: number
   startedAt: number
   command: 'dev' | 'build'
+  cwd: string
   port?: number
   hostname?: string
   url?: string
 }
 
 const LOCK_FILENAME = 'nuxt.lock'
+// PID recycling safety net. Locks older than this cannot be trusted because a
+// recycled PID could match a dead build's record.
+const MAX_LOCK_AGE_MS = 24 * 60 * 60 * 1000
 
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0)
     return true
   }
-  catch {
-    return false
+  catch (err) {
+    // EPERM means the process exists but we can't signal it (different user).
+    // Treat it as alive so we don't clobber locks held by other accounts.
+    return (err as NodeJS.ErrnoException).code === 'EPERM'
   }
 }
 
 function readLockFile(lockPath: string): LockInfo | undefined {
   try {
-    const content = readFileSync(lockPath, 'utf-8')
-    return JSON.parse(content) as LockInfo
+    return JSON.parse(readFileSync(lockPath, 'utf-8')) as LockInfo
   }
   catch {
     return undefined
   }
 }
 
-function isLockEnabled(): boolean {
-  return isAgent && !process.env.NUXT_IGNORE_LOCK
-}
-
-/**
- * Check if a Nuxt process is already running for this project.
- * Only active when running inside an AI agent environment.
- * Set NUXT_IGNORE_LOCK=1 to bypass.
- * Stale lock files (from crashed processes) are automatically cleaned up.
- */
-export function checkLock(buildDir: string): LockInfo | undefined {
-  if (!isLockEnabled()) {
-    return undefined
-  }
-
-  const lockPath = join(buildDir, LOCK_FILENAME)
-
-  if (!existsSync(lockPath)) {
-    return undefined
-  }
-
-  const info = readLockFile(lockPath)
-  if (!info) {
-    try {
-      unlinkSync(lockPath)
-    }
-    catch {}
-    return undefined
-  }
-
-  if (!isProcessAlive(info.pid)) {
-    try {
-      unlinkSync(lockPath)
-    }
-    catch {}
-    return undefined
-  }
-
-  // Don't block ourselves (fork pool scenario)
-  if (info.pid === process.pid) {
-    return undefined
-  }
-
-  return info
-}
-
-/**
- * Write a lock file atomically. Returns a cleanup function.
- * Only writes when running inside an AI agent environment.
- * Uses exclusive file creation (`wx` flag) to prevent race conditions.
- */
-export async function writeLock(buildDir: string, info: LockInfo): Promise<() => void> {
-  const noop = () => {}
-  if (!isLockEnabled()) {
-    return noop
-  }
-
-  const lockPath = join(buildDir, LOCK_FILENAME)
-
-  await mkdir(dirname(lockPath), { recursive: true })
-
+function tryUnlink(lockPath: string): void {
   try {
-    writeFileSync(lockPath, JSON.stringify(info, null, 2), { flag: 'wx' })
+    unlinkSync(lockPath)
   }
-  catch (error) {
-    // Lock already exists, another process won the race
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      return noop
-    }
-    throw error
+  catch {}
+}
+
+function isLockActive(info: LockInfo): boolean {
+  if (info.pid === process.pid) {
+    return false
+  }
+  if (!isProcessAlive(info.pid)) {
+    return false
+  }
+  if (Date.now() - info.startedAt > MAX_LOCK_AGE_MS) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Locking is enabled for agents by default. `NUXT_LOCK=1` forces it on for
+ * non-agents; `NUXT_IGNORE_LOCK=1` forces it off.
+ */
+export function isLockEnabled(): boolean {
+  if (process.env.NUXT_IGNORE_LOCK) {
+    return false
+  }
+  if (process.env.NUXT_LOCK === '1' || process.env.NUXT_LOCK === 'true') {
+    return true
+  }
+  return isAgent
+}
+
+type LockResult
+  = | { existing?: undefined, release: () => void }
+    | { existing: LockInfo, release?: undefined }
+
+/**
+ * Atomically acquire a build/dev lock.
+ * Returns `{ existing }` if another live process holds the lock, otherwise
+ * `{ release }` to be invoked on shutdown. No-op when locking is disabled.
+ */
+export function acquireLock(
+  buildDir: string,
+  info: Omit<LockInfo, 'pid' | 'startedAt'>,
+): LockResult {
+  if (!isLockEnabled()) {
+    return { release: () => {} }
   }
 
-  let cleaned = false
-  const exitHandler = () => cleanup()
-  const signalHandlers: Array<[string, () => void]> = []
+  const lockPath = join(buildDir, LOCK_FILENAME)
+  const fullInfo: LockInfo = {
+    pid: process.pid,
+    startedAt: Date.now(),
+    ...info,
+  }
 
-  function cleanup() {
-    if (cleaned)
-      return
-    cleaned = true
-    process.off('exit', exitHandler)
-    for (const [signal, handler] of signalHandlers) {
-      process.off(signal, handler)
-    }
+  // Try exclusive-create up to twice: the first attempt may race with a stale
+  // lock that we then clean up and retry.
+  for (let attempt = 0; attempt < 2; attempt++) {
     try {
-      unlinkSync(lockPath)
+      writeFileSync(lockPath, JSON.stringify(fullInfo, null, 2), { flag: 'wx' })
+      return { release: makeRelease(lockPath) }
     }
-    catch {}
+    catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw err
+      }
+      const existing = readLockFile(lockPath)
+      if (existing && isLockActive(existing)) {
+        return { existing }
+      }
+      // Stale, corrupted, or self-owned; remove and retry.
+      tryUnlink(lockPath)
+    }
   }
 
-  process.on('exit', exitHandler)
-  for (const signal of ['SIGTERM', 'SIGINT', 'SIGQUIT', 'SIGHUP'] as const) {
-    const handler = () => {
-      cleanup()
-      process.exit()
+  // Two failures in a row; surface whatever we can read.
+  const existing = readLockFile(lockPath)
+  if (existing && isLockActive(existing)) {
+    return { existing }
+  }
+  return { release: () => {} }
+}
+
+/**
+ * Overwrite an existing lock we already own with updated metadata (e.g. port
+ * information learned after the listener binds). Callers must hold the lock
+ * via a prior successful `acquireLock`. Does nothing when locking is disabled.
+ */
+export function updateLock(
+  buildDir: string,
+  info: Omit<LockInfo, 'pid' | 'startedAt'>,
+): void {
+  if (!isLockEnabled()) {
+    return
+  }
+  const lockPath = join(buildDir, LOCK_FILENAME)
+  const current = readLockFile(lockPath)
+  // Only overwrite our own lock; never touch another process's file.
+  if (current && current.pid !== process.pid) {
+    return
+  }
+  const next: LockInfo = {
+    pid: process.pid,
+    startedAt: current?.startedAt ?? Date.now(),
+    ...info,
+  }
+  try {
+    writeFileSync(lockPath, JSON.stringify(next, null, 2))
+  }
+  catch {}
+}
+
+function makeRelease(lockPath: string): () => void {
+  let released = false
+
+  function release(): void {
+    if (released) {
+      return
     }
-    signalHandlers.push([signal, handler])
-    process.once(signal, handler)
+    released = true
+    process.off('exit', release)
+    const current = readLockFile(lockPath)
+    if (!current || current.pid === process.pid) {
+      tryUnlink(lockPath)
+    }
   }
 
-  return cleanup
+  // `exit` fires on normal termination, including after Node's default signal
+  // handling (SIGINT → exit 130) when no custom signal handler runs. We
+  // deliberately do not install SIGINT/SIGTERM listeners: that would suppress
+  // Node's default signal behavior and other shutdown logic, which was the
+  // cause of the earlier review concern.
+  process.on('exit', release)
+
+  return release
 }
 
 /**
  * Format an error message when a Nuxt process is already running.
  * Designed to be actionable for both humans and LLM agents.
  */
-export function formatLockError(info: LockInfo, cwd: string): string {
+export function formatLockError(info: LockInfo): string {
   const isWindows = process.platform === 'win32'
   const killCmd = isWindows ? `taskkill /PID ${info.pid} /F` : `kill ${info.pid}`
   const label = info.command === 'dev' ? 'dev server' : 'build'
@@ -158,7 +199,7 @@ export function formatLockError(info: LockInfo, cwd: string): string {
     lines.push(`  URL:     ${info.url}`)
   }
   lines.push(`  PID:     ${info.pid}`)
-  lines.push(`  Dir:     ${cwd}`)
+  lines.push(`  Dir:     ${info.cwd}`)
   lines.push(`  Started: ${new Date(info.startedAt).toLocaleString()}`)
   lines.push('')
 

--- a/packages/nuxi/src/utils/lockfile.ts
+++ b/packages/nuxi/src/utils/lockfile.ts
@@ -1,0 +1,149 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdir } from 'node:fs/promises'
+import process from 'node:process'
+
+import { dirname, join } from 'pathe'
+import { isAgent } from 'std-env'
+
+export interface LockInfo {
+  pid: number
+  startedAt: number
+  command: 'dev' | 'build'
+  port?: number
+  hostname?: string
+  url?: string
+}
+
+const LOCK_FILENAME = 'nuxt.lock'
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+function readLockFile(lockPath: string): LockInfo | undefined {
+  try {
+    const content = readFileSync(lockPath, 'utf-8')
+    return JSON.parse(content) as LockInfo
+  }
+  catch {
+    return undefined
+  }
+}
+
+/**
+ * Check if a Nuxt process is already running for this project.
+ * Only active when running inside an AI agent environment.
+ * Stale lock files (from crashed processes) are automatically cleaned up.
+ */
+export function checkLock(buildDir: string): LockInfo | undefined {
+  if (!isAgent) {
+    return undefined
+  }
+
+  const lockPath = join(buildDir, LOCK_FILENAME)
+
+  if (!existsSync(lockPath)) {
+    return undefined
+  }
+
+  const info = readLockFile(lockPath)
+  if (!info) {
+    try {
+      unlinkSync(lockPath)
+    }
+    catch {}
+    return undefined
+  }
+
+  if (!isProcessAlive(info.pid)) {
+    try {
+      unlinkSync(lockPath)
+    }
+    catch {}
+    return undefined
+  }
+
+  // Don't block ourselves (fork pool scenario)
+  if (info.pid === process.pid) {
+    return undefined
+  }
+
+  return info
+}
+
+/**
+ * Write a lock file. Returns a cleanup function.
+ * Only writes when running inside an AI agent environment.
+ */
+export async function writeLock(buildDir: string, info: LockInfo): Promise<() => void> {
+  const noop = () => {}
+  if (!isAgent) {
+    return noop
+  }
+
+  const lockPath = join(buildDir, LOCK_FILENAME)
+
+  await mkdir(dirname(lockPath), { recursive: true })
+  writeFileSync(lockPath, JSON.stringify(info, null, 2))
+
+  let cleaned = false
+  function cleanup() {
+    if (cleaned)
+      return
+    cleaned = true
+    try {
+      unlinkSync(lockPath)
+    }
+    catch {}
+  }
+
+  process.on('exit', cleanup)
+  for (const signal of ['SIGTERM', 'SIGINT', 'SIGQUIT', 'SIGHUP'] as const) {
+    process.once(signal, () => {
+      cleanup()
+      process.exit()
+    })
+  }
+
+  return cleanup
+}
+
+/**
+ * Format an error message when a Nuxt process is already running.
+ * Designed to be actionable for both humans and LLM agents.
+ */
+export function formatLockError(info: LockInfo, cwd: string): string {
+  const isWindows = process.platform === 'win32'
+  const killCmd = isWindows ? `taskkill /PID ${info.pid} /F` : `kill ${info.pid}`
+  const label = info.command === 'dev' ? 'dev server' : 'build'
+
+  const lines = [
+    '',
+    `Another Nuxt ${label} is already running:`,
+    '',
+  ]
+
+  if (info.url) {
+    lines.push(`  URL:     ${info.url}`)
+  }
+  lines.push(`  PID:     ${info.pid}`)
+  lines.push(`  Dir:     ${cwd}`)
+  lines.push(`  Started: ${new Date(info.startedAt).toLocaleString()}`)
+  lines.push('')
+
+  if (info.command === 'dev' && info.url) {
+    lines.push(`Run \`${killCmd}\` to stop it, or connect to ${info.url}`)
+  }
+  else {
+    lines.push(`Run \`${killCmd}\` to stop it.`)
+  }
+  lines.push('')
+
+  return lines.join('\n')
+}

--- a/packages/nuxi/src/utils/lockfile.ts
+++ b/packages/nuxi/src/utils/lockfile.ts
@@ -83,8 +83,9 @@ export function checkLock(buildDir: string): LockInfo | undefined {
 }
 
 /**
- * Write a lock file. Returns a cleanup function.
+ * Write a lock file atomically. Returns a cleanup function.
  * Only writes when running inside an AI agent environment.
+ * Uses exclusive file creation (`wx` flag) to prevent race conditions.
  */
 export async function writeLock(buildDir: string, info: LockInfo): Promise<() => void> {
   const noop = () => {}
@@ -95,25 +96,44 @@ export async function writeLock(buildDir: string, info: LockInfo): Promise<() =>
   const lockPath = join(buildDir, LOCK_FILENAME)
 
   await mkdir(dirname(lockPath), { recursive: true })
-  writeFileSync(lockPath, JSON.stringify(info, null, 2))
+
+  try {
+    writeFileSync(lockPath, JSON.stringify(info, null, 2), { flag: 'wx' })
+  }
+  catch (error) {
+    // Lock already exists, another process won the race
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return noop
+    }
+    throw error
+  }
 
   let cleaned = false
+  const exitHandler = () => cleanup()
+  const signalHandlers: Array<[string, () => void]> = []
+
   function cleanup() {
     if (cleaned)
       return
     cleaned = true
+    process.off('exit', exitHandler)
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler)
+    }
     try {
       unlinkSync(lockPath)
     }
     catch {}
   }
 
-  process.on('exit', cleanup)
+  process.on('exit', exitHandler)
   for (const signal of ['SIGTERM', 'SIGINT', 'SIGQUIT', 'SIGHUP'] as const) {
-    process.once(signal, () => {
+    const handler = () => {
       cleanup()
       process.exit()
-    })
+    }
+    signalHandlers.push([signal, handler])
+    process.once(signal, handler)
   }
 
   return cleanup

--- a/packages/nuxi/src/utils/lockfile.ts
+++ b/packages/nuxi/src/utils/lockfile.ts
@@ -36,13 +36,18 @@ function readLockFile(lockPath: string): LockInfo | undefined {
   }
 }
 
+function isLockEnabled(): boolean {
+  return isAgent && !process.env.NUXT_IGNORE_LOCK
+}
+
 /**
  * Check if a Nuxt process is already running for this project.
  * Only active when running inside an AI agent environment.
+ * Set NUXT_IGNORE_LOCK=1 to bypass.
  * Stale lock files (from crashed processes) are automatically cleaned up.
  */
 export function checkLock(buildDir: string): LockInfo | undefined {
-  if (!isAgent) {
+  if (!isLockEnabled()) {
     return undefined
   }
 
@@ -83,7 +88,7 @@ export function checkLock(buildDir: string): LockInfo | undefined {
  */
 export async function writeLock(buildDir: string, info: LockInfo): Promise<() => void> {
   const noop = () => {}
-  if (!isAgent) {
+  if (!isLockEnabled()) {
     return noop
   }
 
@@ -143,6 +148,7 @@ export function formatLockError(info: LockInfo, cwd: string): string {
   else {
     lines.push(`Run \`${killCmd}\` to stop it.`)
   }
+  lines.push(`Set NUXT_IGNORE_LOCK=1 to bypass this check.`)
   lines.push('')
 
   return lines.join('\n')

--- a/packages/nuxi/src/utils/lockfile.ts
+++ b/packages/nuxi/src/utils/lockfile.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 import { dirname, join } from 'pathe'
 import { isAgent } from 'std-env'
 
-export interface LockInfo {
+interface LockInfo {
   pid: number
   startedAt: number
   command: 'dev' | 'build'

--- a/packages/nuxi/test/unit/lockfile.spec.ts
+++ b/packages/nuxi/test/unit/lockfile.spec.ts
@@ -5,6 +5,8 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const isWindows = process.platform === 'win32'
+
 vi.mock('std-env', async (importOriginal) => {
   const original = await importOriginal<typeof import('std-env')>()
   return { ...original, isAgent: true }
@@ -112,7 +114,7 @@ describe('lockfile', () => {
       expect(message).toContain('http://127.0.0.1:3000')
       expect(message).toContain('12345')
       expect(message).toContain('/my/project')
-      expect(message).toContain('kill 12345')
+      expect(message).toContain(isWindows ? 'taskkill /PID 12345 /F' : 'kill 12345')
       expect(message).toContain('connect to')
     })
 

--- a/packages/nuxi/test/unit/lockfile.spec.ts
+++ b/packages/nuxi/test/unit/lockfile.spec.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('std-env', async (importOriginal) => {
+  const original = await importOriginal<typeof import('std-env')>()
+  return { ...original, isAgent: true }
+})
+
+const { checkLock, formatLockError, writeLock } = await import('../../src/utils/lockfile')
+
+describe('lockfile', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'nuxt-lockfile-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  describe('checkLock', () => {
+    it('returns undefined when no lock file exists', () => {
+      expect(checkLock(tempDir)).toBeUndefined()
+    })
+
+    it('returns undefined for own PID (self-check)', async () => {
+      await mkdir(tempDir, { recursive: true })
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: process.pid,
+        port: 3000,
+        hostname: '127.0.0.1',
+        url: 'http://127.0.0.1:3000',
+        command: 'dev',
+        startedAt: Date.now(),
+      }))
+
+      expect(checkLock(tempDir)).toBeUndefined()
+    })
+
+    it('cleans up stale lock files from dead processes', async () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 999999999,
+        port: 3000,
+        hostname: '127.0.0.1',
+        url: 'http://127.0.0.1:3000',
+        command: 'dev',
+        startedAt: Date.now(),
+      }))
+
+      expect(checkLock(tempDir)).toBeUndefined()
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+    })
+
+    it('cleans up corrupted lock files', async () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), 'not valid json')
+
+      expect(checkLock(tempDir)).toBeUndefined()
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+    })
+  })
+
+  describe('writeLock', () => {
+    it('writes lock file and returns cleanup function', async () => {
+      const cleanup = await writeLock(tempDir, {
+        pid: process.pid,
+        command: 'dev',
+        port: 3000,
+        hostname: '127.0.0.1',
+        url: 'http://127.0.0.1:3000',
+        startedAt: Date.now(),
+      })
+      const lockPath = join(tempDir, 'nuxt.lock')
+
+      expect(existsSync(lockPath)).toBe(true)
+      const written = JSON.parse(readFileSync(lockPath, 'utf-8'))
+      expect(written.pid).toBe(process.pid)
+      expect(written.port).toBe(3000)
+      expect(written.command).toBe('dev')
+
+      cleanup()
+      expect(existsSync(lockPath)).toBe(false)
+    })
+
+    it('cleanup is idempotent', async () => {
+      const cleanup = await writeLock(tempDir, {
+        pid: process.pid,
+        command: 'build',
+        startedAt: Date.now(),
+      })
+      cleanup()
+      cleanup() // should not throw
+    })
+  })
+
+  describe('formatLockError', () => {
+    it('includes actionable dev server info', () => {
+      const message = formatLockError({
+        pid: 12345,
+        command: 'dev',
+        port: 3000,
+        hostname: '127.0.0.1',
+        url: 'http://127.0.0.1:3000',
+        startedAt: Date.now(),
+      }, '/my/project')
+
+      expect(message).toContain('dev server')
+      expect(message).toContain('http://127.0.0.1:3000')
+      expect(message).toContain('12345')
+      expect(message).toContain('/my/project')
+      expect(message).toContain('kill 12345')
+      expect(message).toContain('connect to')
+    })
+
+    it('formats build lock without URL', () => {
+      const message = formatLockError({
+        pid: 12345,
+        command: 'build',
+        startedAt: Date.now(),
+      }, '/my/project')
+
+      expect(message).toContain('build')
+      expect(message).toContain('12345')
+      expect(message).not.toContain('connect to')
+    })
+  })
+})

--- a/packages/nuxi/test/unit/lockfile.spec.ts
+++ b/packages/nuxi/test/unit/lockfile.spec.ts
@@ -88,6 +88,31 @@ describe('lockfile', () => {
       expect(existsSync(lockPath)).toBe(false)
     })
 
+    it('returns noop when lock already exists (atomic write)', async () => {
+      // First lock succeeds
+      const cleanup1 = await writeLock(tempDir, {
+        pid: process.pid,
+        command: 'dev',
+        startedAt: Date.now(),
+      })
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
+
+      // Second lock returns noop (file exists)
+      const cleanup2 = await writeLock(tempDir, {
+        pid: process.pid,
+        command: 'dev',
+        startedAt: Date.now(),
+      })
+
+      // cleanup2 is noop, should not remove the file
+      cleanup2()
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
+
+      // cleanup1 still works
+      cleanup1()
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+    })
+
     it('cleanup is idempotent', async () => {
       const cleanup = await writeLock(tempDir, {
         pid: process.pid,

--- a/packages/nuxi/test/unit/lockfile.spec.ts
+++ b/packages/nuxi/test/unit/lockfile.spec.ts
@@ -12,115 +12,216 @@ vi.mock('std-env', async (importOriginal) => {
   return { ...original, isAgent: true }
 })
 
-const { checkLock, formatLockError, writeLock } = await import('../../src/utils/lockfile')
+const { acquireLock, formatLockError, isLockEnabled, updateLock } = await import('../../src/utils/lockfile')
 
 describe('lockfile', () => {
   let tempDir: string
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'nuxt-lockfile-test-'))
+    delete process.env.NUXT_IGNORE_LOCK
+    delete process.env.NUXT_LOCK
   })
 
   afterEach(async () => {
     await rm(tempDir, { recursive: true, force: true })
   })
 
-  describe('checkLock', () => {
-    it('returns undefined when no lock file exists', () => {
-      expect(checkLock(tempDir)).toBeUndefined()
+  describe('isLockEnabled', () => {
+    it('is enabled when isAgent is true (mocked)', () => {
+      expect(isLockEnabled()).toBe(true)
     })
 
-    it('returns undefined for own PID (self-check)', async () => {
-      await mkdir(tempDir, { recursive: true })
-      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
-        pid: process.pid,
-        port: 3000,
-        hostname: '127.0.0.1',
-        url: 'http://127.0.0.1:3000',
-        command: 'dev',
-        startedAt: Date.now(),
-      }))
-
-      expect(checkLock(tempDir)).toBeUndefined()
+    it('nUXT_IGNORE_LOCK=1 disables locking', () => {
+      process.env.NUXT_IGNORE_LOCK = '1'
+      expect(isLockEnabled()).toBe(false)
     })
 
-    it('cleans up stale lock files from dead processes', async () => {
-      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
-        pid: 999999999,
-        port: 3000,
-        hostname: '127.0.0.1',
-        url: 'http://127.0.0.1:3000',
-        command: 'dev',
-        startedAt: Date.now(),
-      }))
-
-      expect(checkLock(tempDir)).toBeUndefined()
-      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+    it('nUXT_LOCK=1 forces locking on', () => {
+      process.env.NUXT_LOCK = '1'
+      expect(isLockEnabled()).toBe(true)
     })
 
-    it('cleans up corrupted lock files', async () => {
-      writeFileSync(join(tempDir, 'nuxt.lock'), 'not valid json')
-
-      expect(checkLock(tempDir)).toBeUndefined()
-      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+    it('nUXT_IGNORE_LOCK takes precedence over NUXT_LOCK', () => {
+      process.env.NUXT_LOCK = '1'
+      process.env.NUXT_IGNORE_LOCK = '1'
+      expect(isLockEnabled()).toBe(false)
     })
   })
 
-  describe('writeLock', () => {
-    it('writes lock file and returns cleanup function', async () => {
-      const cleanup = await writeLock(tempDir, {
-        pid: process.pid,
-        command: 'dev',
-        port: 3000,
-        hostname: '127.0.0.1',
-        url: 'http://127.0.0.1:3000',
-        startedAt: Date.now(),
-      })
+  describe('acquireLock', () => {
+    it('writes lock file and returns release function', () => {
+      const lock = acquireLock(tempDir, { command: 'dev', cwd: '/project' })
       const lockPath = join(tempDir, 'nuxt.lock')
 
+      expect(lock.existing).toBeUndefined()
+      expect(lock.release).toBeDefined()
       expect(existsSync(lockPath)).toBe(true)
       const written = JSON.parse(readFileSync(lockPath, 'utf-8'))
       expect(written.pid).toBe(process.pid)
-      expect(written.port).toBe(3000)
       expect(written.command).toBe('dev')
+      expect(written.cwd).toBe('/project')
+      expect(typeof written.startedAt).toBe('number')
 
-      cleanup()
+      lock.release!()
       expect(existsSync(lockPath)).toBe(false)
     })
 
-    it('returns noop when lock already exists (atomic write)', async () => {
-      // First lock succeeds
-      const cleanup1 = await writeLock(tempDir, {
-        pid: process.pid,
+    it('returns existing lock when another live process holds it', async () => {
+      await mkdir(tempDir, { recursive: true })
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 1, // init/systemd, always alive
         command: 'dev',
+        cwd: '/other',
         startedAt: Date.now(),
-      })
+      }))
+
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      expect(lock.existing).toBeDefined()
+      expect(lock.existing!.pid).toBe(1)
+      expect(lock.existing!.cwd).toBe('/other')
+      expect(lock.release).toBeUndefined()
+      // File untouched.
       expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
-
-      // Second lock returns noop (file exists)
-      const cleanup2 = await writeLock(tempDir, {
-        pid: process.pid,
-        command: 'dev',
-        startedAt: Date.now(),
-      })
-
-      // cleanup2 is noop, should not remove the file
-      cleanup2()
-      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
-
-      // cleanup1 still works
-      cleanup1()
-      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
     })
 
-    it('cleanup is idempotent', async () => {
-      const cleanup = await writeLock(tempDir, {
-        pid: process.pid,
-        command: 'build',
+    it('takes over a lock whose PID is dead', async () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 999999999,
+        command: 'dev',
+        cwd: '/other',
         startedAt: Date.now(),
+      }))
+
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      expect(lock.existing).toBeUndefined()
+      expect(lock.release).toBeDefined()
+      const written = JSON.parse(readFileSync(join(tempDir, 'nuxt.lock'), 'utf-8'))
+      expect(written.pid).toBe(process.pid)
+      lock.release!()
+    })
+
+    it('takes over a lock older than the PID-recycling safety window', () => {
+      // 25h ago — older than MAX_LOCK_AGE_MS
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 1,
+        command: 'dev',
+        cwd: '/other',
+        startedAt: Date.now() - 25 * 60 * 60 * 1000,
+      }))
+
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      expect(lock.existing).toBeUndefined()
+      expect(lock.release).toBeDefined()
+      lock.release!()
+    })
+
+    it('takes over a lock owned by this process (re-entrancy)', () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: process.pid,
+        command: 'dev',
+        cwd: '/project',
+        startedAt: Date.now(),
+      }))
+
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      expect(lock.existing).toBeUndefined()
+      expect(lock.release).toBeDefined()
+      lock.release!()
+    })
+
+    it('cleans up corrupted lock files', () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), 'not valid json')
+
+      const lock = acquireLock(tempDir, { command: 'dev', cwd: '/project' })
+      expect(lock.existing).toBeUndefined()
+      expect(lock.release).toBeDefined()
+      const written = JSON.parse(readFileSync(join(tempDir, 'nuxt.lock'), 'utf-8'))
+      expect(written.pid).toBe(process.pid)
+      lock.release!()
+    })
+
+    it('release is idempotent', () => {
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      lock.release!()
+      lock.release!() // should not throw
+    })
+
+    it('release does not remove another process\'s lock', () => {
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      // Simulate another process replacing the file.
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 1,
+        command: 'dev',
+        cwd: '/other',
+        startedAt: Date.now(),
+      }))
+      lock.release!()
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
+    })
+
+    it('is a no-op when locking is disabled', () => {
+      process.env.NUXT_IGNORE_LOCK = '1'
+      const lock = acquireLock(tempDir, { command: 'dev', cwd: '/project' })
+      expect(lock.existing).toBeUndefined()
+      expect(lock.release).toBeDefined()
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+      lock.release!()
+    })
+
+    it('does not register a duplicate exit listener on release', () => {
+      const before = process.listenerCount('exit')
+      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+      expect(process.listenerCount('exit')).toBe(before + 1)
+      lock.release!()
+      expect(process.listenerCount('exit')).toBe(before)
+    })
+  })
+
+  describe('updateLock', () => {
+    it('overwrites our own lock with new metadata', () => {
+      const lock = acquireLock(tempDir, { command: 'dev', cwd: '/project' })
+      const originalStart = JSON.parse(readFileSync(join(tempDir, 'nuxt.lock'), 'utf-8')).startedAt
+
+      updateLock(tempDir, {
+        command: 'dev',
+        cwd: '/project',
+        port: 3000,
+        hostname: '127.0.0.1',
+        url: 'http://127.0.0.1:3000',
       })
-      cleanup()
-      cleanup() // should not throw
+
+      const written = JSON.parse(readFileSync(join(tempDir, 'nuxt.lock'), 'utf-8'))
+      expect(written.port).toBe(3000)
+      expect(written.url).toBe('http://127.0.0.1:3000')
+      // Preserves startedAt from original acquisition.
+      expect(written.startedAt).toBe(originalStart)
+      lock.release!()
+    })
+
+    it('does not overwrite another process\'s lock', () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 1,
+        command: 'dev',
+        cwd: '/other',
+        startedAt: Date.now(),
+      }))
+
+      updateLock(tempDir, {
+        command: 'dev',
+        cwd: '/project',
+        port: 3000,
+      })
+
+      const written = JSON.parse(readFileSync(join(tempDir, 'nuxt.lock'), 'utf-8'))
+      expect(written.pid).toBe(1)
+      expect(written.port).toBeUndefined()
+    })
+
+    it('is a no-op when locking is disabled', () => {
+      process.env.NUXT_IGNORE_LOCK = '1'
+      updateLock(tempDir, { command: 'dev', cwd: '/project' })
+      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
     })
   })
 
@@ -129,11 +230,12 @@ describe('lockfile', () => {
       const message = formatLockError({
         pid: 12345,
         command: 'dev',
+        cwd: '/my/project',
         port: 3000,
         hostname: '127.0.0.1',
         url: 'http://127.0.0.1:3000',
         startedAt: Date.now(),
-      }, '/my/project')
+      })
 
       expect(message).toContain('dev server')
       expect(message).toContain('http://127.0.0.1:3000')
@@ -147,8 +249,9 @@ describe('lockfile', () => {
       const message = formatLockError({
         pid: 12345,
         command: 'build',
+        cwd: '/my/project',
         startedAt: Date.now(),
-      }, '/my/project')
+      })
 
       expect(message).toContain('build')
       expect(message).toContain('12345')

--- a/packages/nuxi/test/unit/lockfile.spec.ts
+++ b/packages/nuxi/test/unit/lockfile.spec.ts
@@ -68,21 +68,35 @@ describe('lockfile', () => {
     })
 
     it('returns existing lock when another live process holds it', async () => {
-      await mkdir(tempDir, { recursive: true })
-      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
-        pid: 1, // init/systemd, always alive
-        command: 'dev',
-        cwd: '/other',
-        startedAt: Date.now(),
-      }))
+      // Stub process.kill so liveness is deterministic across OSes (Windows
+      // PID 1 semantics differ).
+      const foreignPid = 424242
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid) => {
+        if (pid === foreignPid) {
+          return true as unknown as true
+        }
+        throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+      })
+      try {
+        await mkdir(tempDir, { recursive: true })
+        writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+          pid: foreignPid,
+          command: 'dev',
+          cwd: '/other',
+          startedAt: Date.now(),
+        }))
 
-      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
-      expect(lock.existing).toBeDefined()
-      expect(lock.existing!.pid).toBe(1)
-      expect(lock.existing!.cwd).toBe('/other')
-      expect(lock.release).toBeUndefined()
-      // File untouched.
-      expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
+        const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+        expect(lock.existing).toBeDefined()
+        expect(lock.existing!.pid).toBe(foreignPid)
+        expect(lock.existing!.cwd).toBe('/other')
+        expect(lock.release).toBeUndefined()
+        // File untouched.
+        expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(true)
+      }
+      finally {
+        killSpy.mockRestore()
+      }
     })
 
     it('takes over a lock whose PID is dead', async () => {
@@ -102,18 +116,24 @@ describe('lockfile', () => {
     })
 
     it('takes over a lock older than the PID-recycling safety window', () => {
-      // 25h ago — older than MAX_LOCK_AGE_MS
-      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
-        pid: 1,
-        command: 'dev',
-        cwd: '/other',
-        startedAt: Date.now() - 25 * 60 * 60 * 1000,
-      }))
+      // Mock the PID as alive; age-based override should still kick in.
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true as unknown as true)
+      try {
+        writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+          pid: 424242,
+          command: 'dev',
+          cwd: '/other',
+          startedAt: Date.now() - 25 * 60 * 60 * 1000,
+        }))
 
-      const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
-      expect(lock.existing).toBeUndefined()
-      expect(lock.release).toBeDefined()
-      lock.release!()
+        const lock = acquireLock(tempDir, { command: 'build', cwd: '/project' })
+        expect(lock.existing).toBeUndefined()
+        expect(lock.release).toBeDefined()
+        lock.release!()
+      }
+      finally {
+        killSpy.mockRestore()
+      }
     })
 
     it('takes over a lock owned by this process (re-entrancy)', () => {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/34629

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Inspired by [Next.js 16.2's dev server lock file](https://nextjs.org/blog/next-16-2-ai#dev-server-lock-file) & https://github.com/nuxt/nuxt/pull/34629, this adds a `nuxt.lock` file to the build directory during `nuxi dev` and `nuxi build`. The lock file contains process info (PID, port, URL, command) so that a second invocation can detect the existing process and print an actionable error message with the running server's URL and a kill command.

This only runs for agents (using `std-env` agent detection). Agents can set `NUXT_IGNORE_LOCK=1` to bypass the check if they have a good reason to.

Stale locks from crashed processes are automatically cleaned up on the next startup via PID liveness checking (`process.kill(pid, 0)`). Pure Node.js, zero new dependencies.

#### Lock file format (`<buildDir>/nuxt.lock`)
```json
{
  "pid": 12345,
  "command": "dev",
  "port": 3000,
  "hostname": "127.0.0.1",
  "url": "http://127.0.0.1:3000",
  "startedAt": 1711540800000
}
```

#### Error output when a dev server is already running
```
Another Nuxt dev server is already running:

  URL:     http://127.0.0.1:3000
  PID:     12345
  Dir:     /path/to/project
  Started: 3/27/2026, 2:00:00 PM

Run `kill 12345` to stop it, or connect to http://127.0.0.1:3000
Set NUXT_IGNORE_LOCK=1 to bypass this check.
```

### Limitations

- These aren't OS-level file locks - we can't support these without native bindings. There are edge cases around force process exits and hards crashes but there is recover logic

### Future considerations

Rust bindings for native OS file locking.