### PR TITLE
fix(dev): resolve package versions via their parents

### DIFF
--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -17,8 +17,8 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
     case '@nuxt/vite-builder':
     default: {
       const pkgJSON = getPkgJSON(cwd, 'vite')
-      const isRolldown = pkgJSON.name.includes('rolldown')
-      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON.version }
+      const isRolldown = pkgJSON?.name?.includes('rolldown') ?? false
+      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON?.version ?? '' }
     }
   }
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -16,9 +16,9 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
     case 'vite':
     case '@nuxt/vite-builder':
     default: {
-      const pkgJSON = getPkgJSON(cwd, 'vite')
-      const isRolldown = pkgJSON?.name?.includes('rolldown') ?? false
-      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON?.version ?? '' }
+      const pkgJSON = getPkgJSON(cwd, 'vite') ?? getPkgJSON(cwd, 'vite', { via: '@nuxt/vite-builder' })
+      const isRolldown = pkgJSON?.name?.includes('rolldown')
+      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON?.version || 'unknown' }
     }
   }
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -17,8 +17,8 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
     case '@nuxt/vite-builder':
     default: {
       const pkgJSON = getPkgJSON(cwd, 'vite', { via: ['nuxt', '@nuxt/vite-builder'] })
-      const isRolldown = pkgJSON?.name?.includes('rolldown')
-      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON?.version || 'unknown' }
+      const isRolldown = pkgJSON.name.includes('rolldown')
+      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON.version || 'unknown' }
     }
   }
 }

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -9,14 +9,14 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
   switch (builder) {
     case 'rspack':
     case '@nuxt/rspack-builder':
-      return { name: 'Rspack', version: getPkgVersion(cwd, '@rspack/core') }
+      return { name: 'Rspack', version: getPkgVersion(cwd, '@rspack/core', { via: ['@nuxt/rspack-builder'] }) }
     case 'webpack':
     case '@nuxt/webpack-builder':
-      return { name: 'Webpack', version: getPkgVersion(cwd, 'webpack') }
+      return { name: 'Webpack', version: getPkgVersion(cwd, 'webpack', { via: ['@nuxt/webpack-builder'] }) }
     case 'vite':
     case '@nuxt/vite-builder':
     default: {
-      const pkgJSON = getPkgJSON(cwd, 'vite', { via: '@nuxt/vite-builder' })
+      const pkgJSON = getPkgJSON(cwd, 'vite', { via: ['nuxt', '@nuxt/vite-builder'] })
       const isRolldown = pkgJSON?.name?.includes('rolldown')
       return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON?.version || 'unknown' }
     }
@@ -27,9 +27,10 @@ export function showVersionsFromConfig(cwd: string, config: NuxtOptions) {
   const { bold, gray, green } = colors
 
   const nuxtVersion = getPkgVersion(cwd, 'nuxt') || getPkgVersion(cwd, 'nuxt-nightly') || getPkgVersion(cwd, 'nuxt3') || getPkgVersion(cwd, 'nuxt-edge')
-  const nitroVersion = getPkgVersion(cwd, 'nitropack') || getPkgVersion(cwd, 'nitro') || getPkgVersion(cwd, 'nitropack-nightly') || getPkgVersion(cwd, 'nitropack-edge')
+  const nitroVia = { via: ['nuxt', '@nuxt/nitro-server'] }
+  const nitroVersion = getPkgVersion(cwd, 'nitropack', nitroVia) || getPkgVersion(cwd, 'nitro', nitroVia) || getPkgVersion(cwd, 'nitropack-nightly') || getPkgVersion(cwd, 'nitropack-edge')
   const builder = getBuilder(cwd, config.builder)
-  const vueVersion = getPkgVersion(cwd, 'vue') || null
+  const vueVersion = getPkgVersion(cwd, 'vue', { via: ['nuxt'] }) || null
 
   logger.info(
     green(`Nuxt ${bold(nuxtVersion)}`)

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -16,7 +16,7 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
     case 'vite':
     case '@nuxt/vite-builder':
     default: {
-      const pkgJSON = getPkgJSON(cwd, 'vite') ?? getPkgJSON(cwd, 'vite', { via: '@nuxt/vite-builder' })
+      const pkgJSON = getPkgJSON(cwd, 'vite', { via: '@nuxt/vite-builder' })
       const isRolldown = pkgJSON?.name?.includes('rolldown')
       return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON?.version || 'unknown' }
     }

--- a/packages/nuxi/src/utils/versions.ts
+++ b/packages/nuxi/src/utils/versions.ts
@@ -15,32 +15,57 @@ export async function getNuxtVersion(cwd: string, cache = true) {
   return (pkgDep && coerce(pkgDep)?.version) || '3.0.0'
 }
 
-export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string }) {
+export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string[] }) {
   const pkgJSON = getPkgJSON(cwd, pkg, options)
   return pkgJSON?.version ?? ''
 }
 
-export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string }) {
-  const roots = [cwd, tryResolveNuxt(cwd)].filter((v): v is string => !!v)
-  const searchFrom: string[] = []
+/**
+ * Resolve a package.json, optionally walking a dependency chain.
+ *
+ * `via` is an array of `[startingPoint, ...intermediates]` describing
+ * the dependency path to walk before resolving `pkg`. For example:
+ *
+ *   // vite is a dep of @nuxt/vite-builder, which is a dep of nuxt
+ *   getPkgJSON(cwd, 'vite', { via: ['nuxt', '@nuxt/vite-builder'] })
+ *
+ *   // webpack is a dep of @nuxt/webpack-builder, which the user installs
+ *   getPkgJSON(cwd, 'webpack', { via: ['@nuxt/webpack-builder'] })
+ *
+ * Each entry is resolved from the location of the previous one,
+ * starting from cwd. Falls back to direct resolution from cwd/nuxt.
+ */
+export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string[] }) {
+  // Build list of locations to try resolving pkg from.
+  // When `via` is provided, walk the chain first; then fall back to cwd/nuxt.
+  const roots: string[] = []
 
-  if (options?.via) {
-    for (const from of roots) {
-      const viaPath = resolveModulePath(options.via, { from, try: true })
-      if (viaPath) {
-        searchFrom.push(viaPath)
+  if (options?.via && options.via.length > 0) {
+    let from: string | undefined = cwd
+    for (const step of options.via) {
+      from = resolveModulePath(step, { from, try: true }) ?? undefined
+      if (!from) {
         break
       }
     }
+    if (from) {
+      roots.push(from)
+    }
   }
 
-  searchFrom.push(...roots)
+  // Fallback: direct resolution from cwd or nuxt's location
+  roots.push(cwd)
+  const nuxtPath = tryResolveNuxt(cwd)
+  if (nuxtPath) {
+    roots.push(nuxtPath)
+  }
 
-  for (const from of searchFrom) {
-    const p = resolveModulePath(`${pkg}/package.json`, { from, try: true })
+  for (const root of roots) {
+    const p = resolveModulePath(`${pkg}/package.json`, { from: root, try: true })
     if (p) {
       return JSON.parse(readFileSync(p, 'utf-8'))
     }
   }
+
   return null
 }

--- a/packages/nuxi/src/utils/versions.ts
+++ b/packages/nuxi/src/utils/versions.ts
@@ -15,17 +15,27 @@ export async function getNuxtVersion(cwd: string, cache = true) {
   return (pkgDep && coerce(pkgDep)?.version) || '3.0.0'
 }
 
-export function getPkgVersion(cwd: string, pkg: string) {
-  const pkgJSON = getPkgJSON(cwd, pkg)
+export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string }) {
+  const pkgJSON = getPkgJSON(cwd, pkg, options)
   return pkgJSON?.version ?? ''
 }
 
-export function getPkgJSON(cwd: string, pkg: string) {
-  for (const url of [cwd, tryResolveNuxt(cwd)]) {
-    if (!url) {
-      continue
+export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string }) {
+  const roots = [cwd, tryResolveNuxt(cwd)].filter((v): v is string => !!v)
+  const searchFrom = [...roots]
+
+  if (options?.via) {
+    for (const from of roots) {
+      const viaPath = resolveModulePath(options.via, { from, try: true })
+      if (viaPath) {
+        searchFrom.push(viaPath)
+        break
+      }
     }
-    const p = resolveModulePath(`${pkg}/package.json`, { from: url, try: true })
+  }
+
+  for (const from of searchFrom) {
+    const p = resolveModulePath(`${pkg}/package.json`, { from, try: true })
     if (p) {
       return JSON.parse(readFileSync(p, 'utf-8'))
     }

--- a/packages/nuxi/src/utils/versions.ts
+++ b/packages/nuxi/src/utils/versions.ts
@@ -22,7 +22,7 @@ export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string
 
 export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string }) {
   const roots = [cwd, tryResolveNuxt(cwd)].filter((v): v is string => !!v)
-  const searchFrom = [...roots]
+  const searchFrom: string[] = []
 
   if (options?.via) {
     for (const from of roots) {
@@ -33,6 +33,8 @@ export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string })
       }
     }
   }
+
+  searchFrom.push(...roots)
 
   for (const from of searchFrom) {
     const p = resolveModulePath(`${pkg}/package.json`, { from, try: true })

--- a/packages/nuxi/test/unit/utils/banner.spec.ts
+++ b/packages/nuxi/test/unit/utils/banner.spec.ts
@@ -2,8 +2,6 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../../src/utils/versions', () => ({
   getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string }) => {
-    // simulate pnpm globalVirtualStore: vite not reachable from cwd or nuxt,
-    // only reachable through @nuxt/vite-builder's isolated deps
     if (pkg === 'vite' && options?.via === '@nuxt/vite-builder') {
       return { name: 'vite', version: '7.3.1' }
     }
@@ -15,15 +13,13 @@ vi.mock('../../../src/utils/versions', () => ({
 const { getBuilder } = await import('../../../src/utils/banner')
 
 describe('getBuilder', () => {
-  // regression for banner crash under pnpm globalVirtualStore
-  it('does not throw when vite package.json cannot be resolved anywhere', async () => {
+  it('does not throw when vite package.json cannot be resolved', async () => {
     const { getPkgJSON } = await import('../../../src/utils/versions')
-    vi.mocked(getPkgJSON).mockReturnValueOnce(null).mockReturnValueOnce(null)
+    vi.mocked(getPkgJSON).mockReturnValueOnce(null)
     expect(() => getBuilder('/any', 'vite')).not.toThrow()
   })
 
-  // proper fix: recover version via @nuxt/vite-builder under strict isolation
-  it('resolves vite version via @nuxt/vite-builder when direct lookup fails', () => {
+  it('resolves vite version via @nuxt/vite-builder', () => {
     expect(getBuilder('/any', 'vite')).toEqual({ name: 'Vite', version: '7.3.1' })
   })
 })

--- a/packages/nuxi/test/unit/utils/banner.spec.ts
+++ b/packages/nuxi/test/unit/utils/banner.spec.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../../src/utils/versions', () => ({
-  getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string }) => {
-    if (pkg === 'vite' && options?.via === '@nuxt/vite-builder') {
+  getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string[] }) => {
+    if (pkg === 'vite' && options?.via?.includes('@nuxt/vite-builder')) {
       return { name: 'vite', version: '7.3.1' }
     }
     return null
   }),
-  getPkgVersion: vi.fn(() => ''),
+  getPkgVersion: vi.fn((_cwd: string, pkg: string, options?: { via?: string[] }) => {
+    if (pkg === 'webpack' && options?.via?.includes('@nuxt/webpack-builder')) {
+      return '5.99.0'
+    }
+    if (pkg === '@rspack/core' && options?.via?.includes('@nuxt/rspack-builder')) {
+      return '1.3.0'
+    }
+    return ''
+  }),
 }))
 
 const { getBuilder } = await import('../../../src/utils/banner')
@@ -19,7 +27,15 @@ describe('getBuilder', () => {
     expect(() => getBuilder('/any', 'vite')).not.toThrow()
   })
 
-  it('resolves vite version via @nuxt/vite-builder', () => {
+  it('resolves vite version via nuxt -> @nuxt/vite-builder', () => {
     expect(getBuilder('/any', 'vite')).toEqual({ name: 'Vite', version: '7.3.1' })
+  })
+
+  it('resolves webpack version via @nuxt/webpack-builder', () => {
+    expect(getBuilder('/any', 'webpack')).toEqual({ name: 'Webpack', version: '5.99.0' })
+  })
+
+  it('resolves rspack version via @nuxt/rspack-builder', () => {
+    expect(getBuilder('/any', 'rspack')).toEqual({ name: 'Rspack', version: '1.3.0' })
   })
 })

--- a/packages/nuxi/test/unit/utils/banner.spec.ts
+++ b/packages/nuxi/test/unit/utils/banner.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../src/utils/versions', () => ({
+  getPkgJSON: vi.fn(() => null),
+  getPkgVersion: vi.fn(() => ''),
+}))
+
+const { getBuilder } = await import('../../../src/utils/banner')
+
+describe('getBuilder', () => {
+  // regression for banner crash under pnpm globalVirtualStore
+  // where vite is unreachable from cwd — getPkgJSON returns null
+  it('does not throw when vite package.json cannot be resolved', () => {
+    expect(() => getBuilder('/any', 'vite')).not.toThrow()
+    expect(getBuilder('/any', 'vite')).toMatchObject({ name: 'Vite', version: '' })
+  })
+})

--- a/packages/nuxi/test/unit/utils/banner.spec.ts
+++ b/packages/nuxi/test/unit/utils/banner.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../../src/utils/versions', () => ({
-  getPkgJSON: vi.fn(() => null),
+  getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string }) => {
+    // simulate pnpm globalVirtualStore: vite not reachable from cwd or nuxt,
+    // only reachable through @nuxt/vite-builder's isolated deps
+    if (pkg === 'vite' && options?.via === '@nuxt/vite-builder') {
+      return { name: 'vite', version: '7.3.1' }
+    }
+    return null
+  }),
   getPkgVersion: vi.fn(() => ''),
 }))
 
@@ -9,9 +16,14 @@ const { getBuilder } = await import('../../../src/utils/banner')
 
 describe('getBuilder', () => {
   // regression for banner crash under pnpm globalVirtualStore
-  // where vite is unreachable from cwd — getPkgJSON returns null
-  it('does not throw when vite package.json cannot be resolved', () => {
+  it('does not throw when vite package.json cannot be resolved anywhere', async () => {
+    const { getPkgJSON } = await import('../../../src/utils/versions')
+    vi.mocked(getPkgJSON).mockReturnValueOnce(null).mockReturnValueOnce(null)
     expect(() => getBuilder('/any', 'vite')).not.toThrow()
-    expect(getBuilder('/any', 'vite')).toMatchObject({ name: 'Vite', version: '' })
+  })
+
+  // proper fix: recover version via @nuxt/vite-builder under strict isolation
+  it('resolves vite version via @nuxt/vite-builder when direct lookup fails', () => {
+    expect(getBuilder('/any', 'vite')).toEqual({ name: 'Vite', version: '7.3.1' })
   })
 })

--- a/packages/nuxi/test/unit/utils/banner.spec.ts
+++ b/packages/nuxi/test/unit/utils/banner.spec.ts
@@ -21,12 +21,6 @@ vi.mock('../../../src/utils/versions', () => ({
 const { getBuilder } = await import('../../../src/utils/banner')
 
 describe('getBuilder', () => {
-  it('does not throw when vite package.json cannot be resolved', async () => {
-    const { getPkgJSON } = await import('../../../src/utils/versions')
-    vi.mocked(getPkgJSON).mockReturnValueOnce(null)
-    expect(() => getBuilder('/any', 'vite')).not.toThrow()
-  })
-
   it('resolves vite version via nuxt -> @nuxt/vite-builder', () => {
     expect(getBuilder('/any', 'vite')).toEqual({ name: 'Vite', version: '7.3.1' })
   })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Refs nuxt/nuxt#34809 — this covers the CLI side. The devtools side is in nuxt/devtools#986.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Resolves `vite` via `nuxt -> @nuxt/vite-builder -> vite` instead of resolving it directly from cwd.
Under pnpm 11's enableGlobalVirtualStore, vite is not reachable from CWD or nuxt itself. However, since @nuxt/vite-builder declares vite as a direct dependency, the lookup now works correctly through that path.
- Verified against a pnpm 11 globalVirtualStore repro.
- Added a regression test.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
