### PR TITLE
perf: lazily initialise completions only when requested

### DIFF
--- a/packages/nuxi/src/main.ts
+++ b/packages/nuxi/src/main.ts
@@ -11,7 +11,6 @@ import { provider } from 'std-env'
 import { description, name, version } from '../package.json'
 import { commands } from './commands'
 import { cwdArgs } from './commands/_shared'
-import { initCompletions } from './completions'
 import { runCommand } from './run'
 import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
@@ -102,7 +101,10 @@ const _main = defineCommand({
 export const main = _main as CommandDef<any>
 
 export async function runMain(): Promise<void> {
-  await initCompletions(main)
+  if (process.argv[2] === 'complete') {
+    const { initCompletions } = await import('./completions')
+    await initCompletions(main)
+  }
 
   return _runMain(main)
 }

--- a/packages/nuxt-cli/src/run.ts
+++ b/packages/nuxt-cli/src/run.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url'
 import { runCommand as _runCommand, runMain as _runMain } from 'citty'
 
 import { commands } from '../../nuxi/src/commands'
-import { initCompletions } from '../../nuxi/src/completions'
 import { main } from './main'
 
 globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
@@ -19,7 +18,10 @@ globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
 }
 
 export async function runMain(): Promise<void> {
-  await initCompletions(main)
+  if (process.argv[2] === 'complete') {
+    const { initCompletions } = await import('../../nuxi/src/completions')
+    await initCompletions(main)
+  }
   return _runMain(main)
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
