### PR TITLE
perf(dev,build): use loaded nuxt version in banner

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -5,7 +5,7 @@ import { defineCommand } from 'citty'
 import { colors } from 'consola/utils'
 import { relative, resolve } from 'pathe'
 
-import { showVersions } from '../utils/banner'
+import { showBanner } from '../utils/banner'
 import { overrideEnv } from '../utils/env'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
@@ -52,11 +52,9 @@ export default defineCommand({
       intro(colors.cyan('Building Nuxt for production...'))
 
       const kit = await loadKit(cwd)
-
-      await showVersions(cwd, kit, ctx.args.dotenv)
-
       const nuxt = await kit.loadNuxt({
         cwd,
+        ready: false,
         dotenv: {
           cwd,
           fileName: ctx.args.dotenv,
@@ -80,6 +78,9 @@ export default defineCommand({
           }),
         },
       })
+
+      showBanner(nuxt)
+      await nuxt.ready()
 
       const lock = acquireLock(nuxt.options.buildDir, {
         command: 'build',

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -22,7 +22,7 @@ import { toNodeHandler } from 'srvx/node'
 import { provider } from 'std-env'
 import { joinURL } from 'ufo'
 
-import { showVersionsFromConfig } from '../utils/banner'
+import { showBanner } from '../utils/banner'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 import { acquireLock, formatLockError, updateLock } from '../utils/lockfile'
@@ -203,7 +203,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     this.#acquireDevLock(this.#currentNuxt!.options.buildDir)
 
     if (this.options.showBanner) {
-      showVersionsFromConfig(this.options.cwd, this.#currentNuxt!.options)
+      showBanner(this.#currentNuxt!)
     }
 
     await this.#createListener()

--- a/packages/nuxi/src/utils/banner.ts
+++ b/packages/nuxi/src/utils/banner.ts
@@ -1,4 +1,4 @@
-import type { NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
+import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 
 import { colors } from 'consola/utils'
 
@@ -23,13 +23,15 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
   }
 }
 
-export function showVersionsFromConfig(cwd: string, config: NuxtOptions) {
+export function showBanner(nuxt: Nuxt) {
   const { bold, gray, green } = colors
+  const cwd = nuxt.options.rootDir
 
-  const nuxtVersion = getPkgVersion(cwd, 'nuxt') || getPkgVersion(cwd, 'nuxt-nightly') || getPkgVersion(cwd, 'nuxt3') || getPkgVersion(cwd, 'nuxt-edge')
+  const nuxtVersion = nuxt._version || getPkgVersion(cwd, 'nuxt') || getPkgVersion(cwd, 'nuxt-nightly') || getPkgVersion(cwd, 'nuxt3') || getPkgVersion(cwd, 'nuxt-edge')
+
   const nitroVia = { via: ['nuxt', '@nuxt/nitro-server'] }
   const nitroVersion = getPkgVersion(cwd, 'nitropack', nitroVia) || getPkgVersion(cwd, 'nitro', nitroVia) || getPkgVersion(cwd, 'nitropack-nightly') || getPkgVersion(cwd, 'nitropack-edge')
-  const builder = getBuilder(cwd, config.builder)
+  const builder = getBuilder(cwd, nuxt.options.builder)
   const vueVersion = getPkgVersion(cwd, 'vue', { via: ['nuxt'] }) || null
 
   logger.info(
@@ -40,13 +42,4 @@ export function showVersionsFromConfig(cwd: string, config: NuxtOptions) {
     + (vueVersion ? gray(` and Vue ${bold(vueVersion)}`) : '')
     + gray(')'),
   )
-}
-
-export async function showVersions(cwd: string, kit: typeof import('@nuxt/kit'), dotenv?: string) {
-  const config = await kit.loadNuxtConfig({
-    cwd,
-    dotenv: dotenv ? { cwd, fileName: dotenv } : undefined,
-  })
-
-  return showVersionsFromConfig(cwd, config)
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this avoids an extra import of `nuxt/package.json`