### PR TITLE
fix(cli): create build dir before writing lock file

### DIFF
--- a/packages/nuxi/src/utils/lockfile.ts
+++ b/packages/nuxi/src/utils/lockfile.ts
@@ -1,4 +1,4 @@
-import { readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
 import { join } from 'pathe'
@@ -97,6 +97,13 @@ export function acquireLock(
     startedAt: Date.now(),
     ...info,
   }
+
+  // The build dir may not exist yet (e.g. `rimraf .nuxt && nuxt dev`); the
+  // lock is acquired before `clearBuildDir` runs, so create it lazily.
+  try {
+    mkdirSync(buildDir, { recursive: true })
+  }
+  catch {}
 
   // Try exclusive-create up to twice: the first attempt may race with a stale
   // lock that we then clean up and retry.

--- a/packages/nuxi/test/unit/lockfile.spec.ts
+++ b/packages/nuxi/test/unit/lockfile.spec.ts
@@ -67,6 +67,19 @@ describe('lockfile', () => {
       expect(existsSync(lockPath)).toBe(false)
     })
 
+    it('creates the build dir if it does not exist yet', async () => {
+      const buildDir = join(tempDir, 'missing', '.nuxt')
+      expect(existsSync(buildDir)).toBe(false)
+
+      const lock = acquireLock(buildDir, { command: 'dev', cwd: '/project' })
+      const lockPath = join(buildDir, 'nuxt.lock')
+
+      expect(lock.existing).toBeUndefined()
+      expect(existsSync(lockPath)).toBe(true)
+
+      lock.release!()
+    })
+
     it('returns existing lock when another live process holds it', async () => {
       // Stub process.kill so liveness is deterministic across OSes (Windows
       // PID 1 semantics differ).


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

reported in https://github.com/nuxt/nuxt/issues/33606#issuecomment-4327554207