### PR TITLE
feat(dev): add --portless support

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -12,6 +12,7 @@ import { isBun, isTest } from 'std-env'
 
 import { initialize } from '../dev'
 import { ForkPool } from '../dev/pool'
+import { ensurePortlessAvailable, registerPortlessAlias, registerPortlessExitCleanup, removePortlessAlias, resolvePortlessAliasName, resolvePortlessName, resolvePortlessURL } from '../dev/portless'
 import { debug, logger } from '../utils/logger'
 import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs, profileArgs } from './_shared'
 
@@ -61,6 +62,11 @@ const command = defineCommand({
         description: 'Host to listen on (default: `NUXT_HOST || NITRO_HOST || HOST || nuxtOptions.devServer?.host`)',
       },
       clipboard: { ...listhenArgs.clipboard, default: false },
+      portless: {
+        type: 'boolean',
+        description: 'Expose the dev server with the external `portless` CLI (https://portless.sh). Disables forked mode.',
+        default: false,
+      },
     },
     ...profileArgs,
     sslCert: {
@@ -76,7 +82,19 @@ const command = defineCommand({
     // Prepare
     const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
 
-    const listenOverrides = resolveListenOverrides(ctx.args)
+    if (ctx.args.portless && ctx.args.tunnel) {
+      throw new Error('`--portless` cannot be used with `--tunnel`.')
+    }
+
+    const portlessName = ctx.args.portless ? await resolvePortlessName(cwd) : undefined
+    if (ctx.args.portless) {
+      await ensurePortlessAvailable(cwd)
+    }
+
+    const portlessURL = ctx.args.portless ? await resolvePortlessURL(cwd, portlessName!) : undefined
+    const portlessAliasName = portlessURL ? resolvePortlessAliasName(portlessURL) : undefined
+    const listenOverrides = resolveListenOverrides(ctx.args, portlessURL)
+    let closePortless: (() => Promise<void>) | undefined
 
     // Start the initial dev server in-process with listener
     const { listener, close, onRestart, onReady } = await initialize({ cwd, args: ctx.args }, {
@@ -85,11 +103,36 @@ const command = defineCommand({
       showBanner: true,
     })
 
-    // Disable forking when profiling to capture all activity in one process
-    if (!ctx.args.fork || ctx.args.profile) {
+    if (ctx.args.portless) {
+      const unregisterPortlessExitCleanup = registerPortlessExitCleanup(cwd, portlessAliasName!)
+      try {
+        await registerPortlessAlias(cwd, portlessAliasName!, listener.address.port)
+        closePortless = async () => {
+          unregisterPortlessExitCleanup()
+          await removePortlessAlias(cwd, portlessAliasName!).catch((error) => {
+            logger.warn((error as Error).message)
+          })
+        }
+        await listener.showURL()
+      }
+      catch (error) {
+        unregisterPortlessExitCleanup()
+        await removePortlessAlias(cwd, portlessAliasName!).catch(() => {})
+        await close()
+        throw error
+      }
+    }
+
+    const closeDevServer = async () => {
+      await closePortless?.()
+      await close()
+    }
+
+    if (ctx.args.portless || !ctx.args.fork || ctx.args.profile) {
+      // Disable forking when profiling or using portless to keep lifecycle local.
       return {
         listener,
-        close,
+        close: closeDevServer,
       }
     }
 
@@ -144,6 +187,7 @@ const command = defineCommand({
     return {
       async close() {
         cleanupCurrentFork?.()
+        await closePortless?.()
         await Promise.all([
           listener.close(),
           close(),
@@ -162,7 +206,7 @@ type ArgsT = Exclude<
   undefined | ((...args: unknown[]) => unknown)
 >
 
-function resolveListenOverrides(args: ParsedArgs<ArgsT>) {
+function resolveListenOverrides(args: ParsedArgs<ArgsT>, publicURL?: string) {
   // _PORT is used by `@nuxt/test-utils` to launch the dev server on a specific port
   if (process.env._PORT) {
     return {
@@ -195,6 +239,8 @@ function resolveListenOverrides(args: ParsedArgs<ArgsT>) {
 
   return {
     ...options,
+    publicURL,
+    showURL: !args.portless,
     // if the https flag is not present, https.xxx arguments are ignored.
     // override if https is enabled in devServer config.
     _https: args.https,

--- a/packages/nuxi/src/dev/portless.ts
+++ b/packages/nuxi/src/dev/portless.ts
@@ -1,0 +1,141 @@
+import { spawnSync } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { basename, join } from 'node:path'
+import process from 'node:process'
+
+import { x } from 'tinyexec'
+
+const DEFAULT_PORTLESS_NAME = 'nuxt-app'
+
+export async function ensurePortlessAvailable(cwd: string) {
+  try {
+    await runPortless(cwd, ['--version'])
+  }
+  catch (error) {
+    if (typeof error === 'object' && error && 'code' in error && error.code === 'ENOENT') {
+      throw new Error('Portless is required for `--portless`. Install it from https://portless.sh')
+    }
+
+    throw createPortlessError('check portless availability', error)
+  }
+}
+
+export async function resolvePortlessURL(cwd: string, name: string) {
+  try {
+    await runPortless(cwd, ['proxy', 'start'])
+    const result = await runPortless(cwd, ['get', name])
+    const url = result.stdout.trim()
+
+    if (!url) {
+      throw new Error('Portless returned an empty URL')
+    }
+
+    return new URL(url).toString().replace(/\/$/, '')
+  }
+  catch (error) {
+    throw createPortlessError('resolve the portless URL', error)
+  }
+}
+
+export function resolvePortlessAliasName(url: string) {
+  const aliasName = new URL(url).hostname.replace(/\.[^.]+$/, '')
+  if (!aliasName) {
+    throw new Error('Portless returned an invalid hostname')
+  }
+  return aliasName
+}
+
+export async function registerPortlessAlias(cwd: string, name: string, port: number) {
+  try {
+    await runPortless(cwd, ['alias', name, `${port}`, '--force'])
+  }
+  catch (error) {
+    throw createPortlessError(`register the portless alias for port ${port}`, error)
+  }
+}
+
+export async function removePortlessAlias(cwd: string, name: string) {
+  try {
+    await runPortless(cwd, ['alias', '--remove', name])
+  }
+  catch (error) {
+    throw createPortlessError(`remove the portless alias for ${name}`, error)
+  }
+}
+
+export function registerPortlessExitCleanup(cwd: string, name: string) {
+  let disposed = false
+
+  const cleanup = () => {
+    if (disposed) {
+      return
+    }
+
+    disposed = true
+    process.off('exit', cleanup)
+    const result = runPortlessSync(cwd, ['alias', '--remove', name])
+    if (result.error || result.status) {
+      const message = result.stderr?.trim() || result.error?.message || `portless exited with code ${result.status}`
+      process.stderr.write(`Failed to remove the portless alias for ${name}: ${message}\n`)
+    }
+  }
+
+  process.on('exit', cleanup)
+
+  return () => {
+    disposed = true
+    process.off('exit', cleanup)
+  }
+}
+
+function createPortlessError(action: string, error: unknown) {
+  const message = typeof error === 'object' && error && 'stderr' in error && typeof error.stderr === 'string' && error.stderr.trim()
+    ? error.stderr.trim()
+    : error instanceof Error && error.message
+      ? error.message
+      : 'Unknown portless error'
+
+  return new Error(`Failed to ${action}: ${message}`)
+}
+
+export async function resolvePortlessName(cwd: string) {
+  const configuredName = await readNameFromFile(cwd, 'portless.json')
+    || await readNameFromFile(cwd, 'package.json')
+    || basename(cwd)
+  return normalizePortlessName(configuredName)
+}
+
+function normalizePortlessName(value: string) {
+  const normalizedValue = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalizedValue || DEFAULT_PORTLESS_NAME
+}
+
+function readNameFromFile(cwd: string, filename: string) {
+  return readFile(join(cwd, filename), 'utf8')
+    .then(contents => JSON.parse(contents))
+    .then(config => typeof config.name === 'string' ? config.name : undefined)
+    .catch(() => undefined)
+}
+
+function runPortless(cwd: string, args: string[]) {
+  return x('portless', args, {
+    throwOnError: true,
+    nodeOptions: {
+      cwd,
+      stdio: 'pipe',
+    },
+  })
+}
+
+function runPortlessSync(cwd: string, args: string[]) {
+  return spawnSync('portless', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  })
+}

--- a/packages/nuxi/test/unit/dev/portless-exit.spec.ts
+++ b/packages/nuxi/test/unit/dev/portless-exit.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registerPortlessExitCleanup } from '../../../src/dev/portless'
+
+const { spawnSync } = vi.hoisted(() => {
+  return {
+    spawnSync: vi.fn(),
+  }
+})
+
+vi.mock('node:child_process', () => {
+  return {
+    spawnSync,
+  }
+})
+
+describe('registerPortlessExitCleanup', () => {
+  const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+  afterEach(() => {
+    spawnSync.mockReset()
+    stderrWrite.mockClear()
+  })
+
+  it('removes the alias on process exit', () => {
+    spawnSync.mockReturnValue({ status: 0, stderr: '', error: undefined })
+    const existingListeners = new Set(process.listeners('exit'))
+    const dispose = registerPortlessExitCleanup('/tmp/fixtures-dev', 'fixtures-dev')
+    const cleanup = process.listeners('exit').find(listener => !existingListeners.has(listener))
+
+    expect(cleanup).toBeTypeOf('function')
+
+    cleanup?.(0)
+
+    expect(spawnSync).toHaveBeenCalledWith('portless', ['alias', '--remove', 'fixtures-dev'], {
+      cwd: '/tmp/fixtures-dev',
+      encoding: 'utf8',
+      stdio: 'pipe',
+    })
+    expect(stderrWrite).not.toHaveBeenCalled()
+
+    dispose()
+  })
+
+  it('does nothing after the cleanup is disposed', () => {
+    const existingListeners = new Set(process.listeners('exit'))
+    const dispose = registerPortlessExitCleanup('/tmp/fixtures-dev', 'fixtures-dev')
+    const cleanup = process.listeners('exit').find(listener => !existingListeners.has(listener))
+
+    dispose()
+    cleanup?.(0)
+
+    expect(spawnSync).not.toHaveBeenCalled()
+  })
+
+  it('reports cleanup failures on process exit', () => {
+    spawnSync.mockReturnValue({ status: 1, stderr: 'permission denied\n', error: undefined })
+    const existingListeners = new Set(process.listeners('exit'))
+    const dispose = registerPortlessExitCleanup('/tmp/fixtures-dev', 'fixtures-dev')
+    const cleanup = process.listeners('exit').find(listener => !existingListeners.has(listener))
+
+    cleanup?.(0)
+
+    expect(stderrWrite).toHaveBeenCalledWith(
+      'Failed to remove the portless alias for fixtures-dev: permission denied\n',
+    )
+
+    dispose()
+  })
+})

--- a/packages/nuxi/test/unit/dev/portless.spec.ts
+++ b/packages/nuxi/test/unit/dev/portless.spec.ts
@@ -1,0 +1,172 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resolvePortlessAliasName, resolvePortlessName } from '../../../src/dev/portless'
+
+const tempDirs: string[] = []
+
+async function createTempDir(name: string) {
+  const dir = await mkdtemp(join(tmpdir(), `${name}-`))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function loadPortlessWithTinyexecMock(implementation: (command: string, args: string[]) => Promise<unknown>) {
+  vi.doMock('tinyexec', () => ({
+    x: vi.fn((command: string, args: string[]) => implementation(command, args)),
+  }))
+
+  return await import('../../../src/dev/portless')
+}
+
+describe('resolvePortlessName', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+  })
+
+  it('preserves package scope in normalized form', async () => {
+    const cwd = await createTempDir('portless-scoped')
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: '@acme/web' }))
+
+    await expect(resolvePortlessName(cwd)).resolves.toBe('acme-web')
+  })
+
+  it('prefers portless.json over package.json', async () => {
+    const cwd = await createTempDir('portless-config')
+    await writeFile(join(cwd, 'portless.json'), JSON.stringify({ name: 'preview-app' }))
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: '@acme/web' }))
+
+    await expect(resolvePortlessName(cwd)).resolves.toBe('preview-app')
+  })
+
+  it('normalizes invalid characters', async () => {
+    const cwd = await createTempDir('portless-normalized')
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: 'My App/API' }))
+
+    await expect(resolvePortlessName(cwd)).resolves.toBe('my-app-api')
+  })
+
+  it('falls back to the directory name when package name is missing', async () => {
+    const root = await createTempDir('portless-missing-name')
+    const cwd = join(root, 'Fancy Project')
+    await mkdir(cwd)
+    await writeFile(join(root, 'package.json'), JSON.stringify({ private: true }))
+
+    await expect(resolvePortlessName(cwd)).resolves.toBe('fancy-project')
+  })
+
+  it('does not inherit a package name from parent directories', async () => {
+    const root = await createTempDir('portless-parent-name')
+    const cwd = join(root, 'apps', 'Web App')
+    await mkdir(cwd, { recursive: true })
+    await writeFile(join(root, 'package.json'), JSON.stringify({ name: 'monorepo-root' }))
+
+    await expect(resolvePortlessName(cwd)).resolves.toBe('web-app')
+  })
+
+  it('falls back to nuxt-app when normalization produces an empty name', async () => {
+    const cwd = await createTempDir('portless-empty')
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: '@@@' }))
+
+    await expect(resolvePortlessName(cwd)).resolves.toBe('nuxt-app')
+  })
+})
+
+describe('resolvePortlessAliasName', () => {
+  it('drops the tld but preserves prefixed subdomains', () => {
+    expect(resolvePortlessAliasName('https://preview.fixtures-dev.localhost')).toBe('preview.fixtures-dev')
+    expect(resolvePortlessAliasName('https://fixtures-dev.test')).toBe('fixtures-dev')
+  })
+})
+
+describe('portless command failures', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.doUnmock('tinyexec')
+  })
+
+  it('reports a missing portless binary with an install hint', async () => {
+    const { ensurePortlessAvailable } = await loadPortlessWithTinyexecMock(async () => {
+      const error = new Error('spawn portless ENOENT') as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    })
+
+    await expect(ensurePortlessAvailable('/tmp/fixtures-dev')).rejects.toThrow(
+      'Portless is required for `--portless`. Install it from https://portless.sh',
+    )
+  })
+
+  it('wraps stderr from portless get failures', async () => {
+    const { resolvePortlessURL } = await loadPortlessWithTinyexecMock(async (_command, args) => {
+      if (args[0] === 'proxy') {
+        return { stdout: '' }
+      }
+
+      const error = new Error('permission denied')
+      ;(error as Error & { stderr?: string }).stderr = 'permission denied\n'
+      throw error
+    })
+
+    await expect(resolvePortlessURL('/tmp/fixtures-dev', 'fixtures-dev')).rejects.toThrow(
+      'Failed to resolve the portless URL: permission denied',
+    )
+  })
+
+  it('rejects empty portless URLs', async () => {
+    const { resolvePortlessURL } = await loadPortlessWithTinyexecMock(async () => ({ stdout: '   ' }))
+
+    await expect(resolvePortlessURL('/tmp/fixtures-dev', 'fixtures-dev')).rejects.toThrow(
+      'Failed to resolve the portless URL: Portless returned an empty URL',
+    )
+  })
+
+  it('uses worktree-aware portless URL resolution', async () => {
+    const calls: string[][] = []
+    const { resolvePortlessURL } = await loadPortlessWithTinyexecMock(async (_command, args) => {
+      calls.push(args)
+      if (args[0] === 'proxy') {
+        return { stdout: '' }
+      }
+
+      return { stdout: 'https://preview.fixtures-dev.localhost\n' }
+    })
+
+    await expect(resolvePortlessURL('/tmp/fixtures-dev', 'fixtures-dev')).resolves.toBe('https://preview.fixtures-dev.localhost')
+    expect(calls).toEqual([
+      ['proxy', 'start'],
+      ['get', 'fixtures-dev'],
+    ])
+  })
+
+  it('wraps portless alias failures with the action name', async () => {
+    const { registerPortlessAlias, removePortlessAlias } = await loadPortlessWithTinyexecMock(async () => {
+      throw new Error('alias command failed')
+    })
+
+    await expect(registerPortlessAlias('/tmp/fixtures-dev', 'fixtures-dev', 3000)).rejects.toThrow(
+      'Failed to register the portless alias for port 3000: alias command failed',
+    )
+    await expect(removePortlessAlias('/tmp/fixtures-dev', 'fixtures-dev')).rejects.toThrow(
+      'Failed to remove the portless alias for fixtures-dev: alias command failed',
+    )
+  })
+
+  it('registers portless aliases with force', async () => {
+    const calls: string[][] = []
+    const { registerPortlessAlias } = await loadPortlessWithTinyexecMock(async (_command, args) => {
+      calls.push(args)
+      return { stdout: '' }
+    })
+
+    await registerPortlessAlias('/tmp/fixtures-dev', 'fixtures-dev', 3000)
+
+    expect(calls).toEqual([['alias', 'fixtures-dev', '3000', '--force']])
+  })
+})

--- a/packages/nuxt-cli/test/e2e/dev.spec.ts
+++ b/packages/nuxt-cli/test/e2e/dev.spec.ts
@@ -1,6 +1,9 @@
-import { readFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { request as httpRequest } from 'node:http'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { stripVTControlCharacters } from 'node:util'
 import { getPort } from 'get-port-please'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { runCommand } from '../../src'
@@ -13,6 +16,99 @@ const certsDir = fileURLToPath(new URL('../../../../playground/certs', import.me
 const httpsCert = join(certsDir, 'cert.dummy')
 const httpsKey = join(certsDir, 'key.dummy')
 const httpsPfx = join(certsDir, 'pfx.dummy')
+
+async function createFakePortless(url: string) {
+  const binDir = await mkdtemp(join(tmpdir(), 'portless-bin-'))
+  const logFile = join(binDir, 'portless.log')
+  const scriptFile = join(binDir, 'portless.mjs')
+  const unixBinary = join(binDir, 'portless')
+  const windowsBinary = join(binDir, 'portless.cmd')
+
+  await writeFile(scriptFile, `import { appendFileSync } from 'node:fs'
+
+const args = process.argv.slice(2)
+appendFileSync(process.env.PORTLESS_LOG, \`\${args.join(' ')}\\n\`)
+
+if (args[0] === '--version') {
+  process.stdout.write('0.1.0\\n')
+}
+else if (args[0] === 'get') {
+  process.stdout.write(\`\${process.env.PORTLESS_URL_VALUE || ''}\\n\`)
+}
+`)
+
+  await writeFile(unixBinary, `#!/bin/sh
+exec node "$(dirname "$0")/portless.mjs" "$@"
+`)
+  await chmod(unixBinary, 0o755)
+
+  await writeFile(windowsBinary, `@echo off
+node "%~dp0\\portless.mjs" %*
+`)
+
+  return { binDir, logFile, url }
+}
+
+function requestWithHost(url: string, hostHeader: string) {
+  return new Promise<number>((resolve, reject) => {
+    const req = httpRequest(url, { headers: { host: hostHeader } }, (res) => {
+      resolve(res.statusCode || 0)
+      res.resume()
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+async function waitFor<T>(run: () => Promise<T>, check: (value: T) => boolean, timeout = 15_000) {
+  const start = Date.now()
+  let lastError: unknown
+
+  while (Date.now() - start < timeout) {
+    try {
+      const value = await run()
+      if (check(value)) {
+        return value
+      }
+    }
+    catch (error) {
+      lastError = error
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`Timed out after ${timeout}ms`)
+}
+
+async function readPortlessLogLines(logFile: string) {
+  try {
+    return await readFile(logFile, 'utf-8').then(content => content.trim().split(NEWLINE_RE).filter(Boolean))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+    throw error
+  }
+}
+
+function extractLoggedURLs(calls: unknown[][]) {
+  return calls.flatMap(call => call.flatMap((value) => {
+    if (typeof value !== 'string') {
+      return []
+    }
+
+    return (value.match(/https?:\/\/[^\s)]+/g) || []).map(normalizeLoggedURL)
+  }))
+}
+
+function normalizeLoggedURL(url: string) {
+  return stripVTControlCharacters(url)
+    .trim()
+    .replace(/[),.]+$/g, '')
+    .replace(/\/$/, '')
+}
 
 describe('dev server', () => {
   afterEach(() => {
@@ -63,6 +159,53 @@ describe('dev server', () => {
       port,
       url: `http://${host}:${port}/`,
     })
+  })
+
+  it('should expose the dev server through portless', { timeout: 50_000 }, async () => {
+    await rm(join(fixtureDir, '.nuxt'), { recursive: true, force: true })
+    const host = '127.0.0.1'
+    const port = await getPort({ host, port: 3051 })
+    const portlessURL = 'https://preview.fixtures-dev.localhost'
+    const { binDir, logFile } = await createFakePortless(portlessURL)
+    let close: (() => Promise<void>) | undefined
+
+    vi.stubEnv('PATH', `${binDir}${delimiter}${process.env.PATH || ''}`)
+    vi.stubEnv('PORTLESS_LOG', logFile)
+    vi.stubEnv('PORTLESS_URL_VALUE', portlessURL)
+
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      const result = await runCommand('dev', [`--host=${host}`, `--port=${port}`, `--cwd=${fixtureDir}`, '--portless']) as any
+      close = result.result.close
+
+      expect(await waitFor(
+        () => requestWithHost(`http://${host}:${port}`, 'preview.fixtures-dev.localhost'),
+        status => status === 200,
+      )).toBe(200)
+
+      await close?.()
+      close = undefined
+
+      const logLines = await readPortlessLogLines(logFile)
+
+      expect(logLines[0]).toBe('--version')
+      expect(logLines[1]).toBe('proxy start')
+      expect(logLines[2]).toBe('get fixtures-dev')
+      expect(logLines[3]).toBe(`alias preview.fixtures-dev ${port} --force`)
+      expect(logLines[4]).toBe('alias --remove preview.fixtures-dev')
+      expect(extractLoggedURLs(consoleLog.mock.calls)).toContain(portlessURL)
+      expect(process.env.PORTLESS_URL).toBeUndefined()
+    }
+    finally {
+      await close?.()
+      consoleLog.mockRestore()
+      await rm(binDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should reject combining portless and tunnel', async () => {
+    await expect(runCommand('dev', ['--cwd', fixtureDir, '--portless', '--tunnel'])).rejects.toThrow('`--portless` cannot be used with `--tunnel`.')
   })
 
   it('should handle multiple set-cookie headers correctly', { timeout: 50_000 }, async () => {


### PR DESCRIPTION
Adds `nuxi dev --portless`, precomputes the Portless hostname so Nuxt/Vite allowlists include it, and exposes the dev server through the external Portless CLI.