### PR TITLE
fix: handle missing nuxt version in `readPackageJSON`

### DIFF
--- a/packages/nuxi/src/utils/versions.ts
+++ b/packages/nuxi/src/utils/versions.ts
@@ -6,7 +6,7 @@ import { coerce } from 'semver'
 import { tryResolveNuxt } from './kit'
 
 export async function getNuxtVersion(cwd: string, cache = true) {
-  const nuxtPkg = await readPackageJSON('nuxt', { url: cwd, try: true, cache })
+  const nuxtPkg = await readPackageJSON('nuxt', { url: cwd, try: true, cache }).catch(() => null)
   if (nuxtPkg) {
     return nuxtPkg.version!
   }


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #1179 

### 📚 Description

`npm create nuxt@latest -- test --template=minimal --modules=eslint --install=false`

With `--install=false`, the template is downloaded but `Nuxt` is never installed. `getNuxtVersion` then can't find it and throws an error. The error wasn't caught. Now we simple caught it and the process can finish correctly.