### PR TITLE
fix(dev): suppress spurious dist watcher restart on cold start

### DIFF
--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -451,6 +451,10 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     this.#fileChangeTracker.prime(distDir)
     this.#distWatcher = watch(distDir)
     this.#distWatcher.on('change', (_event, file: string) => {
+      // do not restart if the directory has not been removed
+      if (existsSync(distDir)) {
+        return
+      }
       if (!this.#fileChangeTracker.shouldEmitChange(resolve(distDir, file || ''))) {
         return
       }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this fixes a bug with a full cold start (ie no `.nuxt` dir) where we would always restart 🤦

```
❯ rm -rf .nuxt
❯ pnpm dev

> nuxt-app@ dev /private/tmp/nuxt-app
> nuxt dev

│                                                                                                                                   07:22:19
●  Nuxt 4.4.4 (with Nitro 2.13.4, Vite 7.3.3 and Vue 3.5.34)
[get-port] Unable to find an available port (tried 3000 on host "localhost"). Using alternative port 3001.                          07:22:19
                                                                                                                                    07:22:20
  ➜ Local:    http://localhost:3001/
  ➜ Network:  use --host to expose

  ➜ DevTools: press Shift + Option + D in the browser (v3.2.4)                                                                      07:22:20

✔ Vite client built in 12ms                                                                                                        07:22:20
✔ Vite server built in 5ms                                                                                                         07:22:20
✔ Nuxt Nitro server built in 289ms                                                                                           nitro 07:22:21
ℹ .nuxt/dist directory has been removed. Restarting Nuxt...                                                                        07:22:21
ℹ Vite server warmed up in 157ms                                                                                                   07:22:21
✘ [ERROR] The build was canceled

ℹ Vite client warmed up in 207ms                                                                                                   07:22:21
  ➜ DevTools: press Shift + Option + D in the browser (v3.2.4)                                                                      07:22:21

✔ Vite client built in 3ms                                                                                                         07:22:21
✔ Vite server built in 3ms                                                                                                         07:22:21
✔ Nuxt Nitro server built in 183ms                                                                                           nitro 07:22:21
ℹ Vite server warmed up in 1ms                                                                                                     07:22:21
ℹ Vite client warmed up in 1ms                                                                                                     07:22:21
```