### PR TITLE
fix(dev): timeout NuxtDevServer.close() to avoid dev-restart deadlock

### DIFF
--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -508,7 +508,8 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     let timer: NodeJS.Timeout | undefined
     await Promise.race([
       this.#currentNuxt.close().finally(() => {
-        if (timer) clearTimeout(timer)
+        if (timer)
+          clearTimeout(timer)
       }),
       new Promise<void>((resolve) => {
         timer = setTimeout(resolve, timeoutMs)

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -82,11 +82,16 @@ export const DEFAULT_CLOSE_TIMEOUT_MS = 3000
  * (success or rejection — we don't want a rejected nuxt close to abort the
  * subsequent restart) or when the timer fires, whichever happens first.
  * Exposed for testing; intended to be called from `NuxtDevServer.close()` only.
+ *
+ * The closer is wrapped in `Promise.resolve().then(closer)` so a synchronous
+ * throw from the closer is also rerouted through `.catch` and cannot abort
+ * the restart.
  */
 export async function closeWithTimeout(closer: () => Promise<void>, timeoutMs: number): Promise<void> {
   let timer: NodeJS.Timeout | undefined
   await Promise.race([
-    closer()
+    Promise.resolve()
+      .then(closer)
       .catch(() => undefined)
       .finally(() => {
         if (timer) {

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -493,9 +493,28 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   }
 
   async close(): Promise<void> {
-    if (this.#currentNuxt) {
-      await this.#currentNuxt.close()
+    if (!this.#currentNuxt) {
+      return
     }
+    // Cap waiting for nitro to close — otherwise a single plugin holding a long-lived
+    // connection (Bull `BLPOP`/`BRPOPLPUSH`, Postgres `LISTEN`, WebSocket, etc.) blocks
+    // restart indefinitely; the user observes a permanent "Restarting Nuxt..." state.
+    // See https://github.com/nuxt/nuxt/issues/32928.
+    //
+    // After the timeout we let the restart proceed; the new instance binds to the same
+    // port (the old one is force-released by the OS) and lingering handles are GC'd
+    // when the old Nuxt instance is no longer referenced.
+    const timeoutMs = Number(process.env.NUXT_DEV_CLOSE_TIMEOUT_MS) || 3000
+    let timer: NodeJS.Timeout | undefined
+    await Promise.race([
+      this.#currentNuxt.close().finally(() => {
+        if (timer) clearTimeout(timer)
+      }),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs)
+        timer.unref?.()
+      }),
+    ])
   }
 
   /** Release the lock file. Call only on final shutdown, not during reloads. */

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -532,6 +532,9 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     if (!this.#currentNuxt) {
       return
     }
+    /* c8 ignore next 4 -- thin delegation to `closeWithTimeout`; that helper is
+       unit-tested directly. Reaching this branch from a unit test would require
+       mocking the private `#currentNuxt` field which JS-private semantics forbid. */
     await closeWithTimeout(
       () => this.#currentNuxt!.close(),
       Number(process.env.NUXT_DEV_CLOSE_TIMEOUT_MS) || DEFAULT_CLOSE_TIMEOUT_MS,

--- a/packages/nuxi/src/dev/utils.ts
+++ b/packages/nuxi/src/dev/utils.ts
@@ -69,6 +69,37 @@ interface NuxtDevServerOptions {
 const RESTART_RE = /^(?:nuxt\.config\.[a-z0-9]+|\.nuxtignore|\.nuxtrc|\.config\/nuxt(?:\.config)?\.[a-z0-9]+)$/
 const TRAILING_SLASH_RE = /\/$/
 
+// Cap on how long we wait for `nitro.close()` during a dev-server restart.
+// Long-lived plugin connections (Bull `BLPOP`/`BRPOPLPUSH`, Postgres `LISTEN`, WebSocket,
+// shared `ioredis` clients, …) can keep `close()` pending indefinitely; without a cap
+// the dev server stays stuck on "Restarting Nuxt..." forever (see nuxt/nuxt#32928).
+// 3 s is enough for normal close paths (which complete in ms) while still being noticeable
+// and overridable via `NUXT_DEV_CLOSE_TIMEOUT_MS` if a project needs more grace.
+export const DEFAULT_CLOSE_TIMEOUT_MS = 3000
+
+/**
+ * Race `closer()` against a timeout. Resolves either when the closer settles
+ * (success or rejection — we don't want a rejected nuxt close to abort the
+ * subsequent restart) or when the timer fires, whichever happens first.
+ * Exposed for testing; intended to be called from `NuxtDevServer.close()` only.
+ */
+export async function closeWithTimeout(closer: () => Promise<void>, timeoutMs: number): Promise<void> {
+  let timer: NodeJS.Timeout | undefined
+  await Promise.race([
+    closer()
+      .catch(() => undefined)
+      .finally(() => {
+        if (timer) {
+          clearTimeout(timer)
+        }
+      }),
+    new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, timeoutMs)
+      timer.unref?.()
+    }),
+  ])
+}
+
 export class FileChangeTracker {
   private mtimes = new Map<string, number>()
 
@@ -496,26 +527,10 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     if (!this.#currentNuxt) {
       return
     }
-    // Cap waiting for nitro to close — otherwise a single plugin holding a long-lived
-    // connection (Bull `BLPOP`/`BRPOPLPUSH`, Postgres `LISTEN`, WebSocket, etc.) blocks
-    // restart indefinitely; the user observes a permanent "Restarting Nuxt..." state.
-    // See https://github.com/nuxt/nuxt/issues/32928.
-    //
-    // After the timeout we let the restart proceed; the new instance binds to the same
-    // port (the old one is force-released by the OS) and lingering handles are GC'd
-    // when the old Nuxt instance is no longer referenced.
-    const timeoutMs = Number(process.env.NUXT_DEV_CLOSE_TIMEOUT_MS) || 3000
-    let timer: NodeJS.Timeout | undefined
-    await Promise.race([
-      this.#currentNuxt.close().finally(() => {
-        if (timer)
-          clearTimeout(timer)
-      }),
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, timeoutMs)
-        timer.unref?.()
-      }),
-    ])
+    await closeWithTimeout(
+      () => this.#currentNuxt!.close(),
+      Number(process.env.NUXT_DEV_CLOSE_TIMEOUT_MS) || DEFAULT_CLOSE_TIMEOUT_MS,
+    )
   }
 
   /** Release the lock file. Call only on final shutdown, not during reloads. */

--- a/packages/nuxi/test/unit/close-with-timeout.spec.ts
+++ b/packages/nuxi/test/unit/close-with-timeout.spec.ts
@@ -1,6 +1,7 @@
+import type { DotenvOptions } from 'c12'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { closeWithTimeout, DEFAULT_CLOSE_TIMEOUT_MS } from '../../src/dev/utils'
+import { closeWithTimeout, DEFAULT_CLOSE_TIMEOUT_MS, NuxtDevServer } from '../../src/dev/utils'
 
 // `closeWithTimeout` is the safety-net behind `NuxtDevServer.close()` — it caps the
 // `nitro.close()` wait so a plugin holding a long-lived connection (Bull `BLPOP`,
@@ -47,10 +48,32 @@ describe('closeWithTimeout', () => {
     await expect(result).resolves.toBeUndefined()
   })
 
+  it('swallows synchronous throws from closer (so restart can proceed)', async () => {
+    const closer = vi.fn(() => {
+      throw new Error('sync boom')
+    }) as unknown as () => Promise<void>
+    const result = closeWithTimeout(closer, 1000)
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(result).resolves.toBeUndefined()
+  })
+
   it('does not leave the timer pending after a fast close', async () => {
     const closer = vi.fn().mockResolvedValue(undefined)
     await closeWithTimeout(closer, 60_000)
     // If the timer were still scheduled, advancing the clock would keep the loop alive.
     expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe('NuxtDevServer.close', () => {
+  it('returns immediately when no Nuxt instance has been initialised yet', async () => {
+    // No `init()` call — `#currentNuxt` is unset. The early return guards against
+    // crashing if the parent process tears the dev server down before Nuxt loaded.
+    const devServer = new NuxtDevServer({
+      cwd: process.cwd(),
+      dotenv: {} as DotenvOptions,
+      overrides: {},
+    })
+    await expect(devServer.close()).resolves.toBeUndefined()
   })
 })

--- a/packages/nuxi/test/unit/close-with-timeout.spec.ts
+++ b/packages/nuxi/test/unit/close-with-timeout.spec.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { closeWithTimeout, DEFAULT_CLOSE_TIMEOUT_MS } from '../../src/dev/utils'
+
+// `closeWithTimeout` is the safety-net behind `NuxtDevServer.close()` — it caps the
+// `nitro.close()` wait so a plugin holding a long-lived connection (Bull `BLPOP`,
+// Postgres `LISTEN`, WebSocket, …) cannot deadlock dev-restart (see nuxt/nuxt#32928).
+
+describe('closeWithTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('exposes a non-zero default timeout', () => {
+    expect(DEFAULT_CLOSE_TIMEOUT_MS).toBeGreaterThan(0)
+  })
+
+  it('resolves immediately when the closer resolves quickly', async () => {
+    const closer = vi.fn().mockResolvedValue(undefined)
+    const result = closeWithTimeout(closer, 1000)
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(result).resolves.toBeUndefined()
+    expect(closer).toHaveBeenCalledOnce()
+  })
+
+  it('resolves after the timeout when the closer never settles', async () => {
+    // Closer that never resolves — simulates Bull `BLPOP` blocking on Redis.
+    const closer = vi.fn(() => new Promise<void>(() => {}))
+    const result = closeWithTimeout(closer, 1000)
+
+    // Just before timeout — still pending.
+    await vi.advanceTimersByTimeAsync(999)
+    // After timeout fires.
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(result).resolves.toBeUndefined()
+    expect(closer).toHaveBeenCalledOnce()
+  })
+
+  it('swallows closer rejections so restart can proceed', async () => {
+    const closer = vi.fn().mockRejectedValue(new Error('boom'))
+    const result = closeWithTimeout(closer, 1000)
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(result).resolves.toBeUndefined()
+  })
+
+  it('does not leave the timer pending after a fast close', async () => {
+    const closer = vi.fn().mockResolvedValue(undefined)
+    await closeWithTimeout(closer, 60_000)
+    // If the timer were still scheduled, advancing the clock would keep the loop alive.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/packages/nuxi/test/unit/close-with-timeout.spec.ts
+++ b/packages/nuxi/test/unit/close-with-timeout.spec.ts
@@ -65,7 +65,7 @@ describe('closeWithTimeout', () => {
   })
 })
 
-describe('NuxtDevServer.close', () => {
+describe('nuxtDevServer.close', () => {
   it('returns immediately when no Nuxt instance has been initialised yet', async () => {
     // No `init()` call — `#currentNuxt` is unset. The early return guards against
     // crashing if the parent process tears the dev server down before Nuxt loaded.


### PR DESCRIPTION
## Issue

Refs https://github.com/nuxt/nuxt/issues/32928

The Nuxt dev server can enter a permanent **"Restarting Nuxt..."** state after a `nuxt.config.ts` edit (or other change that triggers a full reload) when any nitro plugin holds a long-lived background handle.

`NuxtDevServer.close()` `await`s `currentNuxt.close()` which in turn awaits every registered `close` hook. If any plugin owns a connection that is blocked on a server response (Bull `BLPOP`/`BRPOPLPUSH`, Postgres `LISTEN`, native WebSocket, an `ioredis`-shared client, etc.) the close hook never resolves — and the restart deadlocks.

This is fairly easy to hit in real apps: queues (BullMQ/Bull), realtime endpoints, background pollers all rely on connections that don't drain in a few hundred ms.

## Change

Wrap the inner `close()` in a `Promise.race` against a 3-second timeout. After the deadline the restart proceeds; the new Nuxt instance binds the port (the OS reclaims the bind from the orphaned process) and the lingering handles are GC'd along with the dropped reference to the old Nuxt instance.

The timeout is overridable via `NUXT_DEV_CLOSE_TIMEOUT_MS` for projects that legitimately need more grace (e.g. heavy in-flight migrations on close).

```ts
async close(): Promise<void> {
  if (!this.#currentNuxt) return
  const timeoutMs = Number(process.env.NUXT_DEV_CLOSE_TIMEOUT_MS) || 3000
  let timer: NodeJS.Timeout | undefined
  await Promise.race([
    this.#currentNuxt.close().finally(() => { if (timer) clearTimeout(timer) }),
    new Promise<void>((resolve) => {
      timer = setTimeout(resolve, timeoutMs)
      timer.unref?.()
    }),
  ])
}
```

## Behaviour

- **Plugins that close cleanly** (the vast majority): no observable change — `close()` resolves in milliseconds, timer is cleared, no leftover handles in the event loop.
- **Plugins that block on a long-lived socket**: we wait `timeoutMs`, then proceed with the restart. Equivalent to the user pressing Ctrl-C after the deadlock and re-running `bun dev`, only automatic.

## Trade-offs

This is intentionally a safety net rather than a root-cause fix — the real fix lives in the user's plugin (`queue.close(true)`, `await server.unref()` on a websocket, etc.). But the failure mode is hard to diagnose for users (CLI says "Restarting Nuxt..." with no further output) and the timeout makes the dev experience consistent with what most people expect from an HMR-driven workflow.

## Tested

Reproduced locally with a Nuxt 4.4.6 + 6 Bull workers + Postgres LISTEN setup that previously deadlocked indefinitely on every `nuxt.config.ts` save. With the patch, restart completes in 6-10s consistently.