### PR TITLE
ci: improve workflows

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   agentscan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: AgentScan
         id: agentscan

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           mode: silent
+
       - name: Handle flagged PR
         if: contains(fromJSON('["automation","mixed"]'), steps.agentscan.outputs.classification) || steps.agentscan.outputs.community-flagged == 'true'
         env:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
-      - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -3,6 +3,10 @@ name: autofix.ci # needed to securely identify the workflow
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   contents: read

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
-      - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: lts/*

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,7 +11,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,8 +10,8 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-slim
-    concurrency:
-      group: ${{ github.workflow }}-lint-${{ github.event.pull_request.number || github.sha }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -41,9 +42,6 @@ jobs:
       #   run: pnpm test:engines
 
   ci:
-    concurrency:
-      group: ${{ github.workflow }}-ci-${{ github.event.pull_request.number || github.sha }}
-      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -95,9 +93,6 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
 
   release:
-    concurrency:
-      group: ${{ github.workflow }}-release-${{ github.event.pull_request.number || github.sha }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          fetch-depth: 0
-      - run: corepack enable
+          persist-credentials: false
 
       - run: npm i -g corepack && corepack enable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -51,7 +51,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,12 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   lint:
     runs-on: ubuntu-slim
+    concurrency:
+      group: ${{ github.workflow }}-lint-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -42,6 +41,9 @@ jobs:
       #   run: pnpm test:engines
 
   ci:
+    concurrency:
+      group: ${{ github.workflow }}-ci-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
@@ -93,6 +95,9 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
 
   release:
+    concurrency:
+      group: ${{ github.workflow }}-release-${{ github.event.pull_request.number || github.sha }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           fetch-depth: 0
       - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
@@ -48,15 +51,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          fetch-depth: 0
-      - run: corepack enable
+          persist-credentials: false
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/-1
           cache: pnpm
+
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
+
       - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
         with:
           # 2.7.5+ regress dev server / ws tests; 2.7.13 rewrites node:http (denoland/deno#33208)
@@ -93,8 +100,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
-      - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-slim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,15 @@ jobs:
           node-version: lts/-1
           cache: pnpm
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: latest
+      - parallel:
+          - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+            with:
+              bun-version: latest
 
-      - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
-        with:
-          # 2.7.5+ regress dev server / ws tests; 2.7.13 rewrites node:http (denoland/deno#33208)
-          deno-version: 2.7.4
+          - uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2
+            with:
+              # 2.7.5+ regress dev server / ws tests; 2.7.13 rewrites node:http (denoland/deno#33208)
+              deno-version: 2.7.4
 
       - name: 📦 Install dependencies
         run: pnpm install

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          fetch-depth: 0
+          persist-credentials: false
       - name: Check provenance downgrades
         uses: danielroe/provenance-action@41bcc969e579d9e29af08ba44fcbfdf95cee6e6c # v0.1.1
         with:

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read
+
 jobs:
   check-provenance:
     runs-on: ubuntu-slim
@@ -21,6 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
+
       - name: Check provenance downgrades
         uses: danielroe/provenance-action@41bcc969e579d9e29af08ba44fcbfdf95cee6e6c # v0.1.1
         with:

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 

--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 jobs:
   check-provenance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/size-comment.yml
+++ b/.github/workflows/size-comment.yml
@@ -13,7 +13,7 @@ jobs:
   comment:
     # Only run if the build workflow succeeded
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   BUNDLE_SIZE: true
 

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*
@@ -65,7 +67,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.base_ref }}
-      - run: corepack enable
+
+      - run: npm i -g corepack && corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -44,17 +44,18 @@ jobs:
       - name: 💾 Save PR number
         run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
 
-      - name: ⏫ Upload stats.json
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: head-stats
-          path: ./packages/*/stats.json
+      - parallel:
+          - name: ⏫ Upload stats.json
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: head-stats
+              path: ./packages/*/stats.json
 
-      - name: ⏫ Upload PR number
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: pr-number
-          path: pr-number.txt
+          - name: ⏫ Upload PR number
+            uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+            with:
+              name: pr-number
+              path: pr-number.txt
 
   # Build base for comparison and upload stats.json
   # You may replace this with your own build method. All that

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -68,7 +68,7 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
 
-      - run: npm i -g corepack && corepack enable
+      - run: npm i -g --force corepack && corepack enable
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -6,8 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   BUNDLE_SIZE: true


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

#### `ubuntu-slim` runner

Use it for `agent-scan.yml`, `provenance.yml`, and `size-comment.yml` — the lighter 1-vCPU runner reduces queue times and resource usage. The `ci.yml` lint job was also switched but moved back to `ubuntu-latest` since `knip`/`oxc-parser` requires more memory.

#### Concurrency groups

Added to all PR-triggered workflows (`autofix.yml`, `bench.yml`, `ci.yml`, `size.yml`) so runs for the same PR/branch queue sequentially. `cancel-in-progress` was intentionally omitted — GitHub's event system can fire duplicate `pull_request` events for a single push, and `cancel-in-progress: true` caused those duplicates to cancel the legitimate run after 1 second. Runs now queue instead.

#### `persist-credentials: false`

Set on `actions/checkout` in `ci.yml`, `release.yml`, and `provenance.yml` — none of those jobs perform subsequent git operations. `autofix.yml` is intentionally excluded since `autofix-ci/action` pushes lint fixes.

#### Pre-install corepack

Use `npm i -g --force corepack && corepack enable` instead of relying on the bundled version, which will be removed in Node 26. The `--force` flag is needed because the npm global prefix on Windows may already contain a `yarn` shim.

#### Remove unnecessary `fetch-depth: 0`

Drop from jobs that don't need git history (lint, autofix, provenance checks). Kept where needed (release with `changelogen`, benchmarks with CodSpeed).

#### `parallel` keyword

Use for independent steps — `setup-bun`/`setup-deno` in the `ci` matrix job, and the two artifact uploads in `size.yml`.

#### Consistent formatting

Add blank lines between all top-level keys and between all steps across every workflow.
