### PR TITLE
feat: suggest proxy-aware retry command when network fails

### DIFF
--- a/packages/nuxt-cli/src/commands/init.ts
+++ b/packages/nuxt-cli/src/commands/init.ts
@@ -23,7 +23,7 @@ import { runCommandDef as runCommand } from '../run'
 import { nuxtIcon, themeColor } from '../utils/ascii'
 import { createInstallLog, resolvePackageManagerDescriptor, runInstall, takeUnreportedIgnoredBuilds } from '../utils/install'
 import { debug, logger } from '../utils/logger'
-import { describeNetworkError, logNetworkError } from '../utils/network'
+import { classifyNetworkError, describeNetworkError, logNetworkError, probeNetworkError } from '../utils/network'
 import { relativeToProcess } from '../utils/paths'
 import { getTemplates, TEMPLATES_API_URL } from '../utils/starter-templates'
 import { getNuxtVersion } from '../utils/versions'
@@ -364,7 +364,10 @@ export default defineCommand({
       if (process.env.DEBUG) {
         throw err
       }
-      logNetworkError(err, {
+      const diagnosable = classifyNetworkError(err).kind === 'unknown'
+        ? await probeNetworkError(registry) ?? err
+        : err
+      logNetworkError(diagnosable, {
         url: registry,
         hints: [
           `Retry with ${colors.cyan('--offline')} or ${colors.cyan('--preferOffline')} to use a cached template, or set ${colors.cyan('NUXI_INIT_REGISTRY')} to a reachable mirror.`,

--- a/packages/nuxt-cli/src/commands/init.ts
+++ b/packages/nuxt-cli/src/commands/init.ts
@@ -22,13 +22,14 @@ import { x } from 'tinyexec'
 import { runCommandDef as runCommand } from '../run'
 import { nuxtIcon, themeColor } from '../utils/ascii'
 import { createInstallLog, resolvePackageManagerDescriptor, runInstall, takeUnreportedIgnoredBuilds } from '../utils/install'
-import { logger } from '../utils/logger'
+import { debug, logger } from '../utils/logger'
+import { describeNetworkError, logNetworkError } from '../utils/network'
 import { relativeToProcess } from '../utils/paths'
-import { getTemplates } from '../utils/starter-templates'
+import { getTemplates, TEMPLATES_API_URL } from '../utils/starter-templates'
 import { getNuxtVersion } from '../utils/versions'
 import { cwdArgs, logLevelArgs } from './_shared'
 import { selectModulesAutocomplete } from './module/_autocomplete'
-import { checkNuxtCompatibility, fetchModules } from './module/_utils'
+import { checkNuxtCompatibility, fetchModules, MODULES_API_URL } from './module/_utils'
 import addModuleCommand from './module/add'
 
 const NON_WORD_RE = /[^\w-]/g
@@ -38,6 +39,7 @@ const LEADING_TRAILING_DASH_RE = /^-|-$/g
 
 const DEFAULT_REGISTRY = 'https://raw.githubusercontent.com/nuxt/starter/templates/templates'
 const DEFAULT_TEMPLATE_NAME = 'minimal'
+const NIGHTLY_DIST_TAGS_URL = 'https://registry.npmjs.org/nuxt-nightly'
 
 const pms: Record<PackageManagerName, undefined> = {
   npm: undefined,
@@ -179,8 +181,9 @@ export default defineCommand({
           availableTemplates = await getTemplates()
           templatesSpinner.stop('Templates loaded')
         }
-        catch {
+        catch (err) {
           availableTemplates = defaultTemplates
+          debug(describeNetworkError(err, TEMPLATES_API_URL))
           templatesSpinner.stop('Templates loaded from cache')
         }
       }
@@ -320,6 +323,8 @@ export default defineCommand({
     // Download template
     let template: DownloadTemplateResult
 
+    const registry = process.env.NUXI_INIT_REGISTRY || DEFAULT_REGISTRY
+
     const downloadSpinner = spinner()
     downloadSpinner.start(`Downloading ${colors.cyan(templateName)} template`)
 
@@ -329,7 +334,7 @@ export default defineCommand({
         force: shouldForce,
         offline: Boolean(ctx.args.offline),
         preferOffline: Boolean(ctx.args.preferOffline),
-        registry: process.env.NUXI_INIT_REGISTRY || DEFAULT_REGISTRY,
+        registry,
       })
 
       if (dir.length > 0) {
@@ -359,7 +364,12 @@ export default defineCommand({
       if (process.env.DEBUG) {
         throw err
       }
-      logger.error(String(err))
+      logNetworkError(err, {
+        url: registry,
+        hints: [
+          `Retry with ${colors.cyan('--offline')} or ${colors.cyan('--preferOffline')} to use a cached template, or set ${colors.cyan('NUXI_INIT_REGISTRY')} to a reachable mirror.`,
+        ],
+      })
       process.exit(1)
     }
 
@@ -367,7 +377,11 @@ export default defineCommand({
       const nightlySpinner = spinner()
       nightlySpinner.start('Fetching nightly version info')
 
-      const response = await $fetch<{ 'dist-tags': Record<string, string> }>('https://registry.npmjs.org/nuxt-nightly')
+      const response = await $fetch<{ 'dist-tags': Record<string, string> }>(NIGHTLY_DIST_TAGS_URL).catch((err) => {
+        nightlySpinner.error('Failed to fetch nightly version info')
+        logNetworkError(err, { url: NIGHTLY_DIST_TAGS_URL })
+        process.exit(1)
+      })
       const nightlyChannelTag = ctx.args.nightly || 'latest'
 
       if (!nightlyChannelTag) {
@@ -578,7 +592,10 @@ export default defineCommand({
 
     // ...or offer to browse and install modules (if not offline nor non-interactive)
     else if (!ctx.args.offline && !ctx.args.preferOffline && !isNonInteractive) {
-      const modulesPromise = fetchModules()
+      const modulesPromise = fetchModules().catch((err) => {
+        logger.warn(`Could not load the Nuxt Modules database. ${describeNetworkError(err, MODULES_API_URL)}`)
+        return []
+      })
       const wantsUserModules = await confirm({
         message: `Would you like to browse and install modules?`,
         initialValue: false,
@@ -690,13 +707,14 @@ export default defineCommand({
 })
 
 async function getModuleDependencies(moduleName: string) {
+  const url = `https://registry.npmjs.org/${moduleName}/latest`
   try {
-    const response = await $fetch(`https://registry.npmjs.org/${moduleName}/latest`)
+    const response = await $fetch(url)
     const dependencies = response.dependencies || {}
     return Object.keys(dependencies)
   }
   catch (err) {
-    logger.warn(`Could not get dependencies for ${colors.cyan(moduleName)}: ${err}`)
+    logger.warn(`Could not get dependencies for ${colors.cyan(moduleName)}. ${describeNetworkError(err, url)}`)
     return []
   }
 }

--- a/packages/nuxt-cli/src/commands/init.ts
+++ b/packages/nuxt-cli/src/commands/init.ts
@@ -595,8 +595,12 @@ export default defineCommand({
 
     // ...or offer to browse and install modules (if not offline nor non-interactive)
     else if (!ctx.args.offline && !ctx.args.preferOffline && !isNonInteractive) {
+      // Requested before the prompt so the list is ready if the user says yes,
+      // but a failure is only reported to users who asked for it (and never
+      // while the prompt is on screen).
+      let modulesError: unknown
       const modulesPromise = fetchModules().catch((err) => {
-        logger.warn(`Could not load the Nuxt Modules database. ${describeNetworkError(err, MODULES_API_URL)}`)
+        modulesError = err
         return []
       })
       const wantsUserModules = await confirm({
@@ -619,7 +623,13 @@ export default defineCommand({
           getNuxtVersion(template.dir),
         ])
 
-        modulesSpinner.stop('Modules loaded')
+        if (modulesError) {
+          modulesSpinner.error('Failed to fetch available modules')
+          logNetworkError(modulesError, { url: MODULES_API_URL, level: 'warn', prefix: 'Could not load the Nuxt Modules database.' })
+        }
+        else {
+          modulesSpinner.stop('Modules loaded')
+        }
 
         const allModules = response
           .filter(module =>
@@ -717,7 +727,7 @@ async function getModuleDependencies(moduleName: string) {
     return Object.keys(dependencies)
   }
   catch (err) {
-    logger.warn(`Could not get dependencies for ${colors.cyan(moduleName)}. ${describeNetworkError(err, url)}`)
+    logNetworkError(err, { url, level: 'warn', prefix: `Could not get dependencies for ${colors.cyan(moduleName)}.` })
     return []
   }
 }

--- a/packages/nuxt-cli/src/commands/module/_utils.ts
+++ b/packages/nuxt-cli/src/commands/module/_utils.ts
@@ -107,10 +107,10 @@ export interface NuxtModule {
   createdAt?: number
 }
 
+export const MODULES_API_URL = 'https://api.nuxt.com/modules?version=all'
+
 export async function fetchModules(): Promise<NuxtModule[]> {
-  const { modules } = await $fetch<NuxtApiModulesResponse>(
-    `https://api.nuxt.com/modules?version=all`,
-  )
+  const { modules } = await $fetch<NuxtApiModulesResponse>(MODULES_API_URL)
   return modules
 }
 

--- a/packages/nuxt-cli/src/commands/module/add.ts
+++ b/packages/nuxt-cli/src/commands/module/add.ts
@@ -22,11 +22,12 @@ import { satisfies } from 'verkit'
 import { runCommandDef as runCommand } from '../../run'
 import { createInstallLog, resolvePackageManagerDescriptor, runInstall, takeUnreportedIgnoredBuilds } from '../../utils/install'
 import { logger } from '../../utils/logger'
+import { describeNetworkError, logNetworkError } from '../../utils/network'
 import { getNuxtVersion } from '../../utils/versions'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import prepareCommand from '../prepare'
 import { selectModulesAutocomplete } from './_autocomplete'
-import { checkNuxtCompatibility, ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, getRegistryFromContent, isPnpmWorkspace } from './_utils'
+import { checkNuxtCompatibility, ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, getRegistryFromContent, isPnpmWorkspace, MODULES_API_URL } from './_utils'
 
 const PROTOCOL_RE = /^https?:\/\//
 const TRAILING_SLASH_RE = /\/$/
@@ -93,7 +94,11 @@ export default defineCommand({
       modulesSpinner.start('Fetching available modules')
 
       const [allModules, nuxtVersion] = await Promise.all([
-        fetchModules(),
+        fetchModules().catch((err) => {
+          modulesSpinner.error('Failed to fetch available modules')
+          logNetworkError(err, { url: MODULES_API_URL })
+          process.exit(1)
+        }),
         getNuxtVersion(cwd),
       ])
 
@@ -343,7 +348,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   }
 
   const modulesDB = await fetchModules().catch((err) => {
-    logger.warn(`Cannot search in the Nuxt Modules database: ${err}`)
+    logger.warn(`Cannot search in the Nuxt Modules database. ${describeNetworkError(err, MODULES_API_URL)}`)
     return []
   })
 
@@ -418,9 +423,12 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   }
 
   // TODO: spinner
-  const pkgDetails = await $fetch(joinURL(meta.registry, `${pkgName}`), { headers }).catch(() => null)
+  const pkgUrl = joinURL(meta.registry, `${pkgName}`)
+  const pkgDetails = await $fetch(pkgUrl, { headers }).catch((err: unknown) => {
+    logNetworkError(err, { url: pkgUrl, prefix: `Failed to fetch package details for ${colors.cyan(pkgName)}.` })
+    return null
+  })
   if (!pkgDetails) {
-    logger.error(`Failed to fetch package details for ${colors.cyan(pkgName)}.`)
     return false
   }
 

--- a/packages/nuxt-cli/src/commands/module/add.ts
+++ b/packages/nuxt-cli/src/commands/module/add.ts
@@ -22,7 +22,7 @@ import { satisfies } from 'verkit'
 import { runCommandDef as runCommand } from '../../run'
 import { createInstallLog, resolvePackageManagerDescriptor, runInstall, takeUnreportedIgnoredBuilds } from '../../utils/install'
 import { logger } from '../../utils/logger'
-import { describeNetworkError, logNetworkError } from '../../utils/network'
+import { logNetworkError } from '../../utils/network'
 import { getNuxtVersion } from '../../utils/versions'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import prepareCommand from '../prepare'
@@ -348,7 +348,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   }
 
   const modulesDB = await fetchModules().catch((err) => {
-    logger.warn(`Cannot search in the Nuxt Modules database. ${describeNetworkError(err, MODULES_API_URL)}`)
+    logNetworkError(err, { url: MODULES_API_URL, level: 'warn', prefix: 'Cannot search in the Nuxt Modules database.' })
     return []
   })
 

--- a/packages/nuxt-cli/src/commands/module/remove.ts
+++ b/packages/nuxt-cli/src/commands/module/remove.ts
@@ -14,10 +14,11 @@ import { readPackageJSON } from 'pkg-types'
 
 import { runCommandDef as runCommand } from '../../run'
 import { logger } from '../../utils/logger'
+import { describeNetworkError } from '../../utils/network'
 import { relativeToProcess } from '../../utils/paths'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import prepareCommand from '../prepare'
-import { ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, isPnpmWorkspace } from './_utils'
+import { ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, isPnpmWorkspace, MODULES_API_URL } from './_utils'
 
 interface OrphanedPeer {
   peer: string
@@ -67,7 +68,7 @@ export default defineCommand({
     const needsDB = modules.some(m => !installedNames.has(m))
     const modulesDB: NuxtModule[] = needsDB
       ? await fetchModules().catch((err) => {
-          logger.warn(`Cannot search in the Nuxt Modules database: ${err}`)
+          logger.warn(`Cannot search in the Nuxt Modules database. ${describeNetworkError(err, MODULES_API_URL)}`)
           return []
         })
       : []

--- a/packages/nuxt-cli/src/commands/module/remove.ts
+++ b/packages/nuxt-cli/src/commands/module/remove.ts
@@ -14,7 +14,7 @@ import { readPackageJSON } from 'pkg-types'
 
 import { runCommandDef as runCommand } from '../../run'
 import { logger } from '../../utils/logger'
-import { describeNetworkError } from '../../utils/network'
+import { logNetworkError } from '../../utils/network'
 import { relativeToProcess } from '../../utils/paths'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import prepareCommand from '../prepare'
@@ -68,7 +68,7 @@ export default defineCommand({
     const needsDB = modules.some(m => !installedNames.has(m))
     const modulesDB: NuxtModule[] = needsDB
       ? await fetchModules().catch((err) => {
-          logger.warn(`Cannot search in the Nuxt Modules database. ${describeNetworkError(err, MODULES_API_URL)}`)
+          logNetworkError(err, { url: MODULES_API_URL, level: 'warn', prefix: 'Cannot search in the Nuxt Modules database.' })
           return []
         })
       : []

--- a/packages/nuxt-cli/src/commands/module/search.ts
+++ b/packages/nuxt-cli/src/commands/module/search.ts
@@ -1,3 +1,5 @@
+import process from 'node:process'
+
 import { box } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import Fuse from 'fuse.js'
@@ -6,9 +8,10 @@ import { kebabCase, upperFirst } from 'scule'
 
 import { formatInfoBox } from '../../utils/formatting'
 import { logger } from '../../utils/logger'
+import { logNetworkError } from '../../utils/network'
 import { getNuxtVersion } from '../../utils/versions'
 import { cwdArgs } from '../_shared'
-import { checkNuxtCompatibility, fetchModules } from './_utils'
+import { checkNuxtCompatibility, fetchModules, MODULES_API_URL } from './_utils'
 
 const DASH_RE = /-/g
 
@@ -44,7 +47,10 @@ export default defineCommand({
 })
 
 async function findModuleByKeywords(query: string, nuxtVersion: string) {
-  const allModules = await fetchModules()
+  const allModules = await fetchModules().catch((err) => {
+    logNetworkError(err, { url: MODULES_API_URL })
+    process.exit(1)
+  })
   const compatibleModules = allModules.filter(m =>
     checkNuxtCompatibility(m, nuxtVersion),
   )

--- a/packages/nuxt-cli/src/dev/binaries.ts
+++ b/packages/nuxt-cli/src/dev/binaries.ts
@@ -11,7 +11,7 @@ import { basename, dirname, join } from 'pathe'
 import { readUser, updateUser } from 'rc9'
 
 import { debug, logger } from '../utils/logger'
-import { describeNetworkError } from '../utils/network'
+import { logNetworkError } from '../utils/network'
 
 interface ConsentOptions {
   /** Key under `tools` in the user `.nuxtrc` used to persist acceptance. */
@@ -156,7 +156,7 @@ async function downloadBinary(url: string, destination: string, options: { archi
   }
   catch (error) {
     debug(`Failed to download \`${url}\`:`, error)
-    logger.warn(`Failed to download \`${label}\`. ${describeNetworkError(error, url)}`)
+    logNetworkError(error, { url, level: 'warn', prefix: `Failed to download \`${label}\`.` })
     return undefined
   }
 }

--- a/packages/nuxt-cli/src/dev/binaries.ts
+++ b/packages/nuxt-cli/src/dev/binaries.ts
@@ -11,6 +11,7 @@ import { basename, dirname, join } from 'pathe'
 import { readUser, updateUser } from 'rc9'
 
 import { debug, logger } from '../utils/logger'
+import { describeNetworkError } from '../utils/network'
 
 interface ConsentOptions {
   /** Key under `tools` in the user `.nuxtrc` used to persist acceptance. */
@@ -155,7 +156,7 @@ async function downloadBinary(url: string, destination: string, options: { archi
   }
   catch (error) {
     debug(`Failed to download \`${url}\`:`, error)
-    logger.warn(`Failed to download \`${label}\`.`)
+    logger.warn(`Failed to download \`${label}\`. ${describeNetworkError(error, url)}`)
     return undefined
   }
 }

--- a/packages/nuxt-cli/src/main.ts
+++ b/packages/nuxt-cli/src/main.ts
@@ -16,7 +16,13 @@ import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
 
 import { logger } from './utils/logger'
+import { setupProxySupport } from './utils/network'
 import { templateNames } from './utils/templates/names'
+
+// Node.js only reads `NODE_USE_ENV_PROXY` during bootstrap, so this cannot make
+// the current process proxy-aware; it propagates the setting to child processes
+// (package manager installs, dev server) and records the state for error hints.
+setupProxySupport()
 
 const _main = defineCommand({
   meta: {

--- a/packages/nuxt-cli/src/utils/network.ts
+++ b/packages/nuxt-cli/src/utils/network.ts
@@ -19,6 +19,10 @@ export function hasProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   return PROXY_ENV_VARS.some(key => !!env[key])
 }
 
+// Matched on flag boundaries so a path or value that merely contains the flag
+// (`--require=/tmp/--use-env-proxy.js`) is not mistaken for it being enabled.
+const USE_ENV_PROXY_RE = /(?:^|\s)--use-env-proxy(?:$|[\s=])/
+
 /** The flags the running Node.js accepts, i.e. `process.allowedNodeEnvironmentFlags`. */
 export interface NodeFlags {
   has: (flag: string) => boolean
@@ -43,7 +47,7 @@ export function isEnvProxyActive(env: NodeJS.ProcessEnv = process.env, execArgv:
   }
   return env.NODE_USE_ENV_PROXY === '1'
     || execArgv.includes('--use-env-proxy')
-    || !!env.NODE_OPTIONS?.includes('--use-env-proxy')
+    || USE_ENV_PROXY_RE.test(env.NODE_OPTIONS || '')
 }
 
 export type ProxySetupResult = 'unused' | 'active' | 'children-only' | 'unsupported'

--- a/packages/nuxt-cli/src/utils/network.ts
+++ b/packages/nuxt-cli/src/utils/network.ts
@@ -19,11 +19,16 @@ export function hasProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   return PROXY_ENV_VARS.some(key => !!env[key])
 }
 
+/** The flags the running Node.js accepts, i.e. `process.allowedNodeEnvironmentFlags`. */
+export interface NodeFlags {
+  has: (flag: string) => boolean
+}
+
 /**
  * Whether the current Node.js can route `fetch`/`http` through `HTTP_PROXY`,
  * `HTTPS_PROXY` and `NO_PROXY` itself.
  */
-export function supportsEnvProxy(flags: { has: (flag: string) => boolean } | undefined = process.allowedNodeEnvironmentFlags): boolean {
+export function supportsEnvProxy(flags: NodeFlags | undefined = process.allowedNodeEnvironmentFlags): boolean {
   return flags?.has('--use-env-proxy') ?? false
 }
 
@@ -32,8 +37,8 @@ export function supportsEnvProxy(flags: { has: (flag: string) => boolean } | und
  * variables. Node.js resolves this during bootstrap, so it cannot be turned on
  * from within the process.
  */
-export function isEnvProxyActive(env: NodeJS.ProcessEnv = process.env, execArgv: string[] = process.execArgv): boolean {
-  if (!supportsEnvProxy()) {
+export function isEnvProxyActive(env: NodeJS.ProcessEnv = process.env, execArgv: string[] = process.execArgv, flags?: NodeFlags): boolean {
+  if (!supportsEnvProxy(flags)) {
     return false
   }
   return env.NODE_USE_ENV_PROXY === '1'
@@ -50,17 +55,17 @@ let envProxyActive: boolean | undefined
  * installs, the dev server) when proxy environment variables are set, and record
  * whether the current process is itself proxy-aware so failures can say so.
  */
-export function setupProxySupport(env: NodeJS.ProcessEnv = process.env): ProxySetupResult {
+export function setupProxySupport(env: NodeJS.ProcessEnv = process.env, flags?: NodeFlags): ProxySetupResult {
   if (!hasProxyEnv(env)) {
     envProxyActive = undefined
     return 'unused'
   }
-  if (!supportsEnvProxy()) {
+  if (!supportsEnvProxy(flags)) {
     envProxyActive = false
     return 'unsupported'
   }
 
-  envProxyActive = isEnvProxyActive(env)
+  envProxyActive = isEnvProxyActive(env, process.execArgv, flags)
   env.NODE_USE_ENV_PROXY ||= '1'
 
   return envProxyActive ? 'active' : 'children-only'
@@ -88,6 +93,7 @@ export interface CommandContext {
   argv?: string[]
   env?: NodeJS.ProcessEnv
   windows?: boolean
+  flags?: NodeFlags
 }
 
 /**
@@ -114,7 +120,7 @@ export function formatRetryCommand(vars: Record<string, string>, ctx: CommandCon
 
 // Some libraries (notably `giget`) rethrow with the original error stringified
 // into the message, which drops the `code` we would otherwise read.
-const ERROR_CODE_RE = /\b(E(?:NOTFOUND|AI_AGAIN|CONNREFUSED|CONNRESET|TIMEDOUT|PIPE|PROTO)|UND_ERR_[A-Z_]+|(?:CERT|DEPTH_ZERO|SELF_SIGNED|UNABLE_TO)[A-Z_]*)\b/
+const ERROR_CODE_RE = /\b(E(?:NOTFOUND|AI_AGAIN|CONNREFUSED|CONNRESET|TIMEDOUT|PIPE|PROTO)|UND_ERR_[A-Z_]+|ERR_(?:SSL|TLS)_[A-Z_]+|(?:CERT|DEPTH_ZERO|SELF_SIGNED|UNABLE_TO)[A-Z_]*)\b/
 
 function getErrorCode(err: unknown): string | undefined {
   let current = err
@@ -205,6 +211,12 @@ export function classifyNetworkError(err: unknown): NetworkFailure {
       return { kind: 'tls', code }
   }
 
+  // OpenSSL surfaces handshake failures (wrong protocol, unsupported ciphers,
+  // hostname mismatch) through a large family of prefixed codes.
+  if (code?.startsWith('ERR_SSL_') || code?.startsWith('ERR_TLS_')) {
+    return { kind: 'tls', code }
+  }
+
   if (code === 'ABORT_ERR' || getErrorName(err) === 'AbortError' || getErrorName(err) === 'TimeoutError') {
     return { kind: 'timeout', code }
   }
@@ -273,10 +285,11 @@ export function describeNetworkError(err: unknown, url?: string): string {
  */
 export function getProxyHint(kind: NetworkFailureKind = 'unknown', ctx: CommandContext = {}): string | undefined {
   const env = ctx.env ?? process.env
+  const proxyInUse = () => envProxyActive ?? isEnvProxyActive(env, process.execArgv, ctx.flags)
 
   // A server that answered is normally not a proxy problem, unless a proxy is
   // configured and being bypassed (a blocked egress often answers 403).
-  if (kind === 'http' && (!hasProxyEnv(env) || (envProxyActive ?? isEnvProxyActive(env)))) {
+  if (kind === 'http' && (!hasProxyEnv(env) || proxyInUse())) {
     return
   }
 
@@ -292,11 +305,11 @@ export function getProxyHint(kind: NetworkFailureKind = 'unknown', ctx: CommandC
     return `If you are behind a proxy, set ${colors.cyan('HTTPS_PROXY')} and ${colors.cyan('NODE_USE_ENV_PROXY=1')} (plus ${colors.cyan('NO_PROXY')} for internal hosts).`
   }
 
-  if (!supportsEnvProxy()) {
+  if (!supportsEnvProxy(ctx.flags)) {
     return `A proxy is configured but this version of Node.js cannot use it; upgrade to Node.js 24 (or 22.18+) to enable ${colors.cyan('NODE_USE_ENV_PROXY')}.`
   }
 
-  if (!(envProxyActive ?? isEnvProxyActive(env))) {
+  if (!proxyInUse()) {
     return `A proxy is configured but Node.js only reads it at startup. Retry with ${colors.cyan(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, ctx))}`
   }
 

--- a/packages/nuxt-cli/src/utils/network.ts
+++ b/packages/nuxt-cli/src/utils/network.ts
@@ -23,8 +23,8 @@ export function hasProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
  * Whether the current Node.js can route `fetch`/`http` through `HTTP_PROXY`,
  * `HTTPS_PROXY` and `NO_PROXY` itself.
  */
-export function supportsEnvProxy(): boolean {
-  return process.allowedNodeEnvironmentFlags?.has('--use-env-proxy') ?? false
+export function supportsEnvProxy(flags: { has: (flag: string) => boolean } | undefined = process.allowedNodeEnvironmentFlags): boolean {
+  return flags?.has('--use-env-proxy') ?? false
 }
 
 /**
@@ -212,6 +212,29 @@ export function classifyNetworkError(err: unknown): NetworkFailure {
   return { kind: 'unknown', code }
 }
 
+/**
+ * `giget` flattens the underlying failure to `TypeError: fetch failed`, dropping
+ * both `cause` and `code`, so DNS, refused and timed-out downloads are
+ * indistinguishable. Re-request the origin to recover a diagnosable error.
+ * Returns `undefined` when the origin turns out to be reachable.
+ */
+export async function probeNetworkError(url: string, timeout = 3000): Promise<unknown | undefined> {
+  let origin: string
+  try {
+    origin = new URL(url).origin
+  }
+  catch {
+    return
+  }
+
+  try {
+    await fetch(origin, { method: 'HEAD', signal: AbortSignal.timeout(timeout) })
+  }
+  catch (err) {
+    return err
+  }
+}
+
 /** A single-line, human-readable explanation of a failed network request. */
 export function describeNetworkError(err: unknown, url?: string): string {
   const host = getHost(url)
@@ -275,6 +298,12 @@ export function getProxyHint(kind: NetworkFailureKind = 'unknown', ctx: CommandC
 
   if (!(envProxyActive ?? isEnvProxyActive(env))) {
     return `A proxy is configured but Node.js only reads it at startup. Retry with ${colors.cyan(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, ctx))}`
+  }
+
+  // A connection dropped mid-handshake through a proxy that is genuinely in use
+  // is the usual signature of TLS interception with an untrusted root.
+  if (kind === 'reset') {
+    return `The proxy may be re-signing TLS traffic. Retry with your organisation's root certificate: ${colors.cyan(formatRetryCommand({ NODE_EXTRA_CA_CERTS: '/path/to/corporate-ca.pem' }, ctx))}`
   }
 }
 

--- a/packages/nuxt-cli/src/utils/network.ts
+++ b/packages/nuxt-cli/src/utils/network.ts
@@ -49,6 +49,7 @@ export function isEnvProxyActive(env: NodeJS.ProcessEnv = process.env, execArgv:
 export type ProxySetupResult = 'unused' | 'active' | 'children-only' | 'unsupported'
 
 let envProxyActive: boolean | undefined
+let proxyHintShown = false
 
 /**
  * Propagate Node.js' built-in proxy support to child processes (package manager
@@ -56,6 +57,8 @@ let envProxyActive: boolean | undefined
  * whether the current process is itself proxy-aware so failures can say so.
  */
 export function setupProxySupport(env: NodeJS.ProcessEnv = process.env, flags?: NodeFlags): ProxySetupResult {
+  proxyHintShown = false
+
   if (!hasProxyEnv(env)) {
     envProxyActive = undefined
     return 'unused'
@@ -320,12 +323,30 @@ export function getProxyHint(kind: NetworkFailureKind = 'unknown', ctx: CommandC
   }
 }
 
-/** Log a failed network request together with at most one line of advice. */
-export function logNetworkError(err: unknown, options: { url?: string, hints?: string[], prefix?: string } = {}): void {
-  const description = describeNetworkError(err, options.url)
-  logger.error(options.prefix ? `${options.prefix} ${description}` : description)
+export interface LogNetworkErrorOptions {
+  url?: string
+  /** Extra advice, shown before the proxy hint. */
+  hints?: string[]
+  /** Context prepended to the description, e.g. which package failed. */
+  prefix?: string
+  /** Use `warn` where the command carries on regardless. */
+  level?: 'error' | 'warn'
+}
 
-  const hints = [...options.hints || [], getProxyHint(classifyNetworkError(err).kind)].filter(Boolean) as string[]
+/**
+ * Log a failed network request together with at most one line of advice. The
+ * proxy hint is shown once per process: several requests usually fail for the
+ * same reason, and repeating the retry command for each one is noise.
+ */
+export function logNetworkError(err: unknown, options: LogNetworkErrorOptions = {}): void {
+  const description = describeNetworkError(err, options.url)
+  const message = options.prefix ? `${options.prefix} ${description}` : description
+  logger[options.level === 'warn' ? 'warn' : 'error'](message)
+
+  const proxyHint = proxyHintShown ? undefined : getProxyHint(classifyNetworkError(err).kind)
+  proxyHintShown ||= !!proxyHint
+
+  const hints = [...options.hints || [], proxyHint].filter(Boolean) as string[]
   if (hints.length > 0) {
     logger.info(hints.join(' '))
   }

--- a/packages/nuxt-cli/src/utils/network.ts
+++ b/packages/nuxt-cli/src/utils/network.ts
@@ -1,0 +1,290 @@
+import process from 'node:process'
+
+import { basename } from 'pathe'
+import colors from 'picocolors'
+import { isWindows } from 'std-env'
+
+import { logger } from './logger'
+
+const PROXY_ENV_VARS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+] as const
+
+export function hasProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return PROXY_ENV_VARS.some(key => !!env[key])
+}
+
+/**
+ * Whether the current Node.js can route `fetch`/`http` through `HTTP_PROXY`,
+ * `HTTPS_PROXY` and `NO_PROXY` itself.
+ */
+export function supportsEnvProxy(): boolean {
+  return process.allowedNodeEnvironmentFlags?.has('--use-env-proxy') ?? false
+}
+
+/**
+ * Whether the current process routes requests through the proxy environment
+ * variables. Node.js resolves this during bootstrap, so it cannot be turned on
+ * from within the process.
+ */
+export function isEnvProxyActive(env: NodeJS.ProcessEnv = process.env, execArgv: string[] = process.execArgv): boolean {
+  if (!supportsEnvProxy()) {
+    return false
+  }
+  return env.NODE_USE_ENV_PROXY === '1'
+    || execArgv.includes('--use-env-proxy')
+    || !!env.NODE_OPTIONS?.includes('--use-env-proxy')
+}
+
+export type ProxySetupResult = 'unused' | 'active' | 'children-only' | 'unsupported'
+
+let envProxyActive: boolean | undefined
+
+/**
+ * Propagate Node.js' built-in proxy support to child processes (package manager
+ * installs, the dev server) when proxy environment variables are set, and record
+ * whether the current process is itself proxy-aware so failures can say so.
+ */
+export function setupProxySupport(env: NodeJS.ProcessEnv = process.env): ProxySetupResult {
+  if (!hasProxyEnv(env)) {
+    envProxyActive = undefined
+    return 'unused'
+  }
+  if (!supportsEnvProxy()) {
+    envProxyActive = false
+    return 'unsupported'
+  }
+
+  envProxyActive = isEnvProxyActive(env)
+  env.NODE_USE_ENV_PROXY ||= '1'
+
+  return envProxyActive ? 'active' : 'children-only'
+}
+
+const BIN_NAMES = new Set(['nuxi', 'nuxi-ng', 'nuxt', 'nuxt-cli'])
+const BIN_EXTENSION_RE = /\.[cm]?js$/
+const NEEDS_QUOTING_RE = /[\s"'$`]/
+
+/**
+ * The command the user typed, if it can be reconstructed. Returns `undefined`
+ * when the CLI was reached indirectly (`npm create nuxt`, `npx`, programmatic
+ * usage), where echoing `argv` back would suggest a command that does not exist.
+ */
+function getCurrentCommand(argv: string[] = process.argv): string | undefined {
+  const entry = argv[1]
+  if (!entry || !BIN_NAMES.has(basename(entry).replace(BIN_EXTENSION_RE, ''))) {
+    return
+  }
+  const args = argv.slice(2).map(arg => NEEDS_QUOTING_RE.test(arg) ? JSON.stringify(arg) : arg)
+  return ['nuxt', ...args].join(' ')
+}
+
+export interface CommandContext {
+  argv?: string[]
+  env?: NodeJS.ProcessEnv
+  windows?: boolean
+}
+
+/**
+ * A copy-pasteable command that re-runs the current invocation with extra
+ * environment variables, in the syntax of the shell the user is most likely in.
+ * Falls back to just the assignment when the invocation is not reconstructable.
+ */
+export function formatRetryCommand(vars: Record<string, string>, ctx: CommandContext = {}): string {
+  const { argv = process.argv, env = process.env, windows = isWindows } = ctx
+  const command = getCurrentCommand(argv)
+  const entries = Object.entries(vars)
+
+  if (windows) {
+    // `$env:` assignments only work in PowerShell, `set` only in cmd.exe.
+    const isPowerShell = !!env.PSModulePath
+    const assignments = entries.map(([key, value]) => isPowerShell ? `$env:${key}="${value}"` : `set ${key}=${value}`)
+    const separator = isPowerShell ? '; ' : ' && '
+    return [...assignments, ...command ? [command] : []].join(separator)
+  }
+
+  const assignments = entries.map(([key, value]) => `${key}=${value}`)
+  return command ? [...assignments, command].join(' ') : `export ${assignments.join(' ')}`
+}
+
+// Some libraries (notably `giget`) rethrow with the original error stringified
+// into the message, which drops the `code` we would otherwise read.
+const ERROR_CODE_RE = /\b(E(?:NOTFOUND|AI_AGAIN|CONNREFUSED|CONNRESET|TIMEDOUT|PIPE|PROTO)|UND_ERR_[A-Z_]+|(?:CERT|DEPTH_ZERO|SELF_SIGNED|UNABLE_TO)[A-Z_]*)\b/
+
+function getErrorCode(err: unknown): string | undefined {
+  let current = err
+  for (let depth = 0; current && typeof current === 'object' && depth < 5; depth++) {
+    const code = (current as { code?: unknown }).code
+    if (typeof code === 'string') {
+      return code
+    }
+    const message = (current as { message?: unknown }).message
+    if (typeof message === 'string') {
+      const match = message.match(ERROR_CODE_RE)
+      if (match) {
+        return match[1]
+      }
+    }
+    current = (current as { cause?: unknown }).cause
+  }
+}
+
+function getErrorName(err: unknown): string | undefined {
+  let current = err
+  for (let depth = 0; current && typeof current === 'object' && depth < 5; depth++) {
+    const name = (current as { name?: unknown }).name
+    if (typeof name === 'string' && name !== 'Error' && name !== 'TypeError' && name !== 'FetchError') {
+      return name
+    }
+    current = (current as { cause?: unknown }).cause
+  }
+}
+
+function getStatus(err: unknown): number | undefined {
+  const status = err as { status?: unknown, statusCode?: unknown, response?: { status?: unknown } }
+  for (const value of [status?.status, status?.statusCode, status?.response?.status]) {
+    if (typeof value === 'number') {
+      return value
+    }
+  }
+}
+
+function getHost(url: string | undefined): string | undefined {
+  if (!url) {
+    return
+  }
+  try {
+    return new URL(url).host
+  }
+  catch {
+    return undefined
+  }
+}
+
+export type NetworkFailureKind = 'dns' | 'timeout' | 'refused' | 'reset' | 'tls' | 'proxy-auth' | 'http' | 'unknown'
+
+export interface NetworkFailure {
+  kind: NetworkFailureKind
+  code?: string
+  status?: number
+}
+
+export function classifyNetworkError(err: unknown): NetworkFailure {
+  const code = getErrorCode(err)
+  const status = getStatus(err)
+
+  if (status) {
+    return { kind: status === 407 ? 'proxy-auth' : 'http', status, code }
+  }
+
+  switch (code) {
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return { kind: 'dns', code }
+    case 'ECONNREFUSED':
+      return { kind: 'refused', code }
+    case 'ECONNRESET':
+    case 'EPIPE':
+      return { kind: 'reset', code }
+    case 'ETIMEDOUT':
+    case 'UND_ERR_CONNECT_TIMEOUT':
+    case 'UND_ERR_HEADERS_TIMEOUT':
+    case 'UND_ERR_BODY_TIMEOUT':
+      return { kind: 'timeout', code }
+    case 'CERT_HAS_EXPIRED':
+    case 'DEPTH_ZERO_SELF_SIGNED_CERT':
+    case 'SELF_SIGNED_CERT_IN_CHAIN':
+    case 'UNABLE_TO_GET_ISSUER_CERT_LOCALLY':
+    case 'UNABLE_TO_VERIFY_LEAF_SIGNATURE':
+    case 'EPROTO':
+      return { kind: 'tls', code }
+  }
+
+  if (code === 'ABORT_ERR' || getErrorName(err) === 'AbortError' || getErrorName(err) === 'TimeoutError') {
+    return { kind: 'timeout', code }
+  }
+
+  return { kind: 'unknown', code }
+}
+
+/** A single-line, human-readable explanation of a failed network request. */
+export function describeNetworkError(err: unknown, url?: string): string {
+  const host = getHost(url)
+  const target = host ? colors.cyan(host) : 'the network'
+  const { kind, code, status } = classifyNetworkError(err)
+
+  switch (kind) {
+    case 'proxy-auth':
+      return `Proxy rejected the request to ${target} with status ${colors.yellow('407')} (proxy authentication required).`
+    case 'http':
+      return `Request to ${target} failed with status ${colors.yellow(String(status))}.`
+    case 'dns':
+      return code === 'EAI_AGAIN'
+        ? `DNS lookup for ${target} timed out.`
+        : `Could not resolve ${target} (DNS lookup failed).`
+    case 'refused':
+      return `Connection to ${target} was refused.`
+    case 'reset':
+      return `Connection to ${target} was reset before the response completed.`
+    case 'timeout':
+      return `Connection to ${target} timed out.`
+    case 'tls':
+      return `TLS connection to ${target} could not be verified (${code}).`
+  }
+
+  const message = err instanceof Error ? err.message : String(err)
+  if (message.includes('fetch failed')) {
+    return `Could not reach ${target}.`
+  }
+  return `Could not reach ${target}: ${message}`
+}
+
+/**
+ * Advice for failures a proxy could explain, naming the command to re-run.
+ * Returns `undefined` when the proxy is already in use or cannot be at fault.
+ */
+export function getProxyHint(kind: NetworkFailureKind = 'unknown', ctx: CommandContext = {}): string | undefined {
+  const env = ctx.env ?? process.env
+
+  // A server that answered is normally not a proxy problem, unless a proxy is
+  // configured and being bypassed (a blocked egress often answers 403).
+  if (kind === 'http' && (!hasProxyEnv(env) || (envProxyActive ?? isEnvProxyActive(env)))) {
+    return
+  }
+
+  if (kind === 'tls') {
+    return `This usually means a proxy is re-signing TLS traffic. Retry with your organisation's root certificate: ${colors.cyan(formatRetryCommand({ NODE_EXTRA_CA_CERTS: '/path/to/corporate-ca.pem' }, ctx))}`
+  }
+
+  if (kind === 'proxy-auth') {
+    return `Include credentials in your proxy URL, e.g. ${colors.cyan('HTTPS_PROXY=http://user:password@proxy.example.com:8080')}.`
+  }
+
+  if (!hasProxyEnv(env)) {
+    return `If you are behind a proxy, set ${colors.cyan('HTTPS_PROXY')} and ${colors.cyan('NODE_USE_ENV_PROXY=1')} (plus ${colors.cyan('NO_PROXY')} for internal hosts).`
+  }
+
+  if (!supportsEnvProxy()) {
+    return `A proxy is configured but this version of Node.js cannot use it; upgrade to Node.js 24 (or 22.18+) to enable ${colors.cyan('NODE_USE_ENV_PROXY')}.`
+  }
+
+  if (!(envProxyActive ?? isEnvProxyActive(env))) {
+    return `A proxy is configured but Node.js only reads it at startup. Retry with ${colors.cyan(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, ctx))}`
+  }
+}
+
+/** Log a failed network request together with at most one line of advice. */
+export function logNetworkError(err: unknown, options: { url?: string, hints?: string[], prefix?: string } = {}): void {
+  const description = describeNetworkError(err, options.url)
+  logger.error(options.prefix ? `${options.prefix} ${description}` : description)
+
+  const hints = [...options.hints || [], getProxyHint(classifyNetworkError(err).kind)].filter(Boolean) as string[]
+  if (hints.length > 0) {
+    logger.info(hints.join(' '))
+  }
+}

--- a/packages/nuxt-cli/src/utils/starter-templates.ts
+++ b/packages/nuxt-cli/src/utils/starter-templates.ts
@@ -22,13 +22,18 @@ export interface TemplateData {
 }
 
 const fetchOptions = {
-  timeout: 3000,
+  // A proxy CONNECT plus TLS handshake on a corporate link regularly costs more
+  // than 3s. The template list is prefetched and has a static fallback, so a
+  // slightly longer deadline only ever delays the prompt on a broken network.
+  timeout: 5000,
   responseType: 'json',
   headers: {
     'user-agent': '@nuxt/cli',
     ...process.env.GITHUB_TOKEN ? { authorization: `token ${process.env.GITHUB_TOKEN}` } : {},
   },
 } as const
+
+export const TEMPLATES_API_URL = 'https://api.github.com/repos/nuxt/starter/contents/templates?ref=templates'
 
 let templatesCache: Promise<Record<string, TemplateData>> | null = null
 
@@ -41,7 +46,7 @@ export async function fetchTemplates() {
   const templates = {} as Record<string, TemplateData>
 
   const files = await $fetch<Array<{ name: string, type: string, download_url?: string }>>(
-    'https://api.github.com/repos/nuxt/starter/contents/templates?ref=templates',
+    TEMPLATES_API_URL,
     fetchOptions,
   )
 

--- a/packages/nuxt-cli/test/unit/commands/network-failures.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/network-failures.spec.ts
@@ -1,0 +1,101 @@
+import type { CommandDef } from 'citty'
+import type { AddressInfo } from 'node:net'
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import initCommand from '../../../src/commands/init'
+import * as moduleUtils from '../../../src/commands/module/_utils'
+import addCommand from '../../../src/commands/module/add'
+import { runCommandDef } from '../../../src/run'
+import { render, screen } from '../../utils/terminal'
+
+/** A port nothing listens on, so connections to it are refused immediately. */
+async function closedPort(): Promise<number> {
+  const server = createServer()
+  const port = await new Promise<number>(resolve => server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port)))
+  await new Promise<void>(resolve => server.close(() => resolve()))
+  return port
+}
+
+class ExitError extends Error {
+  constructor(readonly code: number | undefined) {
+    super(`process.exit(${code})`)
+  }
+}
+
+/** Run a command that is expected to bail out, returning the screen and exit code. */
+async function runFailing(command: CommandDef<any>, argv: string[]) {
+  let exitCode: number | undefined
+  const exit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+    exitCode = code as number | undefined
+    throw new ExitError(exitCode)
+  })
+
+  const renderer = await render(async () => {
+    await runCommandDef(command, argv).catch((err) => {
+      if (!(err instanceof ExitError)) {
+        throw err
+      }
+    })
+  })
+
+  exit.mockRestore()
+  return { output: screen(renderer), exitCode }
+}
+
+describe('network failures reported by commands', () => {
+  let dir: string
+  let port: number
+
+  beforeAll(async () => {
+    port = await closedPort()
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+    delete process.env.NUXI_INIT_REGISTRY
+    delete process.env.COREPACK_NPM_REGISTRY
+  })
+
+  it('names the unreachable registry when a template cannot be downloaded', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'nuxt-init-network-'))
+    process.env.NUXI_INIT_REGISTRY = `http://127.0.0.1:${port}/templates`
+
+    const { output, exitCode } = await runFailing(initCommand, [
+      `--cwd=${dir}`,
+      'app',
+      '--template=minimal',
+      '--packageManager=npm',
+      '--gitInit=false',
+      '--install=false',
+      '--no-modules',
+    ])
+
+    expect(output).toContain('Template download failed')
+    expect(output).toContain(`Connection to 127.0.0.1:${port} was refused.`)
+    expect(output).toContain('--offline')
+    expect(output).toContain('NUXI_INIT_REGISTRY')
+    expect(exitCode).toBe(1)
+  })
+
+  it('names the unreachable npm registry when module metadata cannot be fetched', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'nuxt-add-network-'))
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ name: 'app', devDependencies: { nuxt: '4.0.0' } }))
+    process.env.COREPACK_NPM_REGISTRY = `http://127.0.0.1:${port}`
+
+    // Only the modules database is stubbed; the registry request is real.
+    vi.spyOn(moduleUtils, 'fetchModules').mockResolvedValue([])
+
+    const { output } = await runFailing(addCommand, [`--cwd=${dir}`, '@nuxt/image', '--install=false'])
+
+    expect(output).toContain('Failed to fetch package details for @nuxt/image.')
+    expect(output).toContain(`Connection to 127.0.0.1:${port} was refused.`)
+  })
+})

--- a/packages/nuxt-cli/test/unit/commands/network-failures.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/network-failures.spec.ts
@@ -10,8 +10,10 @@ import process from 'node:process'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import initCommand from '../../../src/commands/init'
+import moduleCommand from '../../../src/commands/module'
 import * as moduleUtils from '../../../src/commands/module/_utils'
 import addCommand from '../../../src/commands/module/add'
+import { resolveTool } from '../../../src/dev/binaries'
 import { runCommandDef } from '../../../src/run'
 import { render, screen } from '../../utils/terminal'
 
@@ -97,5 +99,56 @@ describe('network failures reported by commands', () => {
 
     expect(output).toContain('Failed to fetch package details for @nuxt/image.')
     expect(output).toContain(`Connection to 127.0.0.1:${port} was refused.`)
+  })
+
+  it('reports why the module database is unreachable when searching', async () => {
+    dir = await mkdtemp(join(tmpdir(), 'nuxt-search-network-'))
+
+    // A genuine undici error rather than a hand-built one.
+    const refused = await fetch(`http://127.0.0.1:${port}/`).catch((err: unknown) => err)
+    vi.spyOn(moduleUtils, 'fetchModules').mockRejectedValue(refused)
+
+    const { output, exitCode } = await runFailing(moduleCommand, ['search', `--cwd=${dir}`, 'image'])
+
+    expect(output).toContain('Connection to api.nuxt.com was refused.')
+    expect(exitCode).toBe(1)
+  })
+})
+
+describe('dev tool downloads', () => {
+  let home: string
+  let port: number
+
+  beforeAll(async () => {
+    port = await closedPort()
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+    vi.unstubAllEnvs()
+  })
+
+  it('says which host a tool could not be downloaded from', async () => {
+    home = await mkdtemp(join(tmpdir(), 'nuxt-tool-network-'))
+    // Isolate the cache and pre-accept the terms so the real download runs.
+    vi.stubEnv('HOME', home)
+    vi.stubEnv('XDG_CACHE_HOME', join(home, 'cache'))
+    await writeFile(join(home, '.nuxtrc'), 'tools.probe.termsAccepted=true\n')
+
+    let resolved: string | undefined
+    const renderer = await render(async () => {
+      resolved = await resolveTool('nuxt-probe-does-not-exist', {
+        url: `http://127.0.0.1:${port}/probe.tgz`,
+        consent: {
+          key: 'probe',
+          notice: [],
+          message: 'ok?',
+          nonInteractiveWarning: 'skipped',
+        },
+      })
+    })
+
+    expect(resolved).toBeUndefined()
+    expect(screen(renderer)).toContain(`Connection to 127.0.0.1:${port} was refused.`)
   })
 })

--- a/packages/nuxt-cli/test/unit/commands/network-failures.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/network-failures.spec.ts
@@ -131,8 +131,12 @@ describe('dev tool downloads', () => {
   it('says which host a tool could not be downloaded from', async () => {
     home = await mkdtemp(join(tmpdir(), 'nuxt-tool-network-'))
     // Isolate the cache and pre-accept the terms so the real download runs.
-    vi.stubEnv('HOME', home)
+    // `rc9` reads `XDG_CONFIG_HOME` before `homedir()`, and `homedir()` itself
+    // follows `USERPROFILE` on Windows, so all three have to be pinned.
+    vi.stubEnv('XDG_CONFIG_HOME', home)
     vi.stubEnv('XDG_CACHE_HOME', join(home, 'cache'))
+    vi.stubEnv('HOME', home)
+    vi.stubEnv('USERPROFILE', home)
     await writeFile(join(home, '.nuxtrc'), 'tools.probe.termsAccepted=true\n')
 
     let resolved: string | undefined

--- a/packages/nuxt-cli/test/unit/utils/network.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/network.spec.ts
@@ -1,0 +1,205 @@
+import { stripVTControlCharacters } from 'node:util'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const logs: Array<[string, string]> = []
+
+vi.mock('../../../src/utils/logger', () => ({
+  logger: {
+    error: (message: string) => logs.push(['error', message]),
+    info: (message: string) => logs.push(['info', message]),
+    warn: (message: string) => logs.push(['warn', message]),
+  },
+  debug: () => {},
+}))
+
+const { classifyNetworkError, describeNetworkError, formatRetryCommand, getProxyHint, hasProxyEnv, isEnvProxyActive, logNetworkError, setupProxySupport, supportsEnvProxy } = await import('../../../src/utils/network')
+
+const NUXI_ARGV = ['/usr/bin/node', '/project/node_modules/.bin/nuxi.mjs', 'init', 'my app']
+
+function clean(message: string) {
+  return stripVTControlCharacters(message)
+}
+
+function withCode(code: string, message = 'fetch failed') {
+  return Object.assign(new Error(message), { cause: Object.assign(new Error(code), { code }) })
+}
+
+describe('hasProxyEnv', () => {
+  it('detects lower and upper case variants', () => {
+    expect(hasProxyEnv({})).toBe(false)
+    expect(hasProxyEnv({ http_proxy: 'http://localhost:3128' })).toBe(true)
+    expect(hasProxyEnv({ HTTPS_PROXY: 'http://localhost:3128' })).toBe(true)
+    expect(hasProxyEnv({ NO_PROXY: 'internal.example.com' })).toBe(false)
+  })
+})
+
+describe('setupProxySupport', () => {
+  it('does nothing without proxy environment variables', () => {
+    const env = {}
+    expect(setupProxySupport(env)).toBe('unused')
+    expect(env).toEqual({})
+  })
+
+  it('never overrides an explicit NODE_USE_ENV_PROXY', () => {
+    const env = { HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '0' }
+    setupProxySupport(env)
+    expect(env.NODE_USE_ENV_PROXY).toBe('0')
+  })
+
+  it('propagates proxy support to child processes', () => {
+    const env = { HTTP_PROXY: 'http://localhost:3128' } as NodeJS.ProcessEnv
+    const result = setupProxySupport(env)
+    if (supportsEnvProxy()) {
+      expect(result).toBe('children-only')
+      expect(env.NODE_USE_ENV_PROXY).toBe('1')
+    }
+    else {
+      expect(result).toBe('unsupported')
+      expect(env.NODE_USE_ENV_PROXY).toBeUndefined()
+    }
+  })
+
+  it('reports the current process as proxy-aware when launched with the flag', () => {
+    if (!supportsEnvProxy()) {
+      return
+    }
+    expect(isEnvProxyActive({ NODE_USE_ENV_PROXY: '1' }, [])).toBe(true)
+    expect(isEnvProxyActive({ NODE_OPTIONS: '--use-env-proxy' }, [])).toBe(true)
+    expect(isEnvProxyActive({}, ['--use-env-proxy'])).toBe(true)
+    expect(isEnvProxyActive({ HTTPS_PROXY: 'http://localhost:3128' }, [])).toBe(false)
+    expect(setupProxySupport({ HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' })).toBe('active')
+  })
+})
+
+describe('describeNetworkError', () => {
+  it('names the unreachable host', () => {
+    expect(clean(describeNetworkError(withCode('ENOTFOUND'), 'https://api.github.com/repos')))
+      .toBe('Could not resolve api.github.com (DNS lookup failed).')
+  })
+
+  it('distinguishes DNS, refused, timeout and TLS failures', () => {
+    const url = 'https://registry.npmjs.org/nuxt'
+    expect(clean(describeNetworkError(withCode('EAI_AGAIN'), url))).toContain('DNS lookup for registry.npmjs.org timed out')
+    expect(clean(describeNetworkError(withCode('ECONNREFUSED'), url))).toContain('was refused')
+    expect(clean(describeNetworkError(withCode('UND_ERR_CONNECT_TIMEOUT'), url))).toContain('timed out')
+    expect(clean(describeNetworkError(withCode('CERT_HAS_EXPIRED'), url))).toContain('TLS connection')
+  })
+
+  it('reports non-2xx responses', () => {
+    const err = Object.assign(new Error('404 Not Found'), { response: { status: 404 }, statusCode: 404 })
+    expect(clean(describeNetworkError(err, 'https://api.nuxt.com/modules')))
+      .toBe('Request to api.nuxt.com failed with status 404.')
+  })
+
+  it('calls out proxy authentication failures', () => {
+    const err = Object.assign(new Error('407'), { statusCode: 407 })
+    expect(classifyNetworkError(err).kind).toBe('proxy-auth')
+    expect(clean(describeNetworkError(err, 'https://registry.npmjs.org/nuxt')))
+      .toContain('proxy authentication required')
+  })
+
+  it('reports aborted requests as timeouts', () => {
+    const err = Object.assign(new Error('This operation was aborted'), { name: 'AbortError' })
+    expect(clean(describeNetworkError(err, 'https://api.nuxt.com/modules'))).toContain('timed out')
+  })
+
+  it('recognises codes that were stringified into the message', () => {
+    const err = new Error('Failed to download https://registry.example.com/minimal.json: TypeError: fetch failed (ENOTFOUND)')
+    expect(clean(describeNetworkError(err, 'https://registry.example.com/templates')))
+      .toBe('Could not resolve registry.example.com (DNS lookup failed).')
+  })
+
+  it('collapses opaque `fetch failed` chains', () => {
+    const err = new Error('Failed to download template from registry: Failed to download https://example.com/minimal.json: TypeError: fetch failed')
+    expect(clean(describeNetworkError(err, 'https://example.com/templates'))).toBe('Could not reach example.com.')
+  })
+
+  it('falls back to the original message', () => {
+    expect(clean(describeNetworkError(new Error('socket hang up'), 'https://example.com')))
+      .toBe('Could not reach example.com: socket hang up')
+    expect(clean(describeNetworkError('boom'))).toBe('Could not reach the network: boom')
+  })
+})
+
+describe('formatRetryCommand', () => {
+  it('rebuilds the invocation with an environment prefix', () => {
+    expect(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, { argv: NUXI_ARGV, env: {}, windows: false }))
+      .toBe('NODE_USE_ENV_PROXY=1 nuxt init "my app"')
+  })
+
+  it('uses PowerShell or cmd syntax on Windows', () => {
+    expect(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, { argv: NUXI_ARGV, env: { PSModulePath: 'C:\\ps' }, windows: true }))
+      .toBe('$env:NODE_USE_ENV_PROXY="1"; nuxt init "my app"')
+    expect(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, { argv: NUXI_ARGV, env: {}, windows: true }))
+      .toBe('set NODE_USE_ENV_PROXY=1 && nuxt init "my app"')
+  })
+
+  it('falls back to an assignment when the invocation is indirect', () => {
+    const argv = ['/usr/bin/node', '/tmp/.npm/_npx/abc/node_modules/create-nuxt/dist/index.mjs', 'my-app']
+    expect(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, { argv, env: {}, windows: false }))
+      .toBe('export NODE_USE_ENV_PROXY=1')
+    expect(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, { argv, env: {}, windows: true }))
+      .toBe('set NODE_USE_ENV_PROXY=1')
+  })
+})
+
+describe('getProxyHint', () => {
+  it('suggests proxy variables when none are set, without a retry command', () => {
+    const hint = clean(getProxyHint('dns', { argv: NUXI_ARGV, env: {}, windows: false })!)
+    expect(hint).toContain('HTTPS_PROXY')
+    expect(hint).not.toContain('nuxt init')
+  })
+
+  it('points out when a configured proxy is not in use', () => {
+    const env = { HTTPS_PROXY: 'http://localhost:3128' }
+    setupProxySupport({ ...env })
+    const hint = clean(getProxyHint('dns', { argv: NUXI_ARGV, env, windows: false })!)
+    expect(hint).toContain(supportsEnvProxy() ? 'NODE_USE_ENV_PROXY=1 nuxt init "my app"' : 'cannot use it')
+  })
+
+  it('stays quiet when the proxy is already in use', () => {
+    if (!supportsEnvProxy()) {
+      return
+    }
+    const env = { HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' }
+    setupProxySupport({ ...env })
+    expect(getProxyHint('dns', { env })).toBeUndefined()
+  })
+
+  it('suggests a root certificate for intercepted TLS', () => {
+    const hint = clean(getProxyHint('tls', { argv: NUXI_ARGV, env: {}, windows: false })!)
+    expect(hint).toContain('NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem nuxt init "my app"')
+  })
+
+  it('suggests credentials for a 407', () => {
+    expect(clean(getProxyHint('proxy-auth', { env: {} })!)).toContain('user:password@proxy.example.com')
+  })
+
+  it('does not blame the proxy for a plain HTTP error', () => {
+    expect(getProxyHint('http', { env: {} })).toBeUndefined()
+  })
+})
+
+describe('logNetworkError', () => {
+  beforeEach(() => {
+    logs.length = 0
+  })
+
+  it('logs one error line and one hint line', () => {
+    logNetworkError(withCode('ENOTFOUND'), {
+      url: 'https://raw.githubusercontent.com/nuxt/starter',
+      hints: ['Retry with --offline.'],
+    })
+
+    expect(logs.filter(([level]) => level === 'error')).toHaveLength(1)
+    expect(logs.filter(([level]) => level === 'info')).toHaveLength(1)
+    expect(clean(logs[0]![1])).toContain('raw.githubusercontent.com')
+    expect(clean(logs[1]![1])).toContain('Retry with --offline.')
+  })
+
+  it('prefixes the description when asked', () => {
+    logNetworkError(withCode('ECONNRESET'), { url: 'https://registry.npmjs.org/nuxt', prefix: 'Failed to fetch package details.' })
+    expect(clean(logs[0]![1])).toContain('Failed to fetch package details. Connection to registry.npmjs.org')
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/network.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/network.spec.ts
@@ -99,6 +99,8 @@ describe('setupProxySupport', () => {
   it('reports the current process as proxy-aware when launched with the flag', () => {
     expect(isEnvProxyActive({ NODE_USE_ENV_PROXY: '1' }, [], MODERN_NODE)).toBe(true)
     expect(isEnvProxyActive({ NODE_OPTIONS: '--use-env-proxy' }, [], MODERN_NODE)).toBe(true)
+    expect(isEnvProxyActive({ NODE_OPTIONS: '--max-old-space-size=4096 --use-env-proxy' }, [], MODERN_NODE)).toBe(true)
+    expect(isEnvProxyActive({ NODE_OPTIONS: '--require=/tmp/--use-env-proxy.js' }, [], MODERN_NODE)).toBe(false)
     expect(isEnvProxyActive({}, ['--use-env-proxy'], MODERN_NODE)).toBe(true)
     expect(isEnvProxyActive({ HTTPS_PROXY: 'http://localhost:3128' }, [], MODERN_NODE)).toBe(false)
     expect(isEnvProxyActive({ NODE_USE_ENV_PROXY: '1' }, [], OLD_NODE)).toBe(false)
@@ -188,7 +190,18 @@ describe('describeNetworkError with real failures', () => {
   })
 })
 
-describe('describeNetworkError with an untrusted certificate', () => {
+/** Certificate fixtures need `openssl`, which not every machine has. */
+const hasOpenSSL = (() => {
+  try {
+    execFileSync('openssl', ['version'], { stdio: 'ignore' })
+    return true
+  }
+  catch {
+    return false
+  }
+})()
+
+describe.skipIf(!hasOpenSSL)('describeNetworkError with an untrusted certificate', () => {
   let url = ''
   let server: HttpsServer | undefined
   let dir = ''
@@ -197,28 +210,23 @@ describe('describeNetworkError with an untrusted certificate', () => {
     dir = await mkdtemp(join(tmpdir(), 'nuxt-network-tls-'))
     const key = join(dir, 'key.pem')
     const cert = join(dir, 'cert.pem')
-    try {
-      execFileSync('openssl', [
-        'req',
-        '-x509',
-        '-newkey',
-        'rsa:2048',
-        '-nodes',
-        '-keyout',
-        key,
-        '-out',
-        cert,
-        '-days',
-        '1',
-        '-subj',
-        '/CN=127.0.0.1',
-        '-addext',
-        'subjectAltName=IP:127.0.0.1',
-      ], { stdio: 'ignore' })
-    }
-    catch {
-      return
-    }
+    execFileSync('openssl', [
+      'req',
+      '-x509',
+      '-newkey',
+      'rsa:2048',
+      '-nodes',
+      '-keyout',
+      key,
+      '-out',
+      cert,
+      '-days',
+      '1',
+      '-subj',
+      '/CN=127.0.0.1',
+      '-addext',
+      'subjectAltName=IP:127.0.0.1',
+    ], { stdio: 'ignore' })
 
     server = createHttpsServer({ key: await readFile(key), cert: await readFile(cert) }, (_req, res) => res.end('{}'))
     const port = await new Promise<number>(resolve => server!.listen(0, '127.0.0.1', () => resolve((server!.address() as AddressInfo).port)))
@@ -230,11 +238,7 @@ describe('describeNetworkError with an untrusted certificate', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  // Skipped rather than failed where `openssl` is unavailable.
   it('flags a self-signed certificate as a TLS failure', async () => {
-    if (!server) {
-      return
-    }
     const err = await captureError(() => fetch(url))
     expect(classifyNetworkError(err)).toMatchObject({ kind: 'tls', code: 'DEPTH_ZERO_SELF_SIGNED_CERT' })
     expect(clean(describeNetworkError(err, url)))
@@ -242,9 +246,6 @@ describe('describeNetworkError with an untrusted certificate', () => {
   })
 
   it('advises a root certificate for a self-signed chain, whatever the proxy state', async () => {
-    if (!server) {
-      return
-    }
     const err = await captureError(() => fetch(url))
     const hint = clean(getProxyHint(classifyNetworkError(err).kind, { argv: NUXI_ARGV, env: {}, windows: false, flags: MODERN_NODE })!)
     expect(hint).toContain('NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem')

--- a/packages/nuxt-cli/test/unit/utils/network.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/network.spec.ts
@@ -11,7 +11,7 @@ import { stripVTControlCharacters } from 'node:util'
 
 import { downloadTemplate } from 'giget'
 import { $fetch } from 'ofetch'
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const logs: Array<[string, string]> = []
 
@@ -379,6 +379,17 @@ describe('getProxyHint', () => {
 describe('logNetworkError', () => {
   beforeEach(() => {
     logs.length = 0
+
+    // Pin a proxy that the process is not using, so a hint is always produced
+    // regardless of the environment the suite runs in.
+    vi.stubEnv('HTTPS_PROXY', 'http://localhost:3128')
+    vi.stubEnv('NODE_OPTIONS', '')
+    vi.stubEnv('NODE_USE_ENV_PROXY', undefined)
+    setupProxySupport({})
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('logs one error line and one hint line', () => {
@@ -396,5 +407,28 @@ describe('logNetworkError', () => {
   it('prefixes the description when asked', () => {
     logNetworkError(withCode('ECONNRESET'), { url: 'https://registry.npmjs.org/nuxt', prefix: 'Failed to fetch package details.' })
     expect(clean(logs[0]![1])).toContain('Failed to fetch package details. Connection to registry.npmjs.org')
+  })
+
+  it('warns instead of erroring where the command carries on', () => {
+    logNetworkError(withCode('ENOTFOUND'), { url: 'https://api.nuxt.com/modules', level: 'warn' })
+    expect(logs[0]![0]).toBe('warn')
+  })
+
+  it('repeats the proxy advice only once per process', () => {
+    const options = { url: 'https://api.nuxt.com/modules' }
+    logNetworkError(withCode('ENOTFOUND'), options)
+    logNetworkError(withCode('ENOTFOUND'), options)
+
+    const hints = logs.filter(([level]) => level === 'info')
+    expect(hints).toHaveLength(1)
+    expect(logs.filter(([level]) => level === 'error')).toHaveLength(2)
+  })
+
+  it('still shows caller hints after the proxy advice is spent', () => {
+    logNetworkError(withCode('ENOTFOUND'), { url: 'https://api.nuxt.com/modules' })
+    logs.length = 0
+
+    logNetworkError(withCode('ENOTFOUND'), { url: 'https://api.nuxt.com/modules', hints: ['Retry with --offline.'] })
+    expect(clean(logs[1]![1])).toBe('Retry with --offline.')
   })
 })

--- a/packages/nuxt-cli/test/unit/utils/network.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/network.spec.ts
@@ -1,6 +1,11 @@
+import type { AddressInfo } from 'node:net'
+
+import { createServer } from 'node:http'
 import { stripVTControlCharacters } from 'node:util'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { downloadTemplate } from 'giget'
+import { $fetch } from 'ofetch'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const logs: Array<[string, string]> = []
 
@@ -13,7 +18,7 @@ vi.mock('../../../src/utils/logger', () => ({
   debug: () => {},
 }))
 
-const { classifyNetworkError, describeNetworkError, formatRetryCommand, getProxyHint, hasProxyEnv, isEnvProxyActive, logNetworkError, setupProxySupport, supportsEnvProxy } = await import('../../../src/utils/network')
+const { classifyNetworkError, describeNetworkError, formatRetryCommand, getProxyHint, hasProxyEnv, isEnvProxyActive, logNetworkError, probeNetworkError, setupProxySupport, supportsEnvProxy } = await import('../../../src/utils/network')
 
 const NUXI_ARGV = ['/usr/bin/node', '/project/node_modules/.bin/nuxi.mjs', 'init', 'my app']
 
@@ -24,6 +29,22 @@ function clean(message: string) {
 function withCode(code: string, message = 'fetch failed') {
   return Object.assign(new Error(message), { cause: Object.assign(new Error(code), { code }) })
 }
+
+async function captureError(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+  }
+  catch (err) {
+    return err
+  }
+  throw new Error('expected the request to fail')
+}
+
+// `setupProxySupport` caches whether the current process is proxy-aware, so tests
+// must not inherit each other's state (or the ambient environment's).
+beforeEach(() => {
+  setupProxySupport({})
+})
 
 describe('hasProxyEnv', () => {
   it('detects lower and upper case variants', () => {
@@ -60,6 +81,12 @@ describe('setupProxySupport', () => {
     }
   })
 
+  it('detects support from the flags Node.js accepts', () => {
+    expect(supportsEnvProxy(new Set(['--use-env-proxy']))).toBe(true)
+    expect(supportsEnvProxy(new Set(['--enable-source-maps']))).toBe(false)
+    expect(supportsEnvProxy({ has: () => false })).toBe(false)
+  })
+
   it('reports the current process as proxy-aware when launched with the flag', () => {
     if (!supportsEnvProxy()) {
       return
@@ -69,6 +96,81 @@ describe('setupProxySupport', () => {
     expect(isEnvProxyActive({}, ['--use-env-proxy'])).toBe(true)
     expect(isEnvProxyActive({ HTTPS_PROXY: 'http://localhost:3128' }, [])).toBe(false)
     expect(setupProxySupport({ HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' })).toBe('active')
+  })
+})
+
+describe('describeNetworkError with real failures', () => {
+  const server = createServer((req, res) => {
+    if (req.url?.includes('slow')) {
+      setTimeout(() => res.end('{}'), 500).unref()
+      return
+    }
+    res.writeHead(req.url?.includes('teapot') ? 418 : 404, { 'content-type': 'application/json' })
+    res.end('{}')
+  })
+
+  let port = 0
+  let closedPort = 0
+
+  beforeAll(async () => {
+    port = await new Promise<number>(resolve => server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port)))
+
+    // Bind then release a port so connections to it are refused rather than
+    // rejected by undici's bad-port list (which is what happens for port 1).
+    const spare = createServer()
+    closedPort = await new Promise<number>(resolve => spare.listen(0, '127.0.0.1', () => resolve((spare.address() as AddressInfo).port)))
+    await new Promise<void>(resolve => spare.close(() => resolve()))
+  })
+
+  afterAll(() => new Promise<void>(resolve => server.close(() => resolve())))
+
+  it('describes a real refused connection from `fetch`', async () => {
+    const url = `http://127.0.0.1:${closedPort}/`
+    const err = await captureError(() => fetch(url))
+    expect(classifyNetworkError(err)).toMatchObject({ kind: 'refused', code: 'ECONNREFUSED' })
+    expect(clean(describeNetworkError(err, url))).toBe(`Connection to 127.0.0.1:${closedPort} was refused.`)
+  })
+
+  it('describes a real refused connection from `ofetch`', async () => {
+    const url = `http://127.0.0.1:${closedPort}/`
+    const err = await captureError(() => $fetch(url))
+    expect(classifyNetworkError(err).kind).toBe('refused')
+    expect(clean(describeNetworkError(err, url))).toBe(`Connection to 127.0.0.1:${closedPort} was refused.`)
+  })
+
+  it('describes a real `ofetch` non-2xx response', async () => {
+    const url = `http://127.0.0.1:${port}/teapot`
+    const err = await captureError(() => $fetch(url))
+    expect(classifyNetworkError(err)).toMatchObject({ kind: 'http', status: 418 })
+    expect(clean(describeNetworkError(err, url))).toBe(`Request to 127.0.0.1:${port} failed with status 418.`)
+  })
+
+  it('describes a real `ofetch` timeout, whose code is a DOMException number', async () => {
+    const url = `http://127.0.0.1:${port}/slow`
+    const err = await captureError(() => $fetch(url, { timeout: 20 }))
+    expect(classifyNetworkError(err).kind).toBe('timeout')
+    expect(clean(describeNetworkError(err, url))).toBe(`Connection to 127.0.0.1:${port} timed out.`)
+  })
+
+  it('collapses a real `giget` failure, which preserves neither cause nor code', async () => {
+    const url = `http://127.0.0.1:${closedPort}/templates`
+    const err = await captureError(() => downloadTemplate('minimal', { dir: '/tmp/nuxi-network-spec', registry: url, force: true }))
+
+    expect((err as Error).cause).toBeUndefined()
+    expect(classifyNetworkError(err).kind).toBe('unknown')
+    expect(clean(describeNetworkError(err, url))).toBe(`Could not reach 127.0.0.1:${closedPort}.`)
+  })
+
+  it('recovers a diagnosable error for an unreachable origin', async () => {
+    const probed = await probeNetworkError(`http://127.0.0.1:${closedPort}/templates`)
+    expect(classifyNetworkError(probed)).toMatchObject({ kind: 'refused', code: 'ECONNREFUSED' })
+    expect(clean(describeNetworkError(probed, `http://127.0.0.1:${closedPort}/templates`)))
+      .toBe(`Connection to 127.0.0.1:${closedPort} was refused.`)
+  })
+
+  it('does not invent a failure when the origin is reachable', async () => {
+    await expect(probeNetworkError(`http://127.0.0.1:${port}/templates`)).resolves.toBeUndefined()
+    await expect(probeNetworkError('not a url')).resolves.toBeUndefined()
   })
 })
 
@@ -178,6 +280,27 @@ describe('getProxyHint', () => {
 
   it('does not blame the proxy for a plain HTTP error', () => {
     expect(getProxyHint('http', { env: {} })).toBeUndefined()
+  })
+
+  it('suspects TLS interception when a proxy in use resets the connection', () => {
+    if (!supportsEnvProxy()) {
+      return
+    }
+    const env = { HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' }
+    setupProxySupport({ ...env })
+    const hint = clean(getProxyHint('reset', { argv: NUXI_ARGV, env, windows: false })!)
+    expect(hint).toContain('re-signing TLS traffic')
+    expect(hint).toContain('NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem nuxt init "my app"')
+  })
+
+  it('prefers the proxy-not-in-use hint over the certificate hint', () => {
+    if (!supportsEnvProxy()) {
+      return
+    }
+    const env = { HTTPS_PROXY: 'http://localhost:3128' }
+    setupProxySupport({ ...env })
+    expect(clean(getProxyHint('reset', { argv: NUXI_ARGV, env, windows: false })!))
+      .toContain('NODE_USE_ENV_PROXY=1')
   })
 })
 

--- a/packages/nuxt-cli/test/unit/utils/network.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/network.spec.ts
@@ -1,6 +1,12 @@
+import type { Server as HttpsServer } from 'node:https'
 import type { AddressInfo } from 'node:net'
 
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { createServer } from 'node:http'
+import { createServer as createHttpsServer } from 'node:https'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { stripVTControlCharacters } from 'node:util'
 
 import { downloadTemplate } from 'giget'
@@ -21,6 +27,10 @@ vi.mock('../../../src/utils/logger', () => ({
 const { classifyNetworkError, describeNetworkError, formatRetryCommand, getProxyHint, hasProxyEnv, isEnvProxyActive, logNetworkError, probeNetworkError, setupProxySupport, supportsEnvProxy } = await import('../../../src/utils/network')
 
 const NUXI_ARGV = ['/usr/bin/node', '/project/node_modules/.bin/nuxi.mjs', 'init', 'my app']
+
+/** Stand in for the flags Node.js accepts, so tests do not depend on the runtime. */
+const MODERN_NODE = new Set(['--use-env-proxy'])
+const OLD_NODE = new Set<string>()
 
 function clean(message: string) {
   return stripVTControlCharacters(message)
@@ -70,15 +80,14 @@ describe('setupProxySupport', () => {
 
   it('propagates proxy support to child processes', () => {
     const env = { HTTP_PROXY: 'http://localhost:3128' } as NodeJS.ProcessEnv
-    const result = setupProxySupport(env)
-    if (supportsEnvProxy()) {
-      expect(result).toBe('children-only')
-      expect(env.NODE_USE_ENV_PROXY).toBe('1')
-    }
-    else {
-      expect(result).toBe('unsupported')
-      expect(env.NODE_USE_ENV_PROXY).toBeUndefined()
-    }
+    expect(setupProxySupport(env, MODERN_NODE)).toBe('children-only')
+    expect(env.NODE_USE_ENV_PROXY).toBe('1')
+  })
+
+  it('reports Node.js versions that cannot use the proxy', () => {
+    const env = { HTTP_PROXY: 'http://localhost:3128' } as NodeJS.ProcessEnv
+    expect(setupProxySupport(env, OLD_NODE)).toBe('unsupported')
+    expect(env.NODE_USE_ENV_PROXY).toBeUndefined()
   })
 
   it('detects support from the flags Node.js accepts', () => {
@@ -88,14 +97,12 @@ describe('setupProxySupport', () => {
   })
 
   it('reports the current process as proxy-aware when launched with the flag', () => {
-    if (!supportsEnvProxy()) {
-      return
-    }
-    expect(isEnvProxyActive({ NODE_USE_ENV_PROXY: '1' }, [])).toBe(true)
-    expect(isEnvProxyActive({ NODE_OPTIONS: '--use-env-proxy' }, [])).toBe(true)
-    expect(isEnvProxyActive({}, ['--use-env-proxy'])).toBe(true)
-    expect(isEnvProxyActive({ HTTPS_PROXY: 'http://localhost:3128' }, [])).toBe(false)
-    expect(setupProxySupport({ HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' })).toBe('active')
+    expect(isEnvProxyActive({ NODE_USE_ENV_PROXY: '1' }, [], MODERN_NODE)).toBe(true)
+    expect(isEnvProxyActive({ NODE_OPTIONS: '--use-env-proxy' }, [], MODERN_NODE)).toBe(true)
+    expect(isEnvProxyActive({}, ['--use-env-proxy'], MODERN_NODE)).toBe(true)
+    expect(isEnvProxyActive({ HTTPS_PROXY: 'http://localhost:3128' }, [], MODERN_NODE)).toBe(false)
+    expect(isEnvProxyActive({ NODE_USE_ENV_PROXY: '1' }, [], OLD_NODE)).toBe(false)
+    expect(setupProxySupport({ HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' }, MODERN_NODE)).toBe('active')
   })
 })
 
@@ -171,6 +178,76 @@ describe('describeNetworkError with real failures', () => {
   it('does not invent a failure when the origin is reachable', async () => {
     await expect(probeNetworkError(`http://127.0.0.1:${port}/templates`)).resolves.toBeUndefined()
     await expect(probeNetworkError('not a url')).resolves.toBeUndefined()
+  })
+
+  it('describes a real TLS handshake against a plain HTTP server', async () => {
+    const url = `https://127.0.0.1:${port}/`
+    const err = await captureError(() => fetch(url))
+    expect(classifyNetworkError(err).kind).toBe('tls')
+    expect(clean(describeNetworkError(err, url))).toMatch(/^TLS connection to 127\.0\.0\.1:\d+ could not be verified \(ERR_SSL_/)
+  })
+})
+
+describe('describeNetworkError with an untrusted certificate', () => {
+  let url = ''
+  let server: HttpsServer | undefined
+  let dir = ''
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'nuxt-network-tls-'))
+    const key = join(dir, 'key.pem')
+    const cert = join(dir, 'cert.pem')
+    try {
+      execFileSync('openssl', [
+        'req',
+        '-x509',
+        '-newkey',
+        'rsa:2048',
+        '-nodes',
+        '-keyout',
+        key,
+        '-out',
+        cert,
+        '-days',
+        '1',
+        '-subj',
+        '/CN=127.0.0.1',
+        '-addext',
+        'subjectAltName=IP:127.0.0.1',
+      ], { stdio: 'ignore' })
+    }
+    catch {
+      return
+    }
+
+    server = createHttpsServer({ key: await readFile(key), cert: await readFile(cert) }, (_req, res) => res.end('{}'))
+    const port = await new Promise<number>(resolve => server!.listen(0, '127.0.0.1', () => resolve((server!.address() as AddressInfo).port)))
+    url = `https://127.0.0.1:${port}/`
+  })
+
+  afterAll(async () => {
+    await new Promise<void>(resolve => server ? server.close(() => resolve()) : resolve())
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  // Skipped rather than failed where `openssl` is unavailable.
+  it('flags a self-signed certificate as a TLS failure', async () => {
+    if (!server) {
+      return
+    }
+    const err = await captureError(() => fetch(url))
+    expect(classifyNetworkError(err)).toMatchObject({ kind: 'tls', code: 'DEPTH_ZERO_SELF_SIGNED_CERT' })
+    expect(clean(describeNetworkError(err, url)))
+      .toMatch(/^TLS connection to 127\.0\.0\.1:\d+ could not be verified \(DEPTH_ZERO_SELF_SIGNED_CERT\)\.$/)
+  })
+
+  it('advises a root certificate for a self-signed chain, whatever the proxy state', async () => {
+    if (!server) {
+      return
+    }
+    const err = await captureError(() => fetch(url))
+    const hint = clean(getProxyHint(classifyNetworkError(err).kind, { argv: NUXI_ARGV, env: {}, windows: false, flags: MODERN_NODE })!)
+    expect(hint).toContain('NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem')
   })
 })
 
@@ -255,18 +332,21 @@ describe('getProxyHint', () => {
 
   it('points out when a configured proxy is not in use', () => {
     const env = { HTTPS_PROXY: 'http://localhost:3128' }
-    setupProxySupport({ ...env })
-    const hint = clean(getProxyHint('dns', { argv: NUXI_ARGV, env, windows: false })!)
-    expect(hint).toContain(supportsEnvProxy() ? 'NODE_USE_ENV_PROXY=1 nuxt init "my app"' : 'cannot use it')
+    const hint = clean(getProxyHint('dns', { argv: NUXI_ARGV, env, windows: false, flags: MODERN_NODE })!)
+    expect(hint).toContain('NODE_USE_ENV_PROXY=1 nuxt init "my app"')
+  })
+
+  it('asks for a Node.js upgrade when the flag is unavailable', () => {
+    const env = { HTTPS_PROXY: 'http://localhost:3128' }
+    const hint = clean(getProxyHint('dns', { argv: NUXI_ARGV, env, windows: false, flags: OLD_NODE })!)
+    expect(hint).toContain('cannot use it')
+    expect(hint).toContain('Node.js 24 (or 22.18+)')
+    expect(hint).not.toContain('Retry with')
   })
 
   it('stays quiet when the proxy is already in use', () => {
-    if (!supportsEnvProxy()) {
-      return
-    }
     const env = { HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' }
-    setupProxySupport({ ...env })
-    expect(getProxyHint('dns', { env })).toBeUndefined()
+    expect(getProxyHint('dns', { env, flags: MODERN_NODE })).toBeUndefined()
   })
 
   it('suggests a root certificate for intercepted TLS', () => {
@@ -283,23 +363,15 @@ describe('getProxyHint', () => {
   })
 
   it('suspects TLS interception when a proxy in use resets the connection', () => {
-    if (!supportsEnvProxy()) {
-      return
-    }
     const env = { HTTPS_PROXY: 'http://localhost:3128', NODE_USE_ENV_PROXY: '1' }
-    setupProxySupport({ ...env })
-    const hint = clean(getProxyHint('reset', { argv: NUXI_ARGV, env, windows: false })!)
+    const hint = clean(getProxyHint('reset', { argv: NUXI_ARGV, env, windows: false, flags: MODERN_NODE })!)
     expect(hint).toContain('re-signing TLS traffic')
     expect(hint).toContain('NODE_EXTRA_CA_CERTS=/path/to/corporate-ca.pem nuxt init "my app"')
   })
 
   it('prefers the proxy-not-in-use hint over the certificate hint', () => {
-    if (!supportsEnvProxy()) {
-      return
-    }
     const env = { HTTPS_PROXY: 'http://localhost:3128' }
-    setupProxySupport({ ...env })
-    expect(clean(getProxyHint('reset', { argv: NUXI_ARGV, env, windows: false })!))
+    expect(clean(getProxyHint('reset', { argv: NUXI_ARGV, env, windows: false, flags: MODERN_NODE })!))
       .toContain('NODE_USE_ENV_PROXY=1')
   })
 })

--- a/packages/nuxt-cli/test/unit/utils/starter-templates.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/starter-templates.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { describeNetworkError } from '../../../src/utils/network'
+import { fetchTemplates, TEMPLATES_API_URL } from '../../../src/utils/starter-templates'
+
+function respondAfter(delay: number) {
+  return vi.fn((url: string | URL | Request, init?: RequestInit) => {
+    const signal = init?.signal
+    // `fetch` rejects straight away when handed a spent signal, which is what
+    // `ofetch` does on its retry.
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason)
+    }
+
+    // Only the template listing is slowed down; the per-template fetches that
+    // follow it answer immediately so the test pays the delay once.
+    const isListing = String(url).includes('api.github.com')
+    const body = isListing
+      ? [{ name: 'minimal.json', type: 'file', download_url: 'https://raw.example.com/minimal.json' }]
+      : { name: 'minimal', description: 'Minimal starter', defaultDir: 'nuxt-app', url: '', tar: '' }
+
+    return new Promise<Response>((resolve, reject) => {
+      if (!isListing) {
+        resolve(new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } }))
+        return
+      }
+
+      const timer = setTimeout(() => resolve(new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })), delay)
+      timer.unref()
+      signal?.addEventListener('abort', () => {
+        clearTimeout(timer)
+        reject(signal.reason)
+      })
+    })
+  })
+}
+
+describe('fetchTemplates', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('tolerates a link slower than three seconds', async () => {
+    vi.stubGlobal('fetch', respondAfter(3300))
+
+    await expect(fetchTemplates()).resolves.toHaveProperty('minimal.name', 'minimal')
+  }, 15_000)
+
+  it('gives up rather than hanging on a dead link', async () => {
+    const signals: AbortSignal[] = []
+    vi.stubGlobal('fetch', (url: string | URL | Request, init?: RequestInit) => {
+      if (init?.signal) {
+        signals.push(init.signal)
+      }
+      return respondAfter(60_000)(url, init)
+    })
+
+    // Asserting on the abort rather than the settled promise keeps the test from
+    // waiting out `ofetch`'s retry of the same doomed request.
+    const pending = fetchTemplates().catch((err: unknown) => err)
+    await vi.waitFor(() => expect(signals[0]?.aborted).toBe(true), { timeout: 8000, interval: 100 })
+
+    expect(describeNetworkError(signals[0]!.reason, TEMPLATES_API_URL)).toContain('timed out')
+    // The retry of the same doomed request is left to time out unobserved.
+    void pending
+  }, 15_000)
+})

--- a/packages/nuxt-cli/test/unit/utils/starter-templates.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/starter-templates.spec.ts
@@ -13,8 +13,9 @@ function respondAfter(delay: number) {
     }
 
     // Only the template listing is slowed down; the per-template fetches that
-    // follow it answer immediately so the test pays the delay once.
-    const isListing = String(url).includes('api.github.com')
+    // follow it answer immediately so the test pays the delay once. Matched on
+    // the host rather than a substring, which any URL could contain anywhere.
+    const isListing = new URL(url instanceof Request ? url.url : String(url)).host === 'api.github.com'
     const body = isListing
       ? [{ name: 'minimal.json', type: 'file', download_url: 'https://raw.example.com/minimal.json' }]
       : { name: 'minimal', description: 'Minimal starter', defaultDir: 'nuxt-app', url: '', tar: '' }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #288
resolves #853

closes #419
closes #1089

### 📚 Description

a lot of issues we face are due to proxy issues with network requests

this PR improves the errors we show in these cases, and give people updated commands to run that will resolve the issue using node's builtin `NODE_USE_ENV_PROXY`