### PR TITLE
fix(dev): open inspector only in the process serving the app

### DIFF
--- a/packages/nuxt-cli/src/commands/dev.ts
+++ b/packages/nuxt-cli/src/commands/dev.ts
@@ -12,6 +12,7 @@ import { isBun, isTest } from 'std-env'
 import { satisfies } from 'verkit'
 
 import { initialize } from '../dev'
+import { closeInspector, openInspector, resolveInspectOptions } from '../dev/inspect'
 import { ForkPool } from '../dev/pool'
 import { setupShortcuts } from '../dev/shortcuts'
 import { debug, logger } from '../utils/logger'
@@ -32,6 +33,14 @@ const command = defineCommand({
     ...legacyRootDirArgs,
     ...envNameArgs,
     ...extendsArgs,
+    'inspect': {
+      type: 'boolean',
+      description: 'Enable the Node.js inspector for the process serving your app (`--inspect=[host:]port`)',
+    },
+    'inspect-brk': {
+      type: 'boolean',
+      description: 'Enable the Node.js inspector and wait for a debugger to attach (`--inspect-brk=[host:]port`)',
+    },
     'clear': {
       type: 'boolean',
       description: 'Clear console on restart',
@@ -134,6 +143,13 @@ const command = defineCommand({
 
     const listenOverrides = resolveListenOverrides(ctx.args)
 
+    // The inspector belongs to whichever process is currently serving the app:
+    // this one until a hard restart hands over to a fork.
+    const inspect = resolveInspectOptions(ctx.rawArgs)
+    if (inspect) {
+      await openInspector(inspect)
+    }
+
     // Start the initial dev server in-process with listener
     const { listener, close, reload, onRestart, onReady } = await initialize({ cwd, args: ctx.args }, {
       data: ctx.data,
@@ -154,6 +170,7 @@ const command = defineCommand({
       rawArgs: ctx.rawArgs,
       poolSize: 2,
       listenOverrides,
+      inspect,
     })
 
     // When ready, start warming up the fork pool
@@ -165,14 +182,17 @@ const command = defineCommand({
     })
 
     // On hard restart, use a fork from the pool
-    let cleanupCurrentFork: (() => void) | undefined
+    let cleanupCurrentFork: (() => Promise<void>) | undefined
 
     async function restartWithFork() {
       // Get a fork from the pool (warm if available, cold otherwise)
       const context: NuxtDevContext = { cwd, args: ctx.args }
 
-      // Clean up previous fork if any
-      cleanupCurrentFork?.()
+      // Release the inspector port before the incoming fork tries to bind it
+      await Promise.all([
+        cleanupCurrentFork?.(),
+        inspect ? closeInspector() : undefined,
+      ])
 
       cleanupCurrentFork = await pool.getFork(context, (message) => {
         // Handle IPC messages from the fork
@@ -201,7 +221,7 @@ const command = defineCommand({
     onRestart(restart)
 
     async function closeAll() {
-      cleanupCurrentFork?.()
+      await cleanupCurrentFork?.()
       await close()
     }
 

--- a/packages/nuxt-cli/src/dev/index.ts
+++ b/packages/nuxt-cli/src/dev/index.ts
@@ -8,6 +8,7 @@ import { overrideEnv } from '../utils/env.ts'
 import { isBrokenPipe } from '../utils/errors'
 import { debug } from '../utils/logger'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile.ts'
+import { openInspector } from './inspect'
 import { NuxtDevServer } from './utils'
 
 const start = Date.now()
@@ -31,9 +32,12 @@ class IPC {
         process.exit()
       })
     }
-    process.on('message', (message: NuxtParentIPCMessage) => {
+    process.on('message', async (message: NuxtParentIPCMessage) => {
       if (message.type === 'nuxt:internal:dev:context') {
-        initialize(message.context, { listenOverrides: message.listenOverrides })
+        if (message.inspect) {
+          await openInspector(message.inspect)
+        }
+        await initialize(message.context, { listenOverrides: message.listenOverrides })
       }
     })
     this.send({ type: 'nuxt:internal:dev:fork-ready' })

--- a/packages/nuxt-cli/src/dev/inspect.ts
+++ b/packages/nuxt-cli/src/dev/inspect.ts
@@ -1,0 +1,123 @@
+import process from 'node:process'
+import colors from 'picocolors'
+import { debug, logger } from '../utils/logger'
+
+export interface InspectOptions {
+  host: string
+  port: number
+  /** Wait for a debugger to attach before running any user code (`--inspect-brk`). */
+  wait: boolean
+}
+
+const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_PORT = 9229
+
+const INSPECT_ARG_RE = /^--inspect(-brk|-wait|-port)?(?:=(.*))?$/
+
+/**
+ * Resolve Node inspector options from CLI/exec arguments, following Node's own
+ * `--inspect[=[host:]port]` parsing rules.
+ *
+ * Returns `undefined` when the inspector was not requested. `--inspect-port` on
+ * its own does not enable the inspector, it only sets the address to use.
+ */
+export function parseInspectArgs(args: string[]): InspectOptions | undefined {
+  let enabled = false
+  let wait = false
+  let host = DEFAULT_HOST
+  let port = DEFAULT_PORT
+
+  for (const arg of args) {
+    const match = INSPECT_ARG_RE.exec(arg)
+    if (!match) {
+      continue
+    }
+    const [, modifier, value] = match
+
+    if (modifier !== '-port') {
+      enabled = true
+      wait ||= modifier === '-brk' || modifier === '-wait'
+    }
+
+    const target = parseTarget(value)
+    if (target.host !== undefined) {
+      host = target.host
+    }
+    if (target.port !== undefined) {
+      port = target.port
+    }
+  }
+
+  return enabled ? { host, port, wait } : undefined
+}
+
+function parseTarget(value: string | undefined): { host?: string, port?: number } {
+  if (!value) {
+    return {}
+  }
+
+  if (value.startsWith('[')) {
+    const end = value.indexOf(']')
+    if (end === -1) {
+      return {}
+    }
+    const host = value.slice(1, end)
+    const rest = value.slice(end + 1)
+    return rest.startsWith(':') ? { host, port: toPort(rest.slice(1)) } : { host }
+  }
+
+  const separator = value.lastIndexOf(':')
+  if (separator !== -1) {
+    return { host: value.slice(0, separator) || DEFAULT_HOST, port: toPort(value.slice(separator + 1)) }
+  }
+
+  if (/^\d+$/.test(value)) {
+    return { port: toPort(value) }
+  }
+  return { host: value }
+}
+
+function toPort(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) {
+    return undefined
+  }
+  const port = Number(value)
+  return port >= 0 && port <= 65535 ? port : undefined
+}
+
+/**
+ * Open the inspector in the current process, or move it to the requested
+ * address if Node already opened one via `execArgv`.
+ */
+export async function openInspector(options: InspectOptions): Promise<void> {
+  const inspector = await import('node:inspector')
+
+  try {
+    if (inspector.url()) {
+      inspector.close()
+    }
+    // Node itself logs `Debugger listening on …` when the inspector opens.
+    inspector.open(options.port, options.host, options.wait)
+  }
+  catch (error) {
+    logger.warn(`Could not start the inspector on ${colors.cyan(`${options.host}:${options.port}`)}: ${error instanceof Error ? error.message : error}`)
+  }
+}
+
+/** Release the inspector port so another process (a fork) can bind to it. */
+export async function closeInspector(): Promise<void> {
+  try {
+    const inspector = await import('node:inspector')
+    if (inspector.url()) {
+      inspector.close()
+    }
+  }
+  catch (error) {
+    debug(`Could not close the inspector: ${error}`)
+  }
+}
+
+/** Node exec arguments are inspected too, so `node --inspect nuxt dev` behaves like `nuxt dev --inspect`. */
+export function resolveInspectOptions(rawArgs: string[]): InspectOptions | undefined {
+  return parseInspectArgs([...process.execArgv, ...rawArgs])
+}

--- a/packages/nuxt-cli/src/dev/pool.ts
+++ b/packages/nuxt-cli/src/dev/pool.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process'
+import type { InspectOptions } from './inspect'
 import type { DevListenOverrides } from './listen'
 import type { NuxtDevContext, NuxtDevIPCMessage } from './utils'
 
@@ -11,6 +12,7 @@ interface ForkPoolOptions {
   rawArgs: string[]
   poolSize?: number
   listenOverrides: DevListenOverrides
+  inspect?: InspectOptions
 }
 
 interface PooledFork {
@@ -24,12 +26,14 @@ export class ForkPool {
   private poolSize: number
   private rawArgs: string[]
   private listenOverrides: DevListenOverrides
+  private inspect?: InspectOptions
   private warming = false
 
   constructor(options: ForkPoolOptions) {
     this.rawArgs = options.rawArgs
     this.poolSize = options.poolSize ?? 2
     this.listenOverrides = options.listenOverrides
+    this.inspect = options.inspect
 
     // Graceful shutdown
     for (const signal of [
@@ -56,7 +60,7 @@ export class ForkPool {
     }
   }
 
-  async getFork(context: NuxtDevContext, onMessage?: (message: NuxtDevIPCMessage) => void): Promise<() => void> {
+  async getFork(context: NuxtDevContext, onMessage?: (message: NuxtDevIPCMessage) => void): Promise<() => Promise<void>> {
     // Try to get a ready fork from the pool
     const readyFork = this.pool.find(f => f.state === 'ready')
 
@@ -130,7 +134,10 @@ export class ForkPool {
 
   private createFork(): PooledFork {
     const childProc = fork(globalThis.__nuxt_cli__.devEntry!, this.rawArgs, {
-      execArgv: ['--enable-source-maps', process.argv.find((a: string) => a.includes('--inspect'))].filter(Boolean) as string[],
+      // The inspector is opened by the fork that actually serves the app (see
+      // `sendContext`), never via `execArgv`, so idle pooled forks don't race
+      // each other for the debug port.
+      execArgv: ['--enable-source-maps'],
       env: {
         ...process.env,
         __NUXT__FORK: 'true',
@@ -179,16 +186,33 @@ export class ForkPool {
     childProc.send({
       type: 'nuxt:internal:dev:context',
       listenOverrides: this.listenOverrides,
+      inspect: this.inspect,
       context,
     })
   }
 
-  private killFork(fork: PooledFork, signal: NodeJS.Signals | number = 'SIGTERM'): void {
+  private killFork(fork: PooledFork, signal: NodeJS.Signals | number = 'SIGTERM'): Promise<void> {
+    const wasAlive = fork.state !== 'dead' && !!fork.process && fork.process.exitCode === null
     fork.state = 'dead'
     if (fork.process) {
       fork.process.kill(signal === 0 && isDeno ? 'SIGTERM' : signal)
     }
     this.removeFork(fork)
+
+    if (!wasAlive) {
+      return Promise.resolve()
+    }
+
+    // Resolve once the OS has reaped the process; the next fork may need to
+    // rebind ports (such as the inspector port) that it still holds.
+    return new Promise<void>((resolve) => {
+      const timeout = setTimeout(resolve, 2000)
+      timeout.unref?.()
+      fork.process.once('exit', () => {
+        clearTimeout(timeout)
+        resolve()
+      })
+    })
   }
 
   private removeFork(fork: PooledFork): void {

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -6,6 +6,7 @@ import type { FSWatcher } from 'node:fs'
 import type { Server as HttpServer, IncomingMessage, RequestListener, ServerResponse } from 'node:http'
 
 import type { ResolvedCertificate } from './cert'
+import type { InspectOptions } from './inspect'
 import type { DevListenOverrides, Listener, ListenOptions } from './listen'
 import EventEmitter from 'node:events'
 import { existsSync, readdirSync, statSync, watch } from 'node:fs'
@@ -33,7 +34,7 @@ import { listen } from './listen'
 import { resolvePortlessURLs } from './portless'
 
 export type NuxtParentIPCMessage
-  = | { type: 'nuxt:internal:dev:context', context: NuxtDevContext, listenOverrides: DevListenOverrides }
+  = | { type: 'nuxt:internal:dev:context', context: NuxtDevContext, listenOverrides: DevListenOverrides, inspect?: InspectOptions }
 
 export type NuxtDevIPCMessage
   = | { type: 'nuxt:internal:dev:fork-ready' }

--- a/packages/nuxt-cli/test/unit/help.spec.ts
+++ b/packages/nuxt-cli/test/unit/help.spec.ts
@@ -206,6 +206,8 @@ describe('help', () => {
                                  --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory                                                                                         
                               --envName=<env_name>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
                         -e, --extends=<layer-name>    Extend from a Nuxt layer                                                                                                                            
+                                         --inspect    Enable the Node.js inspector for the process serving your app (\`--inspect=[host:]port\`)                                                             
+                                     --inspect-brk    Enable the Node.js inspector and wait for a debugger to attach (\`--inspect-brk=[host:]port\`)                                                        
                                            --clear    Clear console on restart (Default: false)                                                                                                           
                                         -f, --fork    Enable forked mode (Default: false)                                                                                                                 
                                  --no-f, --no-fork    Disable forked mode                                                                                                                                 

--- a/packages/nuxt-cli/test/unit/inspect.spec.ts
+++ b/packages/nuxt-cli/test/unit/inspect.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseInspectArgs } from '../../src/dev/inspect'
+
+describe('parseInspectArgs', () => {
+  it('should return undefined when the inspector is not requested', () => {
+    expect(parseInspectArgs([])).toBeUndefined()
+    expect(parseInspectArgs(['--port', '3000', '--open'])).toBeUndefined()
+  })
+
+  it('should use node defaults for a bare `--inspect`', () => {
+    expect(parseInspectArgs(['--inspect'])).toStrictEqual({ host: '127.0.0.1', port: 9229, wait: false })
+  })
+
+  it('should parse a port only value', () => {
+    expect(parseInspectArgs(['--inspect=3050'])).toStrictEqual({ host: '127.0.0.1', port: 3050, wait: false })
+  })
+
+  it('should parse a host and port value', () => {
+    expect(parseInspectArgs(['--inspect=0.0.0.0:3050'])).toStrictEqual({ host: '0.0.0.0', port: 3050, wait: false })
+  })
+
+  it('should parse a host only value', () => {
+    expect(parseInspectArgs(['--inspect=0.0.0.0'])).toStrictEqual({ host: '0.0.0.0', port: 9229, wait: false })
+  })
+
+  it('should parse bracketed ipv6 hosts', () => {
+    expect(parseInspectArgs(['--inspect=[::]:3050'])).toStrictEqual({ host: '::', port: 3050, wait: false })
+    expect(parseInspectArgs(['--inspect=[::1]'])).toStrictEqual({ host: '::1', port: 9229, wait: false })
+  })
+
+  it('should preserve `--inspect-brk` semantics', () => {
+    expect(parseInspectArgs(['--inspect-brk'])).toStrictEqual({ host: '127.0.0.1', port: 9229, wait: true })
+    expect(parseInspectArgs(['--inspect-brk=0.0.0.0:3050'])).toStrictEqual({ host: '0.0.0.0', port: 3050, wait: true })
+    expect(parseInspectArgs(['--inspect-wait'])).toStrictEqual({ host: '127.0.0.1', port: 9229, wait: true })
+  })
+
+  it('should apply `--inspect-port` without enabling the inspector on its own', () => {
+    expect(parseInspectArgs(['--inspect-port=3050'])).toBeUndefined()
+    expect(parseInspectArgs(['--inspect', '--inspect-port=3050'])).toStrictEqual({ host: '127.0.0.1', port: 3050, wait: false })
+    expect(parseInspectArgs(['--inspect-port=0.0.0.0:3050', '--inspect'])).toStrictEqual({ host: '0.0.0.0', port: 3050, wait: false })
+  })
+
+  it('should ignore unrelated arguments that mention inspect', () => {
+    expect(parseInspectArgs(['--inspect-publish-uid=http'])).toBeUndefined()
+    expect(parseInspectArgs(['--no-inspect'])).toBeUndefined()
+    expect(parseInspectArgs(['./pages/--inspect.vue'])).toBeUndefined()
+  })
+
+  it('should let the last value win', () => {
+    expect(parseInspectArgs(['--inspect=3050', '--inspect=9230'])).toStrictEqual({ host: '127.0.0.1', port: 9230, wait: false })
+  })
+
+  it('should ignore invalid ports', () => {
+    expect(parseInspectArgs(['--inspect=99999'])).toStrictEqual({ host: '127.0.0.1', port: 9229, wait: false })
+  })
+})

--- a/packages/nuxt-cli/test/unit/inspect.spec.ts
+++ b/packages/nuxt-cli/test/unit/inspect.spec.ts
@@ -20,6 +20,10 @@ describe('parseInspectArgs', () => {
     expect(parseInspectArgs(['--inspect=0.0.0.0:3050'])).toStrictEqual({ host: '0.0.0.0', port: 3050, wait: false })
   })
 
+  it('should fall back to the default host when the host is empty', () => {
+    expect(parseInspectArgs(['--inspect=:3050'])).toStrictEqual({ host: '127.0.0.1', port: 3050, wait: false })
+  })
+
   it('should parse a host only value', () => {
     expect(parseInspectArgs(['--inspect=0.0.0.0'])).toStrictEqual({ host: '0.0.0.0', port: 9229, wait: false })
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1195
resolves #1369

### 📚 Description

this bundles some fixes for native `--inspect` usage