### PR TITLE
fix(upgrade): find lock file in nearest directory, not workspace root

### DIFF
--- a/packages/nuxt-cli/src/commands/upgrade.ts
+++ b/packages/nuxt-cli/src/commands/upgrade.ts
@@ -6,7 +6,7 @@ import process from 'node:process'
 import { cancel, intro, isCancel, note, outro, select, spinner, tasks } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { addDependency, dedupeDependencies, detectPackageManager } from 'nypm'
-import { resolve } from 'pathe'
+import { dirname, relative, resolve } from 'pathe'
 import colors from 'picocolors'
 import { findWorkspaceDir, readPackageJSON } from 'pkg-types'
 
@@ -139,9 +139,16 @@ export default defineCommand({
     // Force install
     const toRemove = ['node_modules']
 
-    const lockFile = normaliseLockFile(workspaceDir, lockFileCandidates)
+    const lockFile = findLockFile(cwd, workspaceDir, lockFileCandidates)
     if (lockFile) {
       toRemove.push(lockFile)
+    }
+    else {
+      logger.error(
+        cwd === workspaceDir
+          ? `Unable to find a ${packageManagerName} lock file in ${colors.cyan(relativeToProcess(cwd))}.`
+          : `Unable to find a ${packageManagerName} lock file in ${colors.cyan(relativeToProcess(cwd))} or any directory up to ${colors.cyan(relativeToProcess(workspaceDir))}.`,
+      )
     }
 
     const forceRemovals = toRemove
@@ -270,17 +277,21 @@ export default defineCommand({
 })
 
 // Find which lock file is in use since `nypm.detectPackageManager` doesn't return this
-function normaliseLockFile(cwd: string, lockFiles: string | Array<string> | undefined) {
-  if (typeof lockFiles === 'string') {
-    lockFiles = [lockFiles]
-  }
+export function findLockFile(cwd: string, workspaceDir: string, lockFiles: string | Array<string> | undefined) {
+  const candidates = typeof lockFiles === 'string' ? [lockFiles] : lockFiles
 
-  const lockFile = lockFiles?.find(file => existsSync(resolve(cwd, file)))
-
-  if (lockFile === undefined) {
-    logger.error(`Unable to find any lock files in ${colors.cyan(relativeToProcess(cwd))}.`)
+  if (!candidates?.length) {
     return undefined
   }
 
-  return lockFile
+  for (let dir = cwd; ; dir = dirname(dir)) {
+    for (const file of candidates) {
+      if (existsSync(resolve(dir, file))) {
+        return relative(cwd, resolve(dir, file))
+      }
+    }
+    if (dir === workspaceDir || dir === dirname(dir)) {
+      return undefined
+    }
+  }
 }

--- a/packages/nuxt-cli/test/unit/commands/upgrade.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/upgrade.spec.ts
@@ -1,0 +1,62 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { findLockFile } from '../../../src/commands/upgrade'
+
+describe('findLockFile', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'nuxt-upgrade-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('should find a lock file in the current directory', async () => {
+    await writeFile(join(tempDir, 'package-lock.json'), '{}')
+
+    expect(findLockFile(tempDir, tempDir, 'package-lock.json')).toBe('package-lock.json')
+  })
+
+  it('should find a lock file in a nested app directory when the workspace root has none', async () => {
+    const appDir = join(tempDir, 'fe')
+    await mkdir(appDir)
+    await writeFile(join(appDir, 'package-lock.json'), '{}')
+
+    expect(findLockFile(appDir, tempDir, ['package-lock.json'])).toBe('package-lock.json')
+  })
+
+  it('should find a lock file in the workspace root', async () => {
+    const appDir = join(tempDir, 'packages', 'app')
+    await mkdir(appDir, { recursive: true })
+    await writeFile(join(tempDir, 'pnpm-lock.yaml'), '')
+
+    expect(findLockFile(appDir, tempDir, 'pnpm-lock.yaml')).toBe('../../pnpm-lock.yaml')
+  })
+
+  it('should prefer the closest lock file', async () => {
+    const appDir = join(tempDir, 'fe')
+    await mkdir(appDir)
+    await writeFile(join(tempDir, 'package-lock.json'), '{}')
+    await writeFile(join(appDir, 'package-lock.json'), '{}')
+
+    expect(findLockFile(appDir, tempDir, 'package-lock.json')).toBe('package-lock.json')
+  })
+
+  it('should not look above the workspace root', async () => {
+    const appDir = join(tempDir, 'fe')
+    await mkdir(appDir)
+    await writeFile(join(tempDir, 'package-lock.json'), '{}')
+
+    expect(findLockFile(appDir, appDir, 'package-lock.json')).toBeUndefined()
+  })
+
+  it('should return undefined when there is no lock file', () => {
+    expect(findLockFile(tempDir, tempDir, ['package-lock.json', 'pnpm-lock.yaml'])).toBeUndefined()
+    expect(findLockFile(tempDir, tempDir, undefined)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #951

### 📚 Description

fixes an edge case where there's a lockfile in package directory but not workspace root