### PR TITLE
fix(dev): settle in-flight responses when nuxt reloads

### DIFF
--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -161,6 +161,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   #fileChangeTracker = new FileChangeTracker()
   #cwd: string
   #websocketConnections = new Set<any>()
+  #inflightResponses = new Set<ServerResponse>()
   #lockCleanup?: () => void
   #lockedBuildDir?: string
 
@@ -190,6 +191,10 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
       }
       await _initPromise
       if (this.#handler) {
+        this.#inflightResponses.add(res)
+        res.once('close', () => {
+          this.#inflightResponses.delete(res)
+        })
         this.#handler(req, res)
       }
       else {
@@ -552,6 +557,25 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     previousRelease?.()
   }
 
+  /**
+   * Requests handed to the outgoing Nitro handler are never answered once it is
+   * torn down, so respond (or drop the socket) before swapping the handler out.
+   */
+  #settleInflightResponses(): void {
+    const responses = [...this.#inflightResponses]
+    this.#inflightResponses.clear()
+    for (const res of responses) {
+      if (res.writableEnded || res.destroyed) {
+        continue
+      }
+      if (res.headersSent) {
+        res.destroy()
+        continue
+      }
+      void this.#renderLoadingScreen(res.req, res).catch(() => res.destroy())
+    }
+  }
+
   #closeWebSocketConnections(): void {
     for (const socket of this.#websocketConnections) {
       socket.destroy()
@@ -563,6 +587,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     const action = reload ? 'Restarting' : 'Starting'
     this.#loadingMessage = `${reason ? `${reason}. ` : ''}${action} Nuxt...`
     this.#handler = undefined
+    this.#settleInflightResponses()
     this.emit('loading', this.#loadingMessage)
     if (reload) {
       // eslint-disable-next-line no-console

--- a/packages/nuxt-cli/test/e2e/dev-restart.spec.ts
+++ b/packages/nuxt-cli/test/e2e/dev-restart.spec.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from 'node:crypto'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { getPort } from 'get-port-please'
+import { describe, expect, it, vi } from 'vitest'
+import { initialize } from '../../src/dev'
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/dev', import.meta.url))
+
+describe('dev server reload', () => {
+  it('should settle in-flight requests when nuxt reloads', { timeout: 90_000 }, async () => {
+    await rm(join(fixtureDir, '.nuxt'), { recursive: true, force: true })
+
+    const host = '127.0.0.1'
+    const port = await getPort({ host, port: 3080 })
+    const { close, reload } = await initialize({ cwd: fixtureDir, args: {} }, {
+      listenOverrides: { hostname: host, port },
+      showBanner: false,
+    })
+    const base = `http://${host}:${port}`
+
+    try {
+      const token = randomUUID()
+      const inflight = fetch(`${base}/api/hang?token=${token}`).then(
+        response => `status:${response.status}`,
+        () => 'error',
+      )
+
+      await vi.waitFor(async () => {
+        const { started } = await fetch(`${base}/api/hang-state?token=${token}`).then(r => r.json()) as { started: boolean }
+        expect(started).toBe(true)
+      }, { timeout: 30_000, interval: 100 })
+
+      await reload('test reload')
+
+      const timer = new Promise<'hanging'>(resolve => setTimeout(resolve, 10_000, 'hanging').unref())
+      await expect(Promise.race([inflight, timer])).resolves.toBe('status:503')
+    }
+    finally {
+      await close()
+    }
+  })
+})

--- a/packages/nuxt-cli/test/fixtures/dev/server/api/hang-state.ts
+++ b/packages/nuxt-cli/test/fixtures/dev/server/api/hang-state.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler, getQuery } from 'h3'
+
+export default defineEventHandler((event) => {
+  const token = (globalThis as { __hangToken?: string }).__hangToken
+  return { started: !!token && token === String(getQuery(event).token) }
+})

--- a/packages/nuxt-cli/test/fixtures/dev/server/api/hang.ts
+++ b/packages/nuxt-cli/test/fixtures/dev/server/api/hang.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler, getQuery } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  ;(globalThis as { __hangToken?: string }).__hangToken = String(getQuery(event).token)
+  await new Promise(() => {})
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

noticed this when creating a repro for something else - previously inflight requests when a nuxt/nitro instance was restarting were never closed and the socket was never destroyed