### PR TITLE
fix(dev): `stdin` paused when using clark spinners on Windows

### DIFF
--- a/packages/nuxt-cli/src/utils/console.ts
+++ b/packages/nuxt-cli/src/utils/console.ts
@@ -56,7 +56,13 @@ export function setupGlobalConsole(opts: { dev?: boolean } = {}) {
  * keyboard shortcuts.
  */
 export function restoreRawMode(): void {
-  if (process.stdin.isTTY && process.stdin.isRaw) {
+  if (!process.stdin.isTTY) {
+    return
+  }
+  if (process.stdin.isPaused()) {
+    process.stdin.resume()
+  }
+  if (process.stdin.isRaw) {
     process.stdin.setRawMode(false)
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When using clark spinners stdin requires 2 enters, for example, pressing `h + enter` on Windows after installing cloudflare executable requires an additional `h + enter`, the `stdin` being paused (`nuxi dev --tunnel`).

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
