### PR TITLE
refactor: normalise on `rootDir` in most usages

### DIFF
--- a/packages/nuxt-cli/src/commands/_shared.ts
+++ b/packages/nuxt-cli/src/commands/_shared.ts
@@ -3,7 +3,7 @@ import type { ArgDef } from 'citty'
 export const cwdArgs = {
   cwd: {
     type: 'string',
-    description: 'Specify the working directory',
+    description: 'Specify the root directory of your Nuxt project',
     valueHint: 'directory',
     default: '.',
   },
@@ -49,17 +49,16 @@ export const profileArgs = {
   },
 } as const satisfies Record<string, ArgDef>
 
-export const legacyRootDirArgs = {
-  // cwd falls back to rootDir's default (indirect default)
-  cwd: {
-    ...cwdArgs.cwd,
-    description: 'Specify the working directory, this takes precedence over ROOTDIR',
-    default: undefined,
-  },
+/**
+ * `--cwd` is deliberately not declared here: it is an undocumented alias for ROOTDIR,
+ * normalised out of `rawArgs` by `normaliseCwdArg` and read back off `args.cwd`.
+ * No default, so `resolveRootDir` can tell an explicit ROOTDIR from an absent one.
+ */
+export const rootDirArgs = {
   rootDir: {
     type: 'positional',
-    description: 'Specifies the working directory',
+    description: 'The root directory of your Nuxt project (default: .)',
     required: false,
-    default: '.',
+    default: undefined,
   },
 } as const satisfies Record<string, ArgDef>

--- a/packages/nuxt-cli/src/commands/analyze.ts
+++ b/packages/nuxt-cli/src/commands/analyze.ts
@@ -7,7 +7,7 @@ import { intro, note, outro, taskLog } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { defu } from 'defu'
 import { H3, lazyEventHandler } from 'h3-next'
-import { join, resolve } from 'pathe'
+import { join } from 'pathe'
 import colors from 'picocolors'
 import { serve } from 'srvx'
 
@@ -15,8 +15,8 @@ import { overrideEnv } from '../utils/env'
 import { clearDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { relativeToProcess } from '../utils/paths'
-import { cwdArgs, dotEnvArgs, extendsArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { relativeToProcess, resolveRootDir } from '../utils/paths'
+import { dotEnvArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
 
 const NON_WORD_RE = /[^\w-]/g
 
@@ -45,9 +45,8 @@ export default defineCommand({
     description: 'Build Nuxt and analyze production bundle (experimental)',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
-    ...legacyRootDirArgs,
     ...dotEnvArgs,
     ...extendsArgs,
     name: {
@@ -66,7 +65,7 @@ export default defineCommand({
   async run(ctx) {
     overrideEnv('production')
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
     const name = ctx.args.name || 'default'
     const slug = name.trim().replace(NON_WORD_RE, '_')
 

--- a/packages/nuxt-cli/src/commands/build.ts
+++ b/packages/nuxt-cli/src/commands/build.ts
@@ -2,18 +2,20 @@ import process from 'node:process'
 
 import { intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { relative, resolve } from 'pathe'
-import colors from 'picocolors'
+import { relative } from 'pathe'
 
+import colors from 'picocolors'
 import { showBanner } from '../utils/banner'
+
 import { overrideEnv } from '../utils/env'
 import { formatDuration } from '../utils/formatting'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 import { acquireLock, formatLockError } from '../utils/lockfile'
 import { logger } from '../utils/logger'
+import { resolveRootDir } from '../utils/paths'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile'
-import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs, profileArgs } from './_shared'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -21,7 +23,7 @@ export default defineCommand({
     description: 'Build Nuxt for production deployment',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
     prerender: {
       type: 'boolean',
@@ -35,14 +37,13 @@ export default defineCommand({
     ...envNameArgs,
     ...extendsArgs,
     ...profileArgs,
-    ...legacyRootDirArgs,
   },
   async run(ctx) {
     overrideEnv('production')
 
     const start = Date.now()
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const profileArg = ctx.args.profile
     const perfValue = profileArg === 'verbose' ? true : profileArg ? 'quiet' : undefined

--- a/packages/nuxt-cli/src/commands/cleanup.ts
+++ b/packages/nuxt-cli/src/commands/cleanup.ts
@@ -1,10 +1,11 @@
 import { defineCommand } from 'citty'
-import { resolve } from 'pathe'
 
 import { loadKit } from '../utils/kit'
+
 import { logger } from '../utils/logger'
 import { cleanupNuxtDirs } from '../utils/nuxt'
-import { cwdArgs, legacyRootDirArgs } from './_shared'
+import { resolveRootDir } from '../utils/paths'
+import { rootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -12,11 +13,10 @@ export default defineCommand({
     description: 'Clean up generated Nuxt files and caches',
   },
   args: {
-    ...cwdArgs,
-    ...legacyRootDirArgs,
+    ...rootDirArgs,
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
     const { loadNuxtConfig } = await loadKit(cwd)
     const nuxtOptions = await loadNuxtConfig({ cwd, overrides: { dev: true } })
     await cleanupNuxtDirs(nuxtOptions.rootDir, nuxtOptions.buildDir)

--- a/packages/nuxt-cli/src/commands/dev-child.ts
+++ b/packages/nuxt-cli/src/commands/dev-child.ts
@@ -1,9 +1,10 @@
 import process from 'node:process'
 import { defineCommand } from 'citty'
-import { resolve } from 'pathe'
-import { isTest } from 'std-env'
 
-import { cwdArgs, dotEnvArgs, envNameArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { isTest } from 'std-env'
+import { resolveRootDir } from '../utils/paths'
+
+import { dotEnvArgs, envNameArgs, logLevelArgs, rootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -12,11 +13,10 @@ export default defineCommand({
     hidden: true,
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
     ...envNameArgs,
     ...dotEnvArgs,
-    ...legacyRootDirArgs,
     clear: {
       type: 'boolean',
       description: 'Clear console on restart',
@@ -28,7 +28,7 @@ export default defineCommand({
       console.warn('`nuxt _dev` is an internal command and should not be used directly. Please use `nuxt dev` instead.')
     }
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const { initialize } = await import('../dev')
     await initialize({ cwd, args: ctx.args }, ctx)

--- a/packages/nuxt-cli/src/commands/dev.ts
+++ b/packages/nuxt-cli/src/commands/dev.ts
@@ -6,17 +6,18 @@ import type { NuxtDevContext } from '../dev/utils'
 import process from 'node:process'
 
 import { defineCommand } from 'citty'
-import { resolve } from 'pathe'
+
 import colors from 'picocolors'
 import { isBun, isTest } from 'std-env'
 import { satisfies } from 'verkit'
-
 import { initialize } from '../dev'
+
 import { closeInspector, openInspector, resolveInspectOptions } from '../dev/inspect'
 import { ForkPool } from '../dev/pool'
 import { setupShortcuts } from '../dev/shortcuts'
 import { debug, logger } from '../utils/logger'
-import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs, profileArgs } from './_shared'
+import { resolveRootDir } from '../utils/paths'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
 
 const startTime: number | undefined = Date.now()
 
@@ -29,10 +30,9 @@ const command = defineCommand({
     description: 'Run Nuxt development server',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
     ...dotEnvArgs,
-    ...legacyRootDirArgs,
     ...envNameArgs,
     ...extendsArgs,
     'inspect': {
@@ -141,7 +141,7 @@ const command = defineCommand({
   },
   async run(ctx) {
     // Prepare
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const listenOverrides = resolveListenOverrides(ctx.args)
 

--- a/packages/nuxt-cli/src/commands/devtools.ts
+++ b/packages/nuxt-cli/src/commands/devtools.ts
@@ -1,12 +1,13 @@
 import process from 'node:process'
 
 import { defineCommand } from 'citty'
-import { resolve } from 'pathe'
+
 import colors from 'picocolors'
 import { x } from 'tinyexec'
-
 import { logger } from '../utils/logger'
-import { cwdArgs, legacyRootDirArgs } from './_shared'
+
+import { resolveRootDir } from '../utils/paths'
+import { rootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -14,16 +15,16 @@ export default defineCommand({
     description: 'Enable or disable devtools in a Nuxt project',
   },
   args: {
-    ...cwdArgs,
+    // `command` has to precede the `dir` positional supplied by `rootDirArgs`
     command: {
       type: 'positional',
       description: 'Command to run',
       valueHint: 'enable|disable',
     },
-    ...legacyRootDirArgs,
+    ...rootDirArgs,
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
     const command = ctx.args.command
 
     if (!command || !['enable', 'disable'].includes(command)) {

--- a/packages/nuxt-cli/src/commands/generate.ts
+++ b/packages/nuxt-cli/src/commands/generate.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs, profileArgs } from './_shared'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
 import buildCommand from './build'
 
 export default defineCommand({
@@ -9,7 +9,7 @@ export default defineCommand({
     description: 'Build Nuxt and prerender all routes',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
     preset: {
       type: 'string',
@@ -19,7 +19,6 @@ export default defineCommand({
     ...envNameArgs,
     ...extendsArgs,
     ...profileArgs,
-    ...legacyRootDirArgs,
   },
   async run(ctx) {
     ctx.args.prerender = true

--- a/packages/nuxt-cli/src/commands/info.ts
+++ b/packages/nuxt-cli/src/commands/info.ts
@@ -7,19 +7,20 @@ import process from 'node:process'
 import { box } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { detectPackageManager } from 'nypm'
-import { resolve } from 'pathe'
+
 import colors from 'picocolors'
 import { readPackageJSON } from 'pkg-types'
 import { isBun, isDeno, isMinimal } from 'std-env'
 import { writeText } from 'tinyclip'
-
 import { version as nuxiVersion } from '../../package.json'
+
 import { getBuilder } from '../utils/banner'
 import { formatInfoBox } from '../utils/formatting'
 import { tryResolveNuxt } from '../utils/kit'
 import { logger } from '../utils/logger'
 import { getPackageManagerVersion } from '../utils/packageManagers'
-import { cwdArgs, legacyRootDirArgs } from './_shared'
+import { resolveRootDir } from '../utils/paths'
+import { rootDirArgs } from './_shared'
 
 const LEADING_SLASH_RE = /^\//
 
@@ -29,12 +30,11 @@ export default defineCommand({
     description: 'Get information about Nuxt project',
   },
   args: {
-    ...cwdArgs,
-    ...legacyRootDirArgs,
+    ...rootDirArgs,
   },
   async run(ctx) {
     // Resolve rootDir
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     // Load Nuxt config
     const nuxtConfig = await getNuxtConfig(cwd)

--- a/packages/nuxt-cli/src/commands/init.ts
+++ b/packages/nuxt-cli/src/commands/init.ts
@@ -137,6 +137,10 @@ export default defineCommand({
   },
   args: {
     ...cwdArgs,
+    cwd: {
+      ...cwdArgs.cwd,
+      description: 'Specify the directory to create the project in',
+    },
     ...logLevelArgs,
     dir: {
       type: 'positional',

--- a/packages/nuxt-cli/src/commands/prepare.ts
+++ b/packages/nuxt-cli/src/commands/prepare.ts
@@ -1,14 +1,13 @@
 import process from 'node:process'
 
 import { defineCommand } from 'citty'
-import { resolve } from 'pathe'
 import colors from 'picocolors'
 
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { relativeToProcess } from '../utils/paths'
-import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { relativeToProcess, resolveRootDir } from '../utils/paths'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -16,17 +15,16 @@ export default defineCommand({
     description: 'Prepare Nuxt for development/build',
   },
   args: {
+    ...rootDirArgs,
     ...dotEnvArgs,
-    ...cwdArgs,
     ...logLevelArgs,
     ...envNameArgs,
     ...extendsArgs,
-    ...legacyRootDirArgs,
   },
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const { loadNuxt, buildNuxt, writeTypes } = await loadKit(cwd)
     const nuxt = await loadNuxt({

--- a/packages/nuxt-cli/src/commands/preview.ts
+++ b/packages/nuxt-cli/src/commands/preview.ts
@@ -10,8 +10,8 @@ import { x } from 'tinyexec'
 
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { relativeToProcess } from '../utils/paths'
-import { cwdArgs, dotEnvArgs, envNameArgs, extendsArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { relativeToProcess, resolveRootDir } from '../utils/paths'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
 
 const command = defineCommand({
   meta: {
@@ -19,11 +19,10 @@ const command = defineCommand({
     description: 'Launches Nitro server for local testing after `nuxt build`.',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
     ...envNameArgs,
     ...extendsArgs,
-    ...legacyRootDirArgs,
     port: {
       type: 'string',
       description: 'Port to listen on',
@@ -34,7 +33,7 @@ const command = defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const { loadNuxt } = await loadKit(cwd)
 

--- a/packages/nuxt-cli/src/commands/test.ts
+++ b/packages/nuxt-cli/src/commands/test.ts
@@ -1,10 +1,11 @@
 import process from 'node:process'
 
 import { defineCommand } from 'citty'
-import { resolve } from 'pathe'
 
 import { logger } from '../utils/logger'
-import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+
+import { resolveRootDir } from '../utils/paths'
+import { logLevelArgs, rootDirArgs } from './_shared'
 
 export default defineCommand({
   meta: {
@@ -12,9 +13,8 @@ export default defineCommand({
     description: 'Run tests',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
-    ...legacyRootDirArgs,
     dev: {
       type: 'boolean',
       description: 'Run in dev mode',
@@ -27,7 +27,7 @@ export default defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'test'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const { runTests } = await importTestUtils()
     await runTests({

--- a/packages/nuxt-cli/src/commands/typecheck.ts
+++ b/packages/nuxt-cli/src/commands/typecheck.ts
@@ -15,8 +15,8 @@ import { x } from 'tinyexec'
 
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { withNodePath } from '../utils/paths'
-import { cwdArgs, dotEnvArgs, extendsArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { resolveRootDir, withNodePath } from '../utils/paths'
+import { dotEnvArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
 
 type TypeChecker = 'vue-tsc' | 'golar'
 
@@ -109,11 +109,10 @@ export default defineCommand({
     description: 'Runs type-checking throughout your app using `vue-tsc` or Golar.',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
     ...dotEnvArgs,
     ...extendsArgs,
-    ...legacyRootDirArgs,
     checker: {
       type: 'string',
       description: 'Type checker to use (`vue-tsc` or `golar`)',
@@ -127,7 +126,7 @@ export default defineCommand({
   async run(ctx) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     const checkerArg = ctx.args.checker
     if (checkerArg && !Object.hasOwn(TYPE_CHECKERS, checkerArg)) {

--- a/packages/nuxt-cli/src/commands/upgrade.ts
+++ b/packages/nuxt-cli/src/commands/upgrade.ts
@@ -17,9 +17,9 @@ import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
 import { cleanupNuxtDirs, nuxtVersionToGitIdentifier } from '../utils/nuxt'
 import { getPackageManagerVersion } from '../utils/packageManagers'
-import { relativeToProcess } from '../utils/paths'
+import { relativeToProcess, resolveRootDir } from '../utils/paths'
 import { getNuxtVersion } from '../utils/versions'
-import { cwdArgs, legacyRootDirArgs, logLevelArgs } from './_shared'
+import { logLevelArgs, rootDirArgs } from './_shared'
 
 function checkNuxtDependencyType(pkg: PackageJson): 'dependencies' | 'devDependencies' {
   if (pkg.dependencies?.nuxt) {
@@ -86,9 +86,8 @@ export default defineCommand({
     description: 'Upgrade Nuxt',
   },
   args: {
-    ...cwdArgs,
+    ...rootDirArgs,
     ...logLevelArgs,
-    ...legacyRootDirArgs,
     dedupe: {
       type: 'boolean',
       description: 'Dedupe dependencies after upgrading',
@@ -107,7 +106,7 @@ export default defineCommand({
     },
   },
   async run(ctx) {
-    const cwd = resolve(ctx.args.cwd || ctx.args.rootDir)
+    const cwd = resolveRootDir(ctx.args)
 
     intro(colors.cyan('Upgrading Nuxt ...'))
 

--- a/packages/nuxt-cli/src/main.ts
+++ b/packages/nuxt-cli/src/main.ts
@@ -12,6 +12,7 @@ import { description, name, version } from '../package.json'
 import { commands } from './commands'
 import { cwdArgs } from './commands/_shared'
 import { runCommand } from './run'
+import { normaliseCwdArg } from './utils/args'
 import { setupGlobalConsole } from './utils/console'
 import { checkEngines } from './utils/engines'
 
@@ -40,6 +41,8 @@ const _main = defineCommand({
   },
   subCommands: commands,
   async setup(ctx) {
+    normaliseCwdArg(ctx.rawArgs)
+
     const command = ctx.args._[0]
     setupGlobalConsole({ dev: command === 'dev' })
 

--- a/packages/nuxt-cli/src/run-command.ts
+++ b/packages/nuxt-cli/src/run-command.ts
@@ -5,6 +5,7 @@ import process from 'node:process'
 import { runCommand as _runCommand } from 'citty'
 
 import { isNuxiCommand } from './commands/_utils'
+import { normaliseCwdArg } from './utils/args'
 
 // To provide subcommands call it as `runCommandDef(<command>, [<subcommand>, ...])`
 export async function runCommandDef<T extends ArgsDef = ArgsDef>(
@@ -22,8 +23,11 @@ export async function runCommandDef<T extends ArgsDef = ArgsDef>(
     throw new Error(`Invalid command, must be named`)
   }
 
+  const rawArgs = [...argv]
+  normaliseCwdArg(rawArgs)
+
   return await _runCommand(command, {
-    rawArgs: argv,
+    rawArgs,
     data: {
       overrides: data.overrides || {},
     },

--- a/packages/nuxt-cli/src/run.ts
+++ b/packages/nuxt-cli/src/run.ts
@@ -5,6 +5,7 @@ import { runCommand as _runCommand, runMain as _runMain } from 'citty'
 
 import { commands } from './commands'
 import { main } from './main'
+import { normaliseCwdArg } from './utils/args'
 
 globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
   // Programmatic usage fallback
@@ -34,8 +35,11 @@ export async function runCommand(
     throw new Error(`Invalid command ${name}`)
   }
 
+  const rawArgs = [...argv]
+  normaliseCwdArg(rawArgs)
+
   return await _runCommand(await commands[name as keyof typeof commands](), {
-    rawArgs: argv,
+    rawArgs,
     data: {
       overrides: data.overrides || {},
     },

--- a/packages/nuxt-cli/src/utils/args.ts
+++ b/packages/nuxt-cli/src/utils/args.ts
@@ -1,0 +1,27 @@
+function cwdArgIndex(rawArgs: string[]): number {
+  const end = rawArgs.indexOf('--')
+  const index = rawArgs.findIndex(arg => arg === '--cwd' || arg.startsWith('--cwd='))
+  return end !== -1 && index > end ? -1 : index
+}
+
+/**
+ * Commands accept `--cwd` as an undeclared alias for their ROOTDIR positional, so it stays out
+ * of `--help`. Undeclared, only the `--cwd=<dir>` form is safe: mri treats a bare `--cwd` as
+ * boolean and its value would be consumed as a positional. Rewrite to that form, keeping the
+ * last occurrence, and move it to the end, past a command name that citty would otherwise
+ * slice the preceding arguments off.
+ * @see https://github.com/nuxt/cli/issues/365
+ */
+export function normaliseCwdArg(rawArgs: string[]): void {
+  let cwd: string | undefined
+  for (let index = cwdArgIndex(rawArgs); index !== -1; index = cwdArgIndex(rawArgs)) {
+    const arg = rawArgs[index]!
+    const inline = arg.includes('=')
+    const [, value] = rawArgs.splice(index, inline ? 1 : 2)
+    cwd = inline ? arg.slice(arg.indexOf('=') + 1) : value
+  }
+
+  if (cwd !== undefined) {
+    rawArgs.push(`--cwd=${cwd}`)
+  }
+}

--- a/packages/nuxt-cli/src/utils/args.ts
+++ b/packages/nuxt-cli/src/utils/args.ts
@@ -8,8 +8,8 @@ function cwdArgIndex(rawArgs: string[]): number {
  * Commands accept `--cwd` as an undeclared alias for their ROOTDIR positional, so it stays out
  * of `--help`. Undeclared, only the `--cwd=<dir>` form is safe: mri treats a bare `--cwd` as
  * boolean and its value would be consumed as a positional. Rewrite to that form, keeping the
- * last occurrence, and move it to the end, past a command name that citty would otherwise
- * slice the preceding arguments off.
+ * last occurrence, and move it after a command name that citty would otherwise slice the
+ * preceding arguments off, but ahead of any `--` separator so it is still parsed as a flag.
  * @see https://github.com/nuxt/cli/issues/365
  */
 export function normaliseCwdArg(rawArgs: string[]): void {
@@ -21,7 +21,10 @@ export function normaliseCwdArg(rawArgs: string[]): void {
     cwd = inline ? arg.slice(arg.indexOf('=') + 1) : value
   }
 
-  if (cwd !== undefined) {
-    rawArgs.push(`--cwd=${cwd}`)
+  if (cwd === undefined) {
+    return
   }
+
+  const separator = rawArgs.indexOf('--')
+  rawArgs.splice(separator === -1 ? rawArgs.length : separator, 0, `--cwd=${cwd}`)
 }

--- a/packages/nuxt-cli/src/utils/paths.ts
+++ b/packages/nuxt-cli/src/utils/paths.ts
@@ -1,8 +1,28 @@
 import { delimiter, relative } from 'node:path'
 import process from 'node:process'
 import { link } from 'clickable-path'
+import { resolve } from 'pathe'
+
+import { logger } from './logger'
 
 const cwd = process.cwd()
+
+/**
+ * Resolve the root directory a command should operate in from its `rootDir` positional
+ * and optional `--cwd` override, warning when the two disagree.
+ */
+export function resolveRootDir(args: { cwd?: string, rootDir?: string }): string {
+  if (!args.cwd) {
+    return resolve(args.rootDir || '.')
+  }
+
+  const resolved = resolve(args.cwd)
+  if (args.rootDir && resolve(args.rootDir) !== resolved) {
+    logger.warn(`Both \`--cwd\` and \`ROOTDIR\` were provided; using \`${relativeToProcess(resolved)}\`.`)
+  }
+
+  return resolved
+}
 
 export function relativeToProcess(path: string) {
   return link(path, {

--- a/packages/nuxt-cli/src/utils/paths.ts
+++ b/packages/nuxt-cli/src/utils/paths.ts
@@ -12,12 +12,16 @@ const cwd = process.cwd()
  * and optional `--cwd` override, warning when the two disagree.
  */
 export function resolveRootDir(args: { cwd?: string, rootDir?: string }): string {
+  // citty fills positionals from mri's `_`, which also collects arguments following `--`, so
+  // `nuxt test -- --watch` would otherwise resolve a directory named after a passthrough flag
+  const rootDir = args.rootDir?.startsWith('-') ? undefined : args.rootDir
+
   if (!args.cwd) {
-    return resolve(args.rootDir || '.')
+    return resolve(rootDir || '.')
   }
 
   const resolved = resolve(args.cwd)
-  if (args.rootDir && resolve(args.rootDir) !== resolved) {
+  if (rootDir && resolve(rootDir) !== resolved) {
     logger.warn(`Both \`--cwd\` and \`ROOTDIR\` were provided; using \`${relativeToProcess(resolved)}\`.`)
   }
 

--- a/packages/nuxt-cli/test/unit/commands/typecheck.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/typecheck.spec.ts
@@ -1,9 +1,8 @@
 import { fileURLToPath } from 'node:url'
 
-import { runCommand } from 'citty'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import typecheck from '../../../src/commands/typecheck'
+import { runCommand } from '../../../src/run'
 import { logger } from '../../../src/utils/logger'
 
 const { x, loadKit } = vi.hoisted(() => ({
@@ -26,7 +25,7 @@ function fixture(name: string) {
 }
 
 async function run(cwd: string, ...args: string[]) {
-  await runCommand(typecheck, { rawArgs: ['--cwd', cwd, ...args] })
+  await runCommand('typecheck', ['--cwd', cwd, ...args])
   return x.mock.calls[0]?.[1]
 }
 

--- a/packages/nuxt-cli/test/unit/global-args.spec.ts
+++ b/packages/nuxt-cli/test/unit/global-args.spec.ts
@@ -1,0 +1,42 @@
+import type { ArgsDef } from 'citty'
+import type { main } from '../../src/main'
+
+import { runCommand } from 'citty'
+
+import { describe, expect, it, vi } from 'vitest'
+import { rootDirArgs } from '../../src/commands/_shared'
+
+async function run(argv: string[], args: ArgsDef = { ...rootDirArgs }): Promise<Record<string, unknown>> {
+  const run = vi.fn()
+  vi.doMock('../../src/commands', () => ({
+    commands: { info: () => ({ meta: { name: 'info' }, args, run }) },
+  }))
+  vi.resetModules()
+
+  const { main: freshMain } = await import('../../src/main') as { main: typeof main }
+  await runCommand(freshMain, { rawArgs: argv })
+
+  return run.mock.calls[0]![0].args
+}
+
+describe('global args', () => {
+  it('should forward a leading --cwd to the subcommand', async () => {
+    expect(await run(['--cwd', 'apps/web', 'info'])).toMatchObject({ cwd: 'apps/web' })
+    expect(await run(['--cwd=apps/web', 'info'])).toMatchObject({ cwd: 'apps/web' })
+  })
+
+  it('should still accept --cwd after the subcommand', async () => {
+    expect(await run(['info', '--cwd', 'apps/web'])).toMatchObject({ cwd: 'apps/web' })
+  })
+
+  it('should prefer an explicit --cwd after the subcommand', async () => {
+    expect(await run(['--cwd', 'apps/docs', 'info', '--cwd', 'apps/web'])).toMatchObject({ cwd: 'apps/web' })
+  })
+
+  it('should preserve the ROOTDIR positional', async () => {
+    expect(await run(['--cwd', 'apps/docs', 'info', 'apps/web'])).toMatchObject({ cwd: 'apps/docs', rootDir: 'apps/web' })
+    const args = await run(['info', 'apps/web'])
+    expect(args).toMatchObject({ rootDir: 'apps/web' })
+    expect(args.cwd).toBeUndefined()
+  })
+})

--- a/packages/nuxt-cli/test/unit/help.spec.ts
+++ b/packages/nuxt-cli/test/unit/help.spec.ts
@@ -34,7 +34,7 @@ describe('help', () => {
 
       OPTIONS
 
-        --cwd=<directory>    Specify the working directory (Default: .)
+        --cwd=<directory>    Specify the root directory of your Nuxt project (Default: .)
 
       COMMANDS
 
@@ -71,7 +71,7 @@ describe('help', () => {
 
       OPTIONS
 
-                         --cwd=<directory>    Specify the working directory (Default: .)                             
+                         --cwd=<directory>    Specify the root directory of your Nuxt project (Default: .)           
           --logLevel=<silent|info|verbose>    Specify build-time log level                                           
                              --skipInstall    Skip npm install                                                       
                               --skipConfig    Skip nuxt.config.ts update                                             
@@ -94,9 +94,9 @@ describe('help', () => {
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory (Default: .)               
-        --logLevel=<silent|info|verbose>    Specify build-time log level                             
-                                 --force    Force override file if it already exists (Default: false)
+                       --cwd=<directory>    Specify the root directory of your Nuxt project (Default: .)
+        --logLevel=<silent|info|verbose>    Specify build-time log level                                
+                                 --force    Force override file if it already exists (Default: false)   
       "
     `)
   })
@@ -109,17 +109,16 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR
-        --logLevel=<silent|info|verbose>    Specify build-time log level                                     
-                       --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory      
-              -e, --extends=<layer-name>    Extend from a Nuxt layer                                         
-                           --name=<name>    Name of the analysis (Default: default)                          
-                                 --serve    Serve the analysis results (Default: true)                       
-                              --no-serve    Skip serving the analysis results                                
+        --logLevel=<silent|info|verbose>    Specify build-time log level                               
+                       --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory
+              -e, --extends=<layer-name>    Extend from a Nuxt layer                                   
+                           --name=<name>    Name of the analysis (Default: default)                    
+                                 --serve    Serve the analysis results (Default: true)                 
+                              --no-serve    Skip serving the analysis results                          
       "
     `)
   })
@@ -132,11 +131,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                              --prerender    Build Nuxt and prerender static routes                                                                                                              
                        --preset=<preset>    Nitro server preset                                                                                                                                 
@@ -156,11 +154,7 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
-
-      OPTIONS
-
-        --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR
+        ROOTDIR    The root directory of your Nuxt project (default: .)
       "
     `)
   })
@@ -173,11 +167,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                     --envName=<env_name>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
                        --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory                                                                                         
@@ -195,11 +188,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                                 --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
                   --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                                  --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory                                                                                         
                               --envName=<env_name>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
@@ -241,12 +233,8 @@ describe('help', () => {
 
       ARGUMENTS
 
-        COMMAND=<enable|disable>    Command to run (Required)                   
-                         ROOTDIR    Specifies the working directory (Default: .)
-
-      OPTIONS
-
-        --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR
+        COMMAND=<enable|disable>    Command to run (Required)                           
+                         ROOTDIR    The root directory of your Nuxt project (default: .)
       "
     `)
   })
@@ -259,11 +247,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                        --preset=<preset>    Nitro server preset                                                                                                                                 
                        --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory                                                                                         
@@ -282,11 +269,7 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
-
-      OPTIONS
-
-        --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR
+        ROOTDIR    The root directory of your Nuxt project (default: .)
       "
     `)
   })
@@ -303,7 +286,7 @@ describe('help', () => {
 
       OPTIONS
 
-                         --cwd=<directory>    Specify the working directory (Default: .)                    
+                         --cwd=<directory>    Specify the directory to create the project in (Default: .)   
           --logLevel=<silent|info|verbose>    Specify build-time log level                                  
                  -t, --template=<template>    Template name                                                 
                                -f, --force    Override existing directory                                   
@@ -344,12 +327,11 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
                        --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory                                                                                         
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                     --envName=<env_name>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
               -e, --extends=<layer-name>    Extend from a Nuxt layer                                                                                                                            
@@ -365,11 +347,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                     --envName=<env_name>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
               -e, --extends=<layer-name>    Extend from a Nuxt layer                                                                                                                            
@@ -387,11 +368,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                                                                   
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                     --envName=<env_name>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
               -e, --extends=<layer-name>    Extend from a Nuxt layer                                                                                                                            
@@ -409,14 +389,13 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR
-        --logLevel=<silent|info|verbose>    Specify build-time log level                                     
-                                   --dev    Run in dev mode                                                  
-                                 --watch    Watch mode                                                       
+        --logLevel=<silent|info|verbose>    Specify build-time log level
+                                   --dev    Run in dev mode             
+                                 --watch    Watch mode                  
       "
     `)
   })
@@ -429,11 +408,10 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR                                
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                     
                        --dotenv=<dotenv>    Path to \`.env\` file to load, relative to the root directory                                      
               -e, --extends=<layer-name>    Extend from a Nuxt layer                                                                         
@@ -451,15 +429,14 @@ describe('help', () => {
 
       ARGUMENTS
 
-        ROOTDIR    Specifies the working directory (Default: .)
+        ROOTDIR    The root directory of your Nuxt project (default: .)
 
       OPTIONS
 
-                                                  --cwd=<directory>    Specify the working directory, this takes precedence over ROOTDIR
-                                   --logLevel=<silent|info|verbose>    Specify build-time log level                                     
-                                                           --dedupe    Dedupe dependencies after upgrading                              
-                                                        -f, --force    Force upgrade to recreate lockfile and node_modules              
-        -ch, --channel=<stable|nightly|v3|v4|v4-nightly|v3-nightly>    Specify a channel to install from (Default: stable)              
+                                   --logLevel=<silent|info|verbose>    Specify build-time log level                       
+                                                           --dedupe    Dedupe dependencies after upgrading                
+                                                        -f, --force    Force upgrade to recreate lockfile and node_modules
+        -ch, --channel=<stable|nightly|v3|v4|v4-nightly|v3-nightly>    Specify a channel to install from (Default: stable)
       "
     `)
   })
@@ -476,7 +453,7 @@ describe('help', () => {
 
       OPTIONS
 
-                         --cwd=<directory>    Specify the working directory (Default: .)                             
+                         --cwd=<directory>    Specify the root directory of your Nuxt project (Default: .)           
           --logLevel=<silent|info|verbose>    Specify build-time log level                                           
                              --skipInstall    Skip npm install                                                       
                               --skipConfig    Skip nuxt.config.ts update                                             
@@ -498,10 +475,10 @@ describe('help', () => {
 
       OPTIONS
 
-                       --cwd=<directory>    Specify the working directory (Default: .)
-        --logLevel=<silent|info|verbose>    Specify build-time log level              
-                           --skipInstall    Skip dependency uninstall                 
-                            --skipConfig    Skip nuxt.config.ts update                
+                       --cwd=<directory>    Specify the root directory of your Nuxt project (Default: .)
+        --logLevel=<silent|info|verbose>    Specify build-time log level                                
+                           --skipInstall    Skip dependency uninstall                                   
+                            --skipConfig    Skip nuxt.config.ts update                                  
       "
     `)
   })
@@ -518,7 +495,7 @@ describe('help', () => {
 
       OPTIONS
 
-          --cwd=<directory>    Specify the working directory (Default: .)                                        
+          --cwd=<directory>    Specify the root directory of your Nuxt project (Default: .)                      
         --nuxtVersion=<2|3>    Filter by Nuxt version and list compatible modules only (auto detected by default)
       "
     `)

--- a/packages/nuxt-cli/test/unit/run.spec.ts
+++ b/packages/nuxt-cli/test/unit/run.spec.ts
@@ -55,4 +55,14 @@ describe('runCommand', () => {
 
     expect(argv).toEqual(['--clear'])
   })
+
+  it('should not modify a `--cwd` it normalises', async () => {
+    const { runCommand } = await import('../../src/run')
+    const argv = ['--clear', '--cwd', '.']
+
+    await runCommand('dev', argv)
+    await runCommandDef(devCommand, argv)
+
+    expect(argv).toEqual(['--clear', '--cwd', '.'])
+  })
 })

--- a/packages/nuxt-cli/test/unit/utils/args.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/args.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { normaliseCwdArg } from '../../../src/utils/args'
+
+function normalise(rawArgs: string[]): string[] {
+  normaliseCwdArg(rawArgs)
+  return rawArgs
+}
+
+describe('normaliseCwdArg', () => {
+  it('should rewrite a bare --cwd to its inline form', () => {
+    expect(normalise(['build', '--cwd', 'apps/web'])).toEqual(['build', '--cwd=apps/web'])
+    expect(normalise(['--cwd', 'apps/web'])).toEqual(['--cwd=apps/web'])
+  })
+
+  it('should move --cwd after the command name', () => {
+    expect(normalise(['--cwd', 'apps/web', 'build'])).toEqual(['build', '--cwd=apps/web'])
+    expect(normalise(['--cwd=apps/web', 'build', '--prerender'])).toEqual(['build', '--prerender', '--cwd=apps/web'])
+  })
+
+  it('should keep the last of several occurrences', () => {
+    expect(normalise(['--cwd', 'apps/docs', 'build', '--cwd=apps/web'])).toEqual(['build', '--cwd=apps/web'])
+  })
+
+  it('should leave the ROOTDIR positional in place', () => {
+    expect(normalise(['build', 'apps/web'])).toEqual(['build', 'apps/web'])
+    expect(normalise(['--cwd', 'apps/docs', 'build', 'apps/web'])).toEqual(['build', 'apps/web', '--cwd=apps/docs'])
+  })
+
+  it('should ignore --cwd after a -- separator', () => {
+    expect(normalise(['test', '--', '--cwd', 'apps/web'])).toEqual(['test', '--', '--cwd', 'apps/web'])
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/args.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/args.spec.ts
@@ -30,4 +30,9 @@ describe('normaliseCwdArg', () => {
   it('should ignore --cwd after a -- separator', () => {
     expect(normalise(['test', '--', '--cwd', 'apps/web'])).toEqual(['test', '--', '--cwd', 'apps/web'])
   })
+
+  it('should keep --cwd ahead of a -- separator', () => {
+    expect(normalise(['--cwd', 'apps/web', 'test', '--', '--watch'])).toEqual(['test', '--cwd=apps/web', '--', '--watch'])
+    expect(normalise(['test', '--cwd=apps/web', '--', '--watch'])).toEqual(['test', '--cwd=apps/web', '--', '--watch'])
+  })
 })

--- a/packages/nuxt-cli/test/unit/utils/paths.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/paths.spec.ts
@@ -1,14 +1,57 @@
 import { join } from 'node:path'
 import process from 'node:process'
 
-import { describe, expect, it, vi } from 'vitest'
+import { resolve } from 'pathe'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { relativeToProcess } from '../../../src/utils/paths'
+import { logger } from '../../../src/utils/logger'
+import { relativeToProcess, resolveRootDir } from '../../../src/utils/paths'
 
 describe('relativeToProcess', () => {
   it('should label paths relative to the working directory', () => {
     vi.stubEnv('FORCE_HYPERLINK', '0')
     expect(relativeToProcess(join(process.cwd(), 'src', 'app.vue'))).toBe(join('src', 'app.vue'))
     expect(relativeToProcess(process.cwd())).toBe(process.cwd())
+  })
+})
+
+describe('resolveRootDir', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should default to the process working directory', () => {
+    expect(resolveRootDir({ rootDir: '.' })).toBe(resolve(process.cwd()))
+    expect(resolveRootDir({})).toBe(resolve(process.cwd()))
+  })
+
+  it.each(['rootDir', 'cwd'] as const)('should resolve %s', (key) => {
+    expect(resolveRootDir({ [key]: 'apps/web' })).toBe(resolve('apps/web'))
+  })
+
+  it('should ignore a flag-like ROOTDIR', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    expect(resolveRootDir({ rootDir: '--watch' })).toBe(resolve('.'))
+    expect(resolveRootDir({ cwd: 'apps/web', rootDir: '--watch' })).toBe(resolve('apps/web'))
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('should let --cwd take precedence over ROOTDIR and warn on conflict', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    expect(resolveRootDir({ cwd: 'apps/docs', rootDir: 'apps/web' })).toBe(resolve('apps/docs'))
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0]![0]).toContain('Both `--cwd` and `ROOTDIR`')
+  })
+
+  it.each([
+    ['equivalent spellings', { cwd: 'apps/web', rootDir: 'apps/web/' }],
+    ['a single directory', { cwd: 'apps/web' }],
+  ])('should not warn for %s', (_label, args) => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    expect(resolveRootDir(args)).toBe(resolve('apps/web'))
+    expect(warn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/365
closes https://github.com/nuxt/cli/issues/450

### 📚 Description

this is backwards-compatible. it removes the deprecation of the positional rootDir argument, which is too firmly entrenched in nuxt examples and documentation to remove at this point.

and it _hides_ `--cwd` in most cases, while still supporting it, to avoid confusion between 'working directory' and 'root directory'. as a side effect, we also resolve https://github.com/nuxt/cli/issues/365 because we parse/handle cwd manually 🙌 