### PR TITLE
feat(add): support adding layers via cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OPTIONS
 
 COMMANDS
 
-           add    Add Nuxt modules
+           add    Add Nuxt modules and layers
   add-template    Create a new template file.
        analyze    Build Nuxt and analyze production bundle (experimental)
          build    Build Nuxt for production deployment
@@ -38,6 +38,18 @@ Use nuxi <command> --help for more information about a command.
 ## Documentation
 
 All commands are documented on https://nuxt.com/docs/api/commands
+
+## Adding modules and layers
+
+`nuxt add <name>` installs the package and writes it to `nuxt.config`. Where it is written depends on what the package is:
+
+```bash
+# added to `modules`
+nuxt add nuxt-shiki
+
+# a layer, added to `extends`
+nuxt add nuxt-seo-kit
+```
 
 ## Update Notifications
 

--- a/packages/nuxt-cli/src/commands/add.ts
+++ b/packages/nuxt-cli/src/commands/add.ts
@@ -1,0 +1,3 @@
+import { defineAddCommand } from './module/add'
+
+export default defineAddCommand({ layers: true })

--- a/packages/nuxt-cli/src/commands/index.ts
+++ b/packages/nuxt-cli/src/commands/index.ts
@@ -3,7 +3,7 @@ import type { CommandDef } from 'citty'
 const _rDefault = (r: any) => (r.default || r) as Promise<CommandDef>
 
 export const commands = {
-  'add': () => import('./module/add').then(_rDefault),
+  'add': () => import('./add').then(_rDefault),
   'add-template': () => import('./add-template').then(_rDefault),
   'analyze': () => import('./analyze').then(_rDefault),
   'build': () => import('./build').then(_rDefault),

--- a/packages/nuxt-cli/src/commands/module/_utils.ts
+++ b/packages/nuxt-cli/src/commands/module/_utils.ts
@@ -126,6 +126,117 @@ export function checkNuxtCompatibility(
   })
 }
 
+// Based on https://github.com/dword-design/package-name-regex, extended with an
+// optional subpath (`maz-ui/nuxt`) and an optional version in either position.
+const MODULE_SPEC_RE = /^(?<name>(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*)(?:@(?<earlyVersion>[^@/]+))?(?<subpath>(?:\/[^@/]+)*)(?:@(?<version>[^@]+))?$/
+
+export interface ModuleSpec {
+  /** npm package name to install, without subpath or version. */
+  pkgName: string
+  /** Requested version, if the user asked for one. */
+  pkgVersion?: string
+  /** Subpath the user asked for, without a leading slash (e.g. `nuxt`). */
+  subpath?: string
+}
+
+/** Parse a user-provided module spec such as `@maz-ui/nuxt@1.2.3` or `maz-ui/nuxt`. */
+export function parseModuleSpec(input: string): ModuleSpec | undefined {
+  const groups = input.match(MODULE_SPEC_RE)?.groups
+  if (!groups?.name) {
+    return
+  }
+
+  const version = groups.version || groups.earlyVersion
+  const subpath = groups.subpath?.replace(/^\//, '')
+
+  return {
+    pkgName: groups.name,
+    pkgVersion: version || undefined,
+    subpath: subpath || undefined,
+  }
+}
+
+/** The npm package name a config entry such as `maz-ui/nuxt` belongs to. */
+export function basePackageName(specifier: string): string {
+  const parts = specifier.split('/')
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]!
+}
+
+const NUXT_CONFIG_ENTRY_RE = /(?:^|\/)nuxt\.config\.[cm]?[jt]s$/
+// Nuxt resolves module specifiers with these suffixes, in this order.
+// https://github.com/nuxt/nuxt/blob/main/packages/kit/src/module/install.ts
+const MODULE_SUBPATHS = ['nuxt', 'module'] as const
+
+export interface ModuleEntry {
+  /** Subpath to use in `nuxt.config`, if the module lives behind one. */
+  subpath?: string
+  /** The package is a Nuxt layer and belongs in `extends`, not `modules`. */
+  isLayer: boolean
+}
+
+type Exports = PackageJson['exports']
+
+function resolveExportTarget(entry: Exports): string | undefined {
+  if (typeof entry === 'string') {
+    return entry
+  }
+  if (Array.isArray(entry)) {
+    for (const item of entry) {
+      const resolved = resolveExportTarget(item)
+      if (resolved) {
+        return resolved
+      }
+    }
+    return
+  }
+  if (entry && typeof entry === 'object') {
+    for (const key of ['nuxt', 'import', 'module', 'require', 'default'] as const) {
+      if (key in entry) {
+        const resolved = resolveExportTarget((entry as Record<string, Exports>)[key])
+        if (resolved) {
+          return resolved
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Work out how a package should be referenced from `nuxt.config`, mirroring the
+ * subpath suffixes Nuxt itself tries when resolving a module specifier, so that
+ * packages exposing their module at `<pkg>/nuxt` and layers whose entrypoint is a
+ * `nuxt.config` file both end up in the right place.
+ */
+export function resolveModuleEntry(pkg: PackageJson): ModuleEntry {
+  const exports = pkg.exports && typeof pkg.exports === 'object' && !Array.isArray(pkg.exports)
+    ? pkg.exports as Record<string, Exports>
+    : undefined
+
+  // Bare condition maps (`exports: { import: '...' }`) describe the root entry.
+  const hasSubpathExports = exports && Object.keys(exports).some(key => key.startsWith('.'))
+
+  if (hasSubpathExports) {
+    for (const subpath of MODULE_SUBPATHS) {
+      if (exports[`./${subpath}`]) {
+        return { subpath, isLayer: false }
+      }
+    }
+  }
+
+  const rootEntry = (hasSubpathExports ? resolveExportTarget(exports['.']) : resolveExportTarget(pkg.exports))
+    ?? pkg.module
+    ?? pkg.main
+
+  // A layer's entrypoint is its `nuxt.config`. Where there is no entry at all, an
+  // explicitly published `nuxt.config` is the only remaining signal (a package
+  // without `main` may still be a module resolved through an implicit `index.js`).
+  const isLayer = rootEntry
+    ? NUXT_CONFIG_ENTRY_RE.test(rootEntry)
+    : Boolean(pkg.files?.some(file => NUXT_CONFIG_ENTRY_RE.test(file)))
+
+  return { isLayer }
+}
+
 export function getProjectDependencies(projectPkg: PackageJson): Set<string> {
   return new Set([
     ...Object.keys(projectPkg.dependencies || {}),

--- a/packages/nuxt-cli/src/commands/module/add.ts
+++ b/packages/nuxt-cli/src/commands/module/add.ts
@@ -384,7 +384,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
     // The database records the package to install, which may itself be scoped
     // differently to what the user typed (`maz-ui` -> `@maz-ui/nuxt`).
     pkgName = basePackageName(matchedModule.npm)
-    subpath = matchedModule.npm.slice(pkgName.length + 1) || undefined
+    subpath = matchedModule.npm.slice(pkgName.length + 1) || subpath
   }
 
   if (matchedModule && matchedModule.compatibility.nuxt) {

--- a/packages/nuxt-cli/src/commands/module/add.ts
+++ b/packages/nuxt-cli/src/commands/module/add.ts
@@ -25,7 +25,7 @@ import { getNuxtVersion } from '../../utils/versions'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import prepareCommand from '../prepare'
 import { selectModulesAutocomplete } from './_autocomplete'
-import { checkNuxtCompatibility, ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, isPnpmWorkspace, MODULES_API_URL } from './_utils'
+import { basePackageName, checkNuxtCompatibility, ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, isPnpmWorkspace, MODULES_API_URL, parseModuleSpec, resolveModuleEntry } from './_utils'
 
 const WHITESPACE_RE = /\s/
 
@@ -34,110 +34,122 @@ interface ResolvedModule {
   pkg: string
   pkgName: string
   pkgVersion: string
+  /** Specifier to write to `nuxt.config`, which may include a subpath. */
+  specifier: string
+  /** Whether the package is a Nuxt layer, and so belongs in `extends`. */
+  isLayer?: boolean
   peerDependencies?: Record<string, string>
   optionalPeerDependencies?: string[]
 }
 type UnresolvedModule = false
 type ModuleResolution = ResolvedModule | UnresolvedModule
 
-export default defineCommand({
-  meta: {
-    name: 'add',
-    description: 'Add Nuxt modules',
-  },
-  args: {
-    ...cwdArgs,
-    ...logLevelArgs,
-    moduleName: {
-      type: 'positional',
-      description: 'Specify one or more modules to install by name, separated by spaces',
+/**
+ * `layers` only affects help text: `nuxt add` is documented as accepting layers as
+ * well as modules, whereas the `nuxt module` namespace documents modules alone.
+ */
+export function defineAddCommand({ layers = false }: { layers?: boolean } = {}) {
+  return defineCommand({
+    meta: {
+      name: 'add',
+      description: layers ? 'Add Nuxt modules and layers' : 'Add Nuxt modules',
     },
-    skipInstall: {
-      type: 'boolean',
-      description: 'Skip npm install',
+    args: {
+      ...cwdArgs,
+      ...logLevelArgs,
+      moduleName: {
+        type: 'positional',
+        description: `Specify one or more modules${layers ? ' or layers' : ''} to install by name, separated by spaces`,
+      },
+      skipInstall: {
+        type: 'boolean',
+        description: 'Skip npm install',
+      },
+      skipConfig: {
+        type: 'boolean',
+        description: 'Skip nuxt.config.ts update',
+      },
+      dev: {
+        type: 'boolean',
+        description: 'Install modules as dev dependencies',
+      },
+      packageManager: {
+        type: 'string',
+        description: `Package manager to install with (${packageManagers.map(pm => pm.name).join(', ')})`,
+      },
     },
-    skipConfig: {
-      type: 'boolean',
-      description: 'Skip nuxt.config.ts update',
-    },
-    dev: {
-      type: 'boolean',
-      description: 'Install modules as dev dependencies',
-    },
-    packageManager: {
-      type: 'string',
-      description: `Package manager to install with (${packageManagers.map(pm => pm.name).join(', ')})`,
-    },
-  },
-  async setup(ctx) {
-    const cwd = resolve(ctx.args.cwd)
-    let modules = ctx.args._.map(e => e.trim()).filter(Boolean)
-    const projectPkg = await readPackageJSON(cwd).catch(() => ({} as PackageJson))
+    async setup(ctx) {
+      const cwd = resolve(ctx.args.cwd)
+      let modules = ctx.args._.map(e => e.trim()).filter(Boolean)
+      const projectPkg = await readPackageJSON(cwd).catch(() => ({} as PackageJson))
 
-    if (!await ensureNuxtDependency(cwd, projectPkg)) {
-      process.exit(1)
-    }
-
-    // If no modules specified, show interactive search
-    if (modules.length === 0) {
-      const modulesSpinner = spinner()
-      modulesSpinner.start('Fetching available modules')
-
-      const [allModules, nuxtVersion] = await Promise.all([
-        fetchModules().catch((err) => {
-          modulesSpinner.error('Failed to fetch available modules')
-          logNetworkError(err, { url: MODULES_API_URL })
-          process.exit(1)
-        }),
-        getNuxtVersion(cwd),
-      ])
-
-      const compatibleModules = allModules.filter(m =>
-        !m.compatibility.nuxt || checkNuxtCompatibility(m, nuxtVersion),
-      )
-
-      modulesSpinner.stop('Modules loaded')
-
-      const result = await selectModulesAutocomplete({
-        modules: compatibleModules,
-        message: 'Search modules to add (Esc to finish):',
-      })
-
-      if (result.selected.length === 0) {
-        cancel('No modules selected.')
-        process.exit(0)
+      if (!await ensureNuxtDependency(cwd, projectPkg)) {
+        process.exit(1)
       }
 
-      modules = result.selected
-    }
+      // If no modules specified, show interactive search
+      if (modules.length === 0) {
+        const modulesSpinner = spinner()
+        modulesSpinner.start('Fetching available modules')
 
-    const resolvedModules: ResolvedModule[] = []
-    for (const moduleName of modules) {
-      const resolvedModule = await resolveModule(moduleName, cwd)
-      if (resolvedModule) {
-        resolvedModules.push(resolvedModule)
+        const [allModules, nuxtVersion] = await Promise.all([
+          fetchModules().catch((err) => {
+            modulesSpinner.error('Failed to fetch available modules')
+            logNetworkError(err, { url: MODULES_API_URL })
+            process.exit(1)
+          }),
+          getNuxtVersion(cwd),
+        ])
+
+        const compatibleModules = allModules.filter(m =>
+          !m.compatibility.nuxt || checkNuxtCompatibility(m, nuxtVersion),
+        )
+
+        modulesSpinner.stop('Modules loaded')
+
+        const result = await selectModulesAutocomplete({
+          modules: compatibleModules,
+          message: 'Search modules to add (Esc to finish):',
+        })
+
+        if (result.selected.length === 0) {
+          cancel('No modules selected.')
+          process.exit(0)
+        }
+
+        modules = result.selected
       }
-    }
 
-    if (resolvedModules.length === 0) {
-      cancel('No modules to add.')
-      process.exit(1)
-    }
+      const resolvedModules: ResolvedModule[] = []
+      for (const moduleName of modules) {
+        const resolvedModule = await resolveModule(moduleName, cwd)
+        if (resolvedModule) {
+          resolvedModules.push(resolvedModule)
+        }
+      }
 
-    logger.info(`Resolved ${resolvedModules.map(x => colors.cyan(x.pkgName)).join(', ')}, adding module${resolvedModules.length > 1 ? 's' : ''}...`)
+      if (resolvedModules.length === 0) {
+        cancel('No modules to add.')
+        process.exit(1)
+      }
 
-    const added = await addModules(resolvedModules, { ...ctx.args, cwd }, projectPkg)
+      logger.info(`Resolved ${resolvedModules.map(x => colors.cyan(x.specifier)).join(', ')}, adding ${describeModules(resolvedModules)}...`)
 
-    if (!added) {
-      process.exit(1)
-    }
+      const added = await addModules(resolvedModules, { ...ctx.args, cwd }, projectPkg)
 
-    // Run prepare command if install is not skipped
-    if (!ctx.args.skipInstall) {
-      await runCommand(prepareCommand, forwardCommandArgs(ctx.args))
-    }
-  },
-})
+      if (!added) {
+        process.exit(1)
+      }
+
+      // Run prepare command if install is not skipped
+      if (!ctx.args.skipInstall) {
+        await runCommand(prepareCommand, forwardCommandArgs(ctx.args))
+      }
+    },
+  })
+}
+
+export default defineAddCommand()
 
 // -- Internal Utils --
 async function addModules(modules: ResolvedModule[], { skipInstall = false, skipConfig = false, cwd, dev = false, packageManager: packageManagerName, logLevel }: { skipInstall?: boolean, skipConfig?: boolean, cwd: string, dev?: boolean, packageManager?: string, logLevel?: string }, projectPkg: PackageJson): Promise<boolean> {
@@ -228,25 +240,33 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
         return getDefaultNuxtConfig()
       },
       async onUpdate(config) {
-        if (!config.modules) {
+        if (!config.modules && modules.some(module => !module.isLayer)) {
           config.modules = []
         }
 
         for (const resolved of modules) {
-          if (config.modules.includes(resolved.pkgName)) {
-            logger.info(`${colors.cyan(resolved.pkgName)} is already in the ${colors.cyan('modules')}`)
+          const key = resolved.isLayer ? 'extends' : 'modules'
+          if (resolved.isLayer && !Array.isArray(config.extends)) {
+            // `extends` also accepts a single layer as a string
+            config.extends = config.extends ? [config.extends] : []
+          }
+
+          const target: unknown[] = resolved.isLayer ? config.extends : config.modules
+
+          if (target.includes(resolved.specifier)) {
+            logger.info(`${colors.cyan(resolved.specifier)} is already in the ${colors.cyan(key)}`)
 
             continue
           }
 
-          logger.info(`Adding ${colors.cyan(resolved.pkgName)} to the ${colors.cyan('modules')}`)
+          logger.info(`Adding ${colors.cyan(resolved.specifier)} to the ${colors.cyan(key)}`)
 
-          config.modules.push(resolved.pkgName)
+          target.push(resolved.specifier)
         }
       },
     }).catch((error) => {
       logger.error(`Failed to update ${colors.cyan('nuxt.config')}: ${error.message}`)
-      logger.error(`Please manually add ${colors.cyan(modules.map(module => module.pkgName).join(', '))} to the ${colors.cyan('modules')} in ${colors.cyan('nuxt.config.ts')}`)
+      logger.error(`Please manually add ${colors.cyan(modules.map(module => module.specifier).join(', '))} to ${colors.cyan('nuxt.config.ts')}`)
 
       return null
     })
@@ -309,6 +329,22 @@ export function resolveRequiredPeerDependencies(modules: ResolvedModule[], depen
   return [...peers.values()]
 }
 
+/** `module`, `layers`, `modules and layers`, and so on. */
+export function describeModules(modules: Array<{ isLayer?: boolean }>): string {
+  const layers = modules.filter(module => module.isLayer).length
+  const plain = modules.length - layers
+
+  const parts: string[] = []
+  if (plain > 0) {
+    parts.push(plain > 1 ? 'modules' : 'module')
+  }
+  if (layers > 0) {
+    parts.push(layers > 1 ? 'layers' : 'layer')
+  }
+
+  return parts.join(' and ')
+}
+
 function getDefaultNuxtConfig() {
   return `
 // https://nuxt.com/docs/api/configuration/nuxt-config
@@ -317,41 +353,38 @@ export default defineNuxtConfig({
 })`
 }
 
-// Based on https://github.com/dword-design/package-name-regex
-const packageRegex
-  = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?([a-z0-9-~][a-z0-9-._~]*)(@[^@]+)?$/
-
 async function resolveModule(moduleName: string, cwd: string): Promise<ModuleResolution> {
-  let pkgName = moduleName
-  let pkgVersion: string | undefined
+  const spec = parseModuleSpec(moduleName)
 
-  const reMatch = moduleName.match(packageRegex)
-  if (reMatch) {
-    if (reMatch[3]) {
-      pkgName = `${reMatch[1] || ''}${reMatch[2] || ''}`
-      pkgVersion = reMatch[3].slice(1)
-    }
-  }
-  else {
-    logger.error(`Invalid package name ${colors.cyan(pkgName)}.`)
+  if (!spec) {
+    logger.error(`Invalid package name ${colors.cyan(moduleName)}.`)
     return false
   }
+
+  let { pkgName, pkgVersion } = spec
+  let subpath = spec.subpath
 
   const modulesDB = await fetchModules().catch((err) => {
     logNetworkError(err, { url: MODULES_API_URL, level: 'warn', prefix: 'Cannot search in the Nuxt Modules database.' })
     return []
   })
 
+  const bareName = subpath ? `${pkgName}/${subpath}` : pkgName
   const matchedModule = modulesDB.find(
     module =>
       module.name === moduleName
-      || (pkgVersion && module.name === pkgName)
+      || module.name === bareName
+      || module.npm === bareName
       || module.npm === pkgName
+      || module.aliases?.includes(bareName)
       || module.aliases?.includes(pkgName),
   )
 
   if (matchedModule?.npm) {
-    pkgName = matchedModule.npm
+    // The database records the package to install, which may itself be scoped
+    // differently to what the user typed (`maz-ui` -> `@maz-ui/nuxt`).
+    pkgName = basePackageName(matchedModule.npm)
+    subpath = matchedModule.npm.slice(pkgName.length + 1) || undefined
   }
 
   if (matchedModule && matchedModule.compatibility.nuxt) {
@@ -432,12 +465,26 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
 
   const pkg = pkgDetails.versions[version!] || {}
 
+  const entry = resolveModuleEntry(pkg)
+  if (!subpath && entry.subpath) {
+    subpath = entry.subpath
+  }
+
+  if (entry.isLayer) {
+    logger.info(`${colors.cyan(pkgName)} is a Nuxt layer, and will be added to ${colors.cyan('extends')}.`)
+  }
+
   const pkgDependencies = Object.assign(
     pkg.dependencies || {},
     pkg.devDependencies || {},
+    pkg.peerDependencies || {},
   )
+  // A package exposing its module behind a `nuxt`/`module` subpath is a Nuxt
+  // integration regardless of how it declares its dependency on Nuxt.
   if (
-    !pkgDependencies.nuxt
+    !entry.isLayer
+    && !subpath
+    && !pkgDependencies.nuxt
     && !pkgDependencies['nuxt-edge']
     && !pkgDependencies['@nuxt/kit']
   ) {
@@ -456,6 +503,8 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
     pkg: `${pkgName}@${version}`,
     pkgName,
     pkgVersion: version,
+    specifier: subpath ? `${pkgName}/${subpath}` : pkgName,
+    isLayer: entry.isLayer,
     peerDependencies: pkg.peerDependencies,
     optionalPeerDependencies: Object.entries(pkg.peerDependenciesMeta || {})
       .filter(([, meta]) => (meta as { optional?: boolean } | undefined)?.optional)

--- a/packages/nuxt-cli/src/commands/module/remove.ts
+++ b/packages/nuxt-cli/src/commands/module/remove.ts
@@ -65,7 +65,7 @@ export default defineCommand({
     // configured modules. Otherwise resolve aliases/names to canonical npm package names.
     const installedNames = getProjectDependencies(projectPkg)
 
-    const needsDB = modules.some(m => !installedNames.has(m))
+    const needsDB = modules.some(m => !installedNames.has(m) && !installedNames.has(basePackageName(m)))
     const modulesDB: NuxtModule[] = needsDB
       ? await fetchModules().catch((err) => {
           logNetworkError(err, { url: MODULES_API_URL, level: 'warn', prefix: 'Cannot search in the Nuxt Modules database.' })
@@ -95,6 +95,7 @@ export default defineCommand({
 // -- Internal Utils --
 async function removeModules(modules: string[], { skipInstall = false, skipConfig = false, cwd }: { skipInstall?: boolean, skipConfig?: boolean, cwd: string }, projectPkg: PackageJson): Promise<boolean> {
   const removedFromConfig: string[] = []
+  const dependencies = getProjectDependencies(projectPkg)
 
   if (!skipConfig) {
     let configMissing = false
@@ -158,7 +159,7 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
             }
             logger.info(`Removing ${colors.cyan(name)} from the ${colors.cyan(key)}`)
             items.splice(i, 1)
-            removedFromConfig.push(basePackageName(name))
+            removedFromConfig.push(name)
           }
         }
       },
@@ -187,9 +188,12 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
     const installedModules: string[] = []
     const notInstalledModules: string[] = []
 
-    const dependencies = getProjectDependencies(projectPkg)
-
-    const targets = Array.from(new Set([...modules, ...removedFromConfig]))
+    // Entries removed from the config are only uninstalled when they name an
+    // installed package, so a local layer (`./layers/admin`) is left alone.
+    const targets = Array.from(new Set([
+      ...modules,
+      ...removedFromConfig.map(basePackageName).filter(name => dependencies.has(name)),
+    ]))
 
     for (const module of targets) {
       if (dependencies.has(module)) {

--- a/packages/nuxt-cli/src/commands/module/remove.ts
+++ b/packages/nuxt-cli/src/commands/module/remove.ts
@@ -18,7 +18,7 @@ import { logNetworkError } from '../../utils/network'
 import { relativeToProcess } from '../../utils/paths'
 import { cwdArgs, logLevelArgs } from '../_shared'
 import prepareCommand from '../prepare'
-import { ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, isPnpmWorkspace, MODULES_API_URL } from './_utils'
+import { basePackageName, ensureNuxtDependency, fetchModules, forwardCommandArgs, getProjectDependencies, isPnpmWorkspace, MODULES_API_URL } from './_utils'
 
 interface OrphanedPeer {
   peer: string
@@ -76,7 +76,7 @@ export default defineCommand({
     const resolvedModules = modules.map(m => resolveModuleName(m, modulesDB, installedNames))
 
     if (resolvedModules.length > 0) {
-      logger.info(`Resolved ${resolvedModules.map(x => colors.cyan(x)).join(', ')}, removing module${resolvedModules.length > 1 ? 's' : ''}...`)
+      logger.info(`Resolved ${resolvedModules.map(x => colors.cyan(x)).join(', ')}, removing...`)
     }
 
     const proceed = await removeModules(resolvedModules, { ...ctx.args, cwd }, projectPkg)
@@ -108,15 +108,20 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
         return false
       },
       async onUpdate(config) {
-        if (!Array.isArray(config.modules)) {
+        const arrays = ([['modules', config.modules], ['extends', config.extends]] as const)
+          .filter(([, value]) => Array.isArray(value)) as Array<[string, unknown[]]>
+
+        if (arrays.length === 0) {
           return
         }
 
         const present: string[] = []
-        for (const item of config.modules) {
-          const name = readModuleName(item)
-          if (name) {
-            present.push(name)
+        for (const [, items] of arrays) {
+          for (const item of items) {
+            const name = readModuleName(item)
+            if (name) {
+              present.push(name)
+            }
           }
         }
 
@@ -143,12 +148,17 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
           toRemove = new Set(modules)
         }
 
-        for (let i = config.modules.length - 1; i >= 0; i--) {
-          const name = readModuleName(config.modules[i])
-          if (name && toRemove.has(name)) {
-            logger.info(`Removing ${colors.cyan(name)} from the ${colors.cyan('modules')}`)
-            config.modules.splice(i, 1)
-            removedFromConfig.push(name)
+        for (const [key, items] of arrays) {
+          for (let i = items.length - 1; i >= 0; i--) {
+            const name = readModuleName(items[i])
+            // A package may be configured through a subpath (`maz-ui/nuxt`) while the
+            // user asks to remove the package itself.
+            if (!name || !(toRemove.has(name) || toRemove.has(basePackageName(name)))) {
+              continue
+            }
+            logger.info(`Removing ${colors.cyan(name)} from the ${colors.cyan(key)}`)
+            items.splice(i, 1)
+            removedFromConfig.push(basePackageName(name))
           }
         }
       },
@@ -157,7 +167,7 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
         return
       }
       logger.error(`Failed to update ${colors.cyan('nuxt.config')}: ${error.message}`)
-      logger.error(`Please manually remove ${colors.cyan(modules.join(', ') || 'the relevant modules')} from the ${colors.cyan('modules')} array in ${colors.cyan('nuxt.config.ts')}`)
+      logger.error(`Please manually remove ${colors.cyan(modules.join(', ') || 'the relevant modules')} from ${colors.cyan('nuxt.config.ts')}`)
     })
 
     if (cancelled) {
@@ -262,6 +272,11 @@ function readModuleName(item: unknown): string | null {
 function resolveModuleName(input: string, modulesDB: NuxtModule[], installed: Set<string>): string {
   if (installed.has(input)) {
     return input
+  }
+
+  const base = basePackageName(input)
+  if (installed.has(base)) {
+    return base
   }
 
   const matched = modulesDB.find(m =>

--- a/packages/nuxt-cli/test/unit/commands/module/add-config.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/module/add-config.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import commands from '../../../../src/commands/module'
+import * as utils from '../../../../src/commands/module/_utils'
+import * as runCommands from '../../../../src/run-command'
+import * as installUtils from '../../../../src/utils/install'
+import * as versions from '../../../../src/utils/versions'
+
+const { updateConfig } = vi.hoisted(() => ({
+  updateConfig: vi.fn((_options: { onUpdate: (config: { modules?: unknown[], extends?: unknown[] }) => Promise<void> }) => Promise.resolve()),
+}))
+
+let manifest: Record<string, unknown> = {}
+
+vi.mock('c12/update', () => ({ updateConfig }))
+vi.mock('nypm', () => ({
+  detectPackageManager: () => Promise.resolve({ name: 'npm', command: 'npm' }),
+  packageManagers: [{ name: 'npm', command: 'npm' }],
+}))
+vi.mock('pkg-types', () => ({
+  readPackageJSON: () => Promise.resolve({ devDependencies: { nuxt: '3.0.0' } }),
+}))
+vi.mock('ofetch', () => ({
+  $fetch: vi.fn(() => Promise.resolve({
+    'dist-tags': { latest: '1.0.0' },
+    'versions': { '1.0.0': manifest },
+  })),
+}))
+
+interface CommandsType {
+  subCommands: { add: () => Promise<{ setup: (args: any) => void }> }
+}
+
+async function addModule(name: string, pkg: Record<string, unknown>) {
+  manifest = { devDependencies: { nuxt: '3.0.0' }, ...pkg }
+
+  const addCommand = await (commands as CommandsType).subCommands.add()
+  await addCommand.setup({ args: { cwd: '/fake-dir', _: [name] } })
+
+  const config: { modules?: unknown[], extends?: unknown[] } = {}
+  await updateConfig.mock.calls.at(-1)![0]!.onUpdate(config)
+  return config
+}
+
+describe('module add config', () => {
+  vi.spyOn(installUtils, 'runInstall').mockResolvedValue({ success: true, output: '', command: 'npm install', ignoredBuilds: [] })
+  vi.spyOn(runCommands, 'runCommandDef').mockImplementation(vi.fn())
+  vi.spyOn(versions, 'getNuxtVersion').mockResolvedValue('3.0.0')
+  vi.spyOn(utils, 'fetchModules').mockResolvedValue([])
+
+  beforeEach(() => {
+    updateConfig.mockClear()
+  })
+
+  it('should add a module to `modules`', async () => {
+    const config = await addModule('nuxt-shiki', { main: './dist/module.mjs' })
+
+    expect(config).toEqual({ modules: ['nuxt-shiki'] })
+  })
+
+  it('should keep an explicitly requested subpath', async () => {
+    const config = await addModule('maz-ui/nuxt', { exports: { '.': './dist/index.mjs', './nuxt': './dist/nuxt.mjs' } })
+
+    expect(config).toEqual({ modules: ['maz-ui/nuxt'] })
+  })
+
+  it('should resolve a module exposed at a `nuxt` subpath', async () => {
+    const config = await addModule('maz-ui', { exports: { '.': './dist/index.mjs', './nuxt': './dist/nuxt.mjs' } })
+
+    expect(config).toEqual({ modules: ['maz-ui/nuxt'] })
+  })
+
+  it('should add a layer to `extends`', async () => {
+    const config = await addModule('nuxt-seo-kit', { main: 'nuxt.config.ts' })
+
+    expect(config).toEqual({ extends: ['nuxt-seo-kit'] })
+  })
+
+  it('should install the package without its subpath', async () => {
+    manifest = { devDependencies: { nuxt: '3.0.0' }, exports: { '.': './dist/index.mjs', './nuxt': './dist/nuxt.mjs' } }
+
+    const addCommand = await (commands as CommandsType).subCommands.add()
+    await addCommand.setup({ args: { cwd: '/fake-dir', _: ['maz-ui/nuxt'] } })
+
+    expect(installUtils.runInstall).toHaveBeenCalledWith(expect.objectContaining({
+      dependencies: ['maz-ui@1.0.0'],
+    }))
+  })
+})

--- a/packages/nuxt-cli/test/unit/commands/module/add-config.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/module/add-config.spec.ts
@@ -1,3 +1,5 @@
+import type { NuxtModule } from '../../../../src/commands/module/_utils'
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import commands from '../../../../src/commands/module'
@@ -12,7 +14,7 @@ const { updateConfig } = vi.hoisted(() => ({
 
 let manifest: Record<string, unknown> = {}
 
-vi.mock('c12/update', () => ({ updateConfig }))
+vi.mock('../../../../src/utils/config', () => ({ updateConfig }))
 vi.mock('nypm', () => ({
   detectPackageManager: () => Promise.resolve({ name: 'npm', command: 'npm' }),
   packageManagers: [{ name: 'npm', command: 'npm' }],
@@ -26,6 +28,23 @@ vi.mock('ofetch', () => ({
     'versions': { '1.0.0': manifest },
   })),
 }))
+
+function databaseEntry(name: string, npm: string): NuxtModule {
+  return {
+    name,
+    npm,
+    compatibility: { nuxt: '', requires: {}, versionMap: {} },
+    description: '',
+    repo: '',
+    github: '',
+    website: '',
+    learn_more: '',
+    category: '',
+    type: 'community',
+    maintainers: [],
+    stats: { downloads: 0, stars: 0, maintainers: 0, contributors: 0, modules: 0 },
+  }
+}
 
 interface CommandsType {
   subCommands: { add: () => Promise<{ setup: (args: any) => void }> }
@@ -46,7 +65,7 @@ describe('module add config', () => {
   vi.spyOn(installUtils, 'runInstall').mockResolvedValue({ success: true, output: '', command: 'npm install', ignoredBuilds: [] })
   vi.spyOn(runCommands, 'runCommandDef').mockImplementation(vi.fn())
   vi.spyOn(versions, 'getNuxtVersion').mockResolvedValue('3.0.0')
-  vi.spyOn(utils, 'fetchModules').mockResolvedValue([])
+  const fetchModules = vi.spyOn(utils, 'fetchModules').mockResolvedValue([])
 
   beforeEach(() => {
     updateConfig.mockClear()
@@ -62,6 +81,14 @@ describe('module add config', () => {
     const config = await addModule('maz-ui/nuxt', { exports: { '.': './dist/index.mjs', './nuxt': './dist/nuxt.mjs' } })
 
     expect(config).toEqual({ modules: ['maz-ui/nuxt'] })
+  })
+
+  it('should keep an explicitly requested subpath when the database matches the package name', async () => {
+    fetchModules.mockResolvedValueOnce([databaseEntry('sonner', 'vue-sonner')])
+
+    const config = await addModule('vue-sonner/custom', { exports: { '.': './dist/index.mjs', './custom': './dist/custom.mjs' } })
+
+    expect(config).toEqual({ modules: ['vue-sonner/custom'] })
   })
 
   it('should resolve a module exposed at a `nuxt` subpath', async () => {

--- a/packages/nuxt-cli/test/unit/commands/module/add-peers.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/module/add-peers.spec.ts
@@ -5,7 +5,7 @@ import { resolveRequiredPeerDependencies } from '../../../../src/commands/module
 describe('resolveRequiredPeerDependencies', () => {
   it('should include required peers the project does not have', () => {
     const peers = resolveRequiredPeerDependencies([
-      { pkg: '@pinia/nuxt@1.0.1', pkgName: '@pinia/nuxt', pkgVersion: '1.0.1', peerDependencies: { pinia: '^4.0.2' } },
+      { pkg: '@pinia/nuxt@1.0.1', pkgName: '@pinia/nuxt', specifier: '@pinia/nuxt', pkgVersion: '1.0.1', peerDependencies: { pinia: '^4.0.2' } },
     ], new Set(['nuxt', 'vue']))
 
     expect(peers).toEqual(['pinia@^4.0.2'])
@@ -16,11 +16,12 @@ describe('resolveRequiredPeerDependencies', () => {
       {
         pkg: '@nuxt/example@1.0.0',
         pkgName: '@nuxt/example',
+        specifier: '@nuxt/example',
         pkgVersion: '1.0.0',
         peerDependencies: { 'vue': '^3.0.0', 'some-optional': '^1.0.0', '@pinia/nuxt': '^1.0.0' },
         optionalPeerDependencies: ['some-optional'],
       },
-      { pkg: '@pinia/nuxt@1.0.1', pkgName: '@pinia/nuxt', pkgVersion: '1.0.1' },
+      { pkg: '@pinia/nuxt@1.0.1', pkgName: '@pinia/nuxt', specifier: '@pinia/nuxt', pkgVersion: '1.0.1' },
     ], new Set(['nuxt', 'vue']))
 
     expect(peers).toEqual([])
@@ -28,7 +29,7 @@ describe('resolveRequiredPeerDependencies', () => {
 
   it('should fall back to the bare name for ranges that are not valid specs', () => {
     const peers = resolveRequiredPeerDependencies([
-      { pkg: 'mod@1.0.0', pkgName: 'mod', pkgVersion: '1.0.0', peerDependencies: { a: '*', b: '>=3 <5' } },
+      { pkg: 'mod@1.0.0', pkgName: 'mod', specifier: 'mod', pkgVersion: '1.0.0', peerDependencies: { a: '*', b: '>=3 <5' } },
     ], new Set())
 
     expect(peers).toEqual(['a', 'b'])

--- a/packages/nuxt-cli/test/unit/commands/module/remove.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/module/remove.spec.ts
@@ -119,6 +119,25 @@ describe('module remove', () => {
     expect(removeDependency).toHaveBeenCalledWith(['@nuxt/content'], expect.objectContaining({ cwd: '/fake-dir' }))
   })
 
+  it('should remove a layer from `extends` without uninstalling a local path', async () => {
+    const config: { extends: string[] } = { extends: ['./layers/admin', 'nuxt-seo-kit'] }
+    updateConfig.mockImplementationOnce((async (options: any) => {
+      await options.onUpdate(config)
+    }) as typeof updateConfig)
+    multiselect.mockResolvedValueOnce(['./layers/admin'])
+
+    const removeCommand = await (commands as CommandsType).subCommands.remove()
+    await removeCommand.setup({
+      args: {
+        cwd: '/fake-dir',
+        _: [],
+      },
+    })
+
+    expect(config.extends).toEqual(['nuxt-seo-kit'])
+    expect(removeDependency).not.toHaveBeenCalled()
+  })
+
   it('should skip uninstall when --skipInstall is set', async () => {
     const removeCommand = await (commands as CommandsType).subCommands.remove()
     await removeCommand.setup({

--- a/packages/nuxt-cli/test/unit/commands/module/specs.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/module/specs.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { basePackageName, parseModuleSpec, resolveModuleEntry } from '../../../../src/commands/module/_utils'
+import { describeModules } from '../../../../src/commands/module/add'
+
+describe('parseModuleSpec', () => {
+  it('should parse plain and scoped package names', () => {
+    expect(parseModuleSpec('nuxt-shiki')).toEqual({ pkgName: 'nuxt-shiki', pkgVersion: undefined, subpath: undefined })
+    expect(parseModuleSpec('@nuxt/content')).toEqual({ pkgName: '@nuxt/content', pkgVersion: undefined, subpath: undefined })
+  })
+
+  it('should parse versions', () => {
+    expect(parseModuleSpec('@nuxt/content@2.9.0')).toEqual({ pkgName: '@nuxt/content', pkgVersion: '2.9.0', subpath: undefined })
+    expect(parseModuleSpec('content@2')).toEqual({ pkgName: 'content', pkgVersion: '2', subpath: undefined })
+  })
+
+  it('should parse subpaths', () => {
+    expect(parseModuleSpec('maz-ui/nuxt')).toEqual({ pkgName: 'maz-ui', pkgVersion: undefined, subpath: 'nuxt' })
+    expect(parseModuleSpec('@maz-ui/nuxt/module')).toEqual({ pkgName: '@maz-ui/nuxt', pkgVersion: undefined, subpath: 'module' })
+  })
+
+  it('should parse a subpath with a version in either position', () => {
+    expect(parseModuleSpec('maz-ui/nuxt@3.1.0')).toEqual({ pkgName: 'maz-ui', pkgVersion: '3.1.0', subpath: 'nuxt' })
+    expect(parseModuleSpec('maz-ui@3.1.0/nuxt')).toEqual({ pkgName: 'maz-ui', pkgVersion: '3.1.0', subpath: 'nuxt' })
+  })
+
+  it('should reject invalid specs', () => {
+    expect(parseModuleSpec('Not Valid')).toBeUndefined()
+    expect(parseModuleSpec('@scope')).toBeUndefined()
+  })
+})
+
+describe('basePackageName', () => {
+  it('should strip subpaths', () => {
+    expect(basePackageName('maz-ui/nuxt')).toBe('maz-ui')
+    expect(basePackageName('@maz-ui/nuxt')).toBe('@maz-ui/nuxt')
+    expect(basePackageName('@maz-ui/nuxt/module')).toBe('@maz-ui/nuxt')
+  })
+})
+
+describe('resolveModuleEntry', () => {
+  it('should leave regular modules alone', () => {
+    expect(resolveModuleEntry({
+      main: './dist/module.mjs',
+      exports: { '.': { types: './dist/types.d.mts', import: './dist/module.mjs' } },
+    })).toEqual({ isLayer: false })
+  })
+
+  it('should prefer a `nuxt` subpath export, then `module`', () => {
+    expect(resolveModuleEntry({
+      exports: { '.': './dist/index.mjs', './nuxt': './dist/nuxt.mjs', './module': './dist/module.mjs' },
+    })).toEqual({ subpath: 'nuxt', isLayer: false })
+
+    expect(resolveModuleEntry({
+      exports: { '.': './dist/index.mjs', './module': './dist/module.mjs' },
+    })).toEqual({ subpath: 'module', isLayer: false })
+  })
+
+  it('should ignore wildcard exports', () => {
+    expect(resolveModuleEntry({
+      exports: { '.': './dist/index.mjs', './*': './*' },
+    })).toEqual({ isLayer: false })
+  })
+
+  it('should detect layers from their entrypoint', () => {
+    expect(resolveModuleEntry({ main: 'nuxt.config.ts', type: 'module' })).toEqual({ isLayer: true })
+    expect(resolveModuleEntry({ exports: { '.': './nuxt.config.js' } })).toEqual({ isLayer: true })
+  })
+
+  it('should detect layers that only publish a `nuxt.config`', () => {
+    expect(resolveModuleEntry({ files: ['nuxt.config.ts', 'components'] })).toEqual({ isLayer: true })
+    expect(resolveModuleEntry({ files: ['index.js'] })).toEqual({ isLayer: false })
+  })
+})
+
+describe('describeModules', () => {
+  it('should describe modules, layers and a mixture of both', () => {
+    expect(describeModules([{}])).toBe('module')
+    expect(describeModules([{}, {}])).toBe('modules')
+    expect(describeModules([{ isLayer: true }])).toBe('layer')
+    expect(describeModules([{ isLayer: true }, { isLayer: true }])).toBe('layers')
+    expect(describeModules([{}, { isLayer: true }])).toBe('module and layer')
+    expect(describeModules([{}, {}, { isLayer: true }, { isLayer: true }])).toBe('modules and layers')
+  })
+})

--- a/packages/nuxt-cli/test/unit/help.spec.ts
+++ b/packages/nuxt-cli/test/unit/help.spec.ts
@@ -38,7 +38,7 @@ describe('help', () => {
 
       COMMANDS
 
-                 add    Add Nuxt modules                                                
+                 add    Add Nuxt modules and layers                                     
         add-template    Create a new template file.                                     
              analyze    Build Nuxt and analyze production bundle (experimental)         
                build    Build Nuxt for production deployment                            
@@ -61,13 +61,13 @@ describe('help', () => {
 
   it('nuxt add', async () => {
     expect(await usage(commands.add, main)).toMatchInlineSnapshot(`
-      "Add Nuxt modules (nuxt add v0.0.0)
+      "Add Nuxt modules and layers (nuxt add v0.0.0)
 
       USAGE nuxt add [OPTIONS] <MODULENAME>
 
       ARGUMENTS
 
-        MODULENAME    Specify one or more modules to install by name, separated by spaces (Required)
+        MODULENAME    Specify one or more modules or layers to install by name, separated by spaces (Required)
 
       OPTIONS
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/202
resolves https://github.com/nuxt/cli/issues/218

### 📚 Description

this improves `nuxt add` to support adding layers, and also autodetect module subpaths, e.g. `nuxt add vue-sonner` would automatically add `vue-sonner/nuxt` to the `modules[]` array in nuxt.config.