### PR TITLE
fix(analyze): skip prerendering routes when building

### DIFF
--- a/packages/nuxt-cli/src/commands/analyze.ts
+++ b/packages/nuxt-cli/src/commands/analyze.ts
@@ -61,6 +61,11 @@ export default defineCommand({
       negativeDescription: 'Skip serving the analysis results',
       default: true,
     },
+    prerender: {
+      type: 'boolean',
+      description: 'Prerender routes while analyzing',
+      default: false,
+    },
   },
   async run(ctx) {
     overrideEnv('production')
@@ -77,6 +82,7 @@ export default defineCommand({
 
     const nuxt = await loadNuxt({
       cwd,
+      ready: false,
       dotenv: {
         cwd,
         fileName: ctx.args.dotenv,
@@ -99,8 +105,29 @@ export default defineCommand({
           },
         },
         logLevel: ctx.args.logLevel,
+        ...(!ctx.args.prerender && {
+          nitro: {
+            prerender: {
+              routes: [],
+              crawlLinks: false,
+              ignore: [() => true],
+            },
+          },
+        }),
       }),
     })
+
+    let skippedPrerenderRoutes = 0
+    if (!ctx.args.prerender) {
+      nuxt.hook('nitro:init', (nitro) => {
+        nitro.hooks.hook('prerender:routes', (routes) => {
+          skippedPrerenderRoutes = routes.size
+          routes.clear()
+        })
+      })
+    }
+
+    await nuxt.ready()
 
     const analyzeDir = nuxt.options.analyzeDir
     const buildDir = nuxt.options.buildDir
@@ -122,6 +149,10 @@ export default defineCommand({
     tasklog.message('Building Nuxt...')
     await buildNuxt(nuxt)
     tasklog.success('Build complete')
+
+    if (skippedPrerenderRoutes > 0) {
+      logger.info(`Skipped prerendering ${skippedPrerenderRoutes} route${skippedPrerenderRoutes === 1 ? '' : 's'}. Pass ${colors.cyan('--prerender')} to include assets emitted while prerendering.`)
+    }
 
     const endTime = Date.now()
 

--- a/packages/nuxt-cli/test/unit/commands/analyze.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/analyze.spec.ts
@@ -1,0 +1,113 @@
+import type { Nuxt } from '@nuxt/schema'
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { runCommand } from 'citty'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import analyze from '../../../src/commands/analyze'
+import { render, screen } from '../../utils/terminal'
+
+type Hook = (...args: any[]) => unknown
+
+function createHooks() {
+  const hooks = new Map<string, Hook[]>()
+  return {
+    hook: (name: string, fn: Hook) => void hooks.set(name, [...hooks.get(name) || [], fn]),
+    callHook: async (name: string, ...args: unknown[]) => {
+      for (const fn of hooks.get(name) || []) {
+        await fn(...args)
+      }
+    },
+  }
+}
+
+const { loadNuxt, buildNuxt } = vi.hoisted(() => ({
+  loadNuxt: vi.fn(),
+  buildNuxt: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/kit', () => ({
+  loadKit: () => Promise.resolve({ loadNuxt, buildNuxt }),
+}))
+
+let cwd: string
+
+/**
+ * Runs the command against a stub Nuxt, driving the same sequence Nitro does:
+ * route rules and explicit routes are gathered into a set, `prerender:routes`
+ * gets a chance to change it, and `prerender.ignore` filters what is left.
+ */
+async function runAnalyze({ args = [], routes = [] }: { args?: string[], routes?: string[] } = {}) {
+  const nuxtHooks = createHooks()
+  const prerenderRoutes = new Set(routes)
+  let overrides: Record<string, any> = {}
+
+  loadNuxt.mockImplementation((options: { overrides: Record<string, any> }) => {
+    overrides = options.overrides
+    return Promise.resolve({
+      ...nuxtHooks,
+      ready: () => Promise.resolve(),
+      options: {
+        analyzeDir: join(cwd, 'analyze'),
+        buildDir: join(cwd, '.nuxt'),
+        rootDir: cwd,
+        nitro: {},
+        build: {},
+      },
+    } as unknown as Nuxt)
+  })
+
+  buildNuxt.mockImplementation(async () => {
+    await mkdir(join(cwd, 'analyze'), { recursive: true })
+    const nitroHooks = createHooks()
+    await nuxtHooks.callHook('nitro:init', { hooks: nitroHooks })
+    await nitroHooks.callHook('prerender:routes', prerenderRoutes)
+  })
+
+  const renderer = await render(() => runCommand(analyze, { rawArgs: [`--cwd=${cwd}`, '--no-serve', ...args] }))
+
+  const ignore: ((path: string) => unknown)[] = overrides.nitro?.prerender?.ignore || []
+  return {
+    output: screen(renderer),
+    overrides,
+    prerendered: [...prerenderRoutes].filter(route => !ignore.some(matches => matches(route))),
+  }
+}
+
+describe('nuxt analyze command', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    cwd = await mkdtemp(join(tmpdir(), 'nuxt-analyze-'))
+  })
+
+  afterEach(async () => {
+    await rm(cwd, { recursive: true, force: true })
+  })
+
+  it('should not prerender any routes by default', async () => {
+    const { prerendered, overrides } = await runAnalyze({ routes: ['/', '/about'] })
+    expect(prerendered).toEqual([])
+    expect(overrides.nitro.prerender.crawlLinks).toBe(false)
+  })
+
+  it('should report the routes it skipped prerendering', async () => {
+    const { output } = await runAnalyze({ routes: ['/', '/about'] })
+    expect(output).toContain('Skipped prerendering 2 routes')
+    expect(output).toContain('--prerender')
+  })
+
+  it('should say nothing when there was nothing to prerender', async () => {
+    const { output } = await runAnalyze()
+    expect(output).not.toContain('prerender')
+  })
+
+  it('should prerender when the --prerender flag is passed', async () => {
+    const { prerendered, overrides, output } = await runAnalyze({ args: ['--prerender'], routes: ['/', '/about'] })
+    expect(prerendered).toEqual(['/', '/about'])
+    expect(overrides.nitro?.prerender).toBeUndefined()
+    expect(output).not.toContain('Skipped prerendering')
+  })
+})

--- a/packages/nuxt-cli/test/unit/help.spec.ts
+++ b/packages/nuxt-cli/test/unit/help.spec.ts
@@ -119,6 +119,7 @@ describe('help', () => {
                            --name=<name>    Name of the analysis (Default: default)                    
                                  --serve    Serve the analysis results (Default: true)                 
                               --no-serve    Skip serving the analysis results                          
+                             --prerender    Prerender routes while analyzing (Default: false)          
       "
     `)
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/328

### 📚 Description

mostly when running analysis, users do not want their whole site to be prerendered. this can be overridden with `nuxt analyze --prerender`