### PR TITLE
perf(nuxi): do not bundle jiti

### DIFF
--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -32,6 +32,14 @@
     "prepack": "pnpm build",
     "test:dist": "node ./bin/nuxi.mjs info ../../playground && node --experimental-strip-types ../../scripts/check-dist.ts && node --experimental-strip-types ../../scripts/check-youch.ts"
   },
+  "peerDependencies": {
+    "jiti": "^2.7.0"
+  },
+  "peerDependenciesMeta": {
+    "jiti": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^24.13.3",
     "citty": "^0.2.2",

--- a/packages/nuxt-cli/src/utils/nuxt-config.ts
+++ b/packages/nuxt-cli/src/utils/nuxt-config.ts
@@ -8,6 +8,8 @@ import { resolveModulePath } from 'exsolve'
 
 import { join } from 'pathe'
 
+const MODULE_NOT_FOUND_CODES = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND'])
+
 const CONFIG_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs', '.mts', '.cts']
 
 /**
@@ -45,7 +47,7 @@ export async function getNuxtConfig(rootDir: string) {
     }
   }
   catch (error) {
-    consola.warn(`Failed to load \`${configFile}\`: ${(error as Error).message}`)
+    consola.warn(`Failed to load \`${configFile}\`: ${error instanceof Error ? error.message : String(error)}`)
     return {}
   }
   finally {
@@ -82,7 +84,12 @@ async function importWithoutTypelessWarning(href: string): Promise<NuxtConfig> {
  * where Nuxt provides it.
  */
 async function importConfigWithJiti(rootDir: string, cause: unknown) {
-  const { createJiti } = await import('jiti').catch(async () => {
+  const { createJiti } = await import('jiti').catch(async (error) => {
+    // a `jiti` that resolves but fails to evaluate is a real error, not a missing peer
+    const code = (error as NodeJS.ErrnoException).code
+    if (code && !MODULE_NOT_FOUND_CODES.has(code)) {
+      throw error
+    }
     const jitiPath = resolveModulePath('jiti', {
       try: true,
       from: pathToFileURL(join(rootDir, '/')).href,

--- a/packages/nuxt-cli/src/utils/nuxt-config.ts
+++ b/packages/nuxt-cli/src/utils/nuxt-config.ts
@@ -3,7 +3,9 @@ import type { NuxtConfig } from '@nuxt/schema'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 
+import { consola } from 'consola'
 import { resolveModulePath } from 'exsolve'
+
 import { join } from 'pathe'
 
 const CONFIG_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs', '.mts', '.cts']
@@ -39,11 +41,11 @@ export async function getNuxtConfig(rootDir: string) {
       if (!LOADER_REQUIRED_CODES.has((error as NodeJS.ErrnoException).code!)) {
         throw error
       }
-      return await importConfigWithJiti(rootDir)
+      return await importConfigWithJiti(rootDir, error)
     }
   }
-  catch {
-    // TODO: Show error as warning if it is not 404
+  catch (error) {
+    consola.warn(`Failed to load \`${configFile}\`: ${(error as Error).message}`)
     return {}
   }
   finally {
@@ -74,12 +76,22 @@ async function importWithoutTypelessWarning(href: string): Promise<NuxtConfig> {
 }
 
 /**
- * `jiti` is an optional peer dependency, so it is only present when the project
- * (or something in its tree) depends on it. Nuxt does, so this is the normal path
- * for configs that native `import()` cannot handle.
+ * `jiti` is an optional peer dependency, so the plain import is the normal
+ * path when the CLI is installed in a project. When the CLI runs from outside
+ * the project (`npx nuxi`), it is instead resolved from the user's project,
+ * where Nuxt provides it.
  */
-async function importConfigWithJiti(rootDir: string) {
-  const { createJiti } = await import('jiti')
+async function importConfigWithJiti(rootDir: string, cause: unknown) {
+  const { createJiti } = await import('jiti').catch(async () => {
+    const jitiPath = resolveModulePath('jiti', {
+      try: true,
+      from: pathToFileURL(join(rootDir, '/')).href,
+    })
+    if (!jitiPath) {
+      throw new Error(`${(cause as Error)?.message}. Hint: install \`jiti\` for compatibility.`, { cause })
+    }
+    return await import(pathToFileURL(jitiPath).href) as typeof import('jiti')
+  })
   const jiti = createJiti(rootDir, {
     interopDefault: true,
     // allow using `~` and `@` in `nuxt.config`


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this makes `jiti` an optional peer dependency of `nuxi`, so we use it if the project has it installed; otherwise we give a tip to install.

(it's only used in `nuxi info` command)