### PR TITLE
perf: disable mimalloc eager arena commit at cli entry

### DIFF
--- a/packages/nuxi/bin/nuxi.mjs
+++ b/packages/nuxi/bin/nuxi.mjs
@@ -5,6 +5,10 @@ import nodeModule from 'node:module'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
+// rolldown/oxc link mimalloc, whose eager 1GiB arenas inflate RSS on Linux.
+// mimalloc reads this once, when the first addon linking it loads, so keep it above all imports.
+process.env.MIMALLOC_ARENA_EAGER_COMMIT ||= '0'
+
 // https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
 // https://github.com/nodejs/node/pull/54501
 if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {

--- a/packages/nuxt-cli/bin/nuxi.mjs
+++ b/packages/nuxt-cli/bin/nuxi.mjs
@@ -5,6 +5,10 @@ import nodeModule from 'node:module'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
+// rolldown/oxc link mimalloc, whose eager 1GiB arenas inflate RSS on Linux.
+// mimalloc reads this once, when the first addon linking it loads, so keep it above all imports.
+process.env.MIMALLOC_ARENA_EAGER_COMMIT ||= '0'
+
 // https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
 // https://github.com/nodejs/node/pull/54501
 if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

rolldown and oxc link mimalloc, which eagerly commits its 1GiB arenas on Linux. those commits end up backed by transparent huge pages, so a dev server's resident set tracks arena size rather than live bytes

this change should improve memory consumption on nuxt dev/build on linux, and shouldn't affect macOS and Windows.