### PR TITLE
fix(dev): do not restart when a client aborts a connection

### DIFF
--- a/packages/nuxt-cli/src/dev/index.ts
+++ b/packages/nuxt-cli/src/dev/index.ts
@@ -6,7 +6,7 @@ import type { NuxtDevContext, NuxtDevIPCMessage, NuxtParentIPCMessage } from './
 import process from 'node:process'
 import defu from 'defu'
 import { overrideEnv } from '../utils/env.ts'
-import { isAbortedConnection, isBrokenPipe } from '../utils/errors'
+import { isRemotePeerError } from '../utils/errors'
 import { debug } from '../utils/logger'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile.ts'
 import { openInspector } from './inspect'
@@ -25,8 +25,8 @@ function formatErrorMessage(error: unknown): string {
  */
 export function createRejectionHandler(report: (message: string) => void, stop: () => void): (reason: unknown) => void {
   return (reason: unknown) => {
-    if (isAbortedConnection(reason)) {
-      debug('Ignoring aborted connection:', reason)
+    if (isRemotePeerError(reason)) {
+      debug('Ignoring remote peer error:', reason)
       return
     }
     report(formatErrorMessage(reason))
@@ -53,8 +53,6 @@ class IPC {
       process.once('disconnect', () => {
         process.exit(0)
       })
-      // `on` rather than `once`, so that an ignored connection error does not
-      // consume the listener and leave a later genuine rejection unreported.
       process.on('unhandledRejection', createRejectionHandler(
         message => this.send({ type: 'nuxt:internal:dev:rejection', message }),
         () => process.exit(),
@@ -237,12 +235,8 @@ export function createRestartHook(source: RestartSource): (callback: (reason?: D
   }
 
   function restartOnError(error: unknown) {
-    if (isBrokenPipe(error)) {
-      debug('Ignoring broken pipe:', error)
-      return
-    }
-    if (isAbortedConnection(error)) {
-      debug('Ignoring aborted connection:', error)
+    if (isRemotePeerError(error)) {
+      debug('Ignoring remote peer error:', error)
       return
     }
     restart({ type: 'error', message: formatErrorMessage(error) })

--- a/packages/nuxt-cli/src/dev/index.ts
+++ b/packages/nuxt-cli/src/dev/index.ts
@@ -6,7 +6,7 @@ import type { NuxtDevContext, NuxtDevIPCMessage, NuxtParentIPCMessage } from './
 import process from 'node:process'
 import defu from 'defu'
 import { overrideEnv } from '../utils/env.ts'
-import { isBrokenPipe } from '../utils/errors'
+import { isAbortedConnection, isBrokenPipe } from '../utils/errors'
 import { debug } from '../utils/logger'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile.ts'
 import { openInspector } from './inspect'
@@ -37,7 +37,13 @@ class IPC {
       process.once('disconnect', () => {
         process.exit(0)
       })
-      process.once('unhandledRejection', (reason) => {
+      // `on` rather than `once`, so that an ignored connection error does not
+      // consume the listener and leave a later genuine rejection unreported.
+      process.on('unhandledRejection', (reason) => {
+        if (isAbortedConnection(reason)) {
+          debug('Ignoring aborted connection:', reason)
+          return
+        }
         this.send({ type: 'nuxt:internal:dev:rejection', message: formatErrorMessage(reason) })
         process.exit()
       })
@@ -221,6 +227,10 @@ export function createRestartHook(source: RestartSource): (callback: (reason?: D
   function restartOnError(error: unknown) {
     if (isBrokenPipe(error)) {
       debug('Ignoring broken pipe:', error)
+      return
+    }
+    if (isAbortedConnection(error)) {
+      debug('Ignoring aborted connection:', error)
       return
     }
     restart({ type: 'error', message: formatErrorMessage(error) })

--- a/packages/nuxt-cli/src/dev/index.ts
+++ b/packages/nuxt-cli/src/dev/index.ts
@@ -18,6 +18,22 @@ function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.toString() : 'Unhandled Rejection'
 }
 
+/**
+ * Hand an unhandled rejection to the parent process and stop this one, unless
+ * it is only a client that went away — that is traffic, not a crash, and the
+ * session has to survive it.
+ */
+export function createRejectionHandler(report: (message: string) => void, stop: () => void): (reason: unknown) => void {
+  return (reason: unknown) => {
+    if (isAbortedConnection(reason)) {
+      debug('Ignoring aborted connection:', reason)
+      return
+    }
+    report(formatErrorMessage(reason))
+    stop()
+  }
+}
+
 interface InitializeOptions {
   data?: {
     overrides?: NuxtConfig
@@ -39,14 +55,10 @@ class IPC {
       })
       // `on` rather than `once`, so that an ignored connection error does not
       // consume the listener and leave a later genuine rejection unreported.
-      process.on('unhandledRejection', (reason) => {
-        if (isAbortedConnection(reason)) {
-          debug('Ignoring aborted connection:', reason)
-          return
-        }
-        this.send({ type: 'nuxt:internal:dev:rejection', message: formatErrorMessage(reason) })
-        process.exit()
-      })
+      process.on('unhandledRejection', createRejectionHandler(
+        message => this.send({ type: 'nuxt:internal:dev:rejection', message }),
+        () => process.exit(),
+      ))
     }
     process.on('message', async (message: NuxtParentIPCMessage) => {
       if (message.type === 'nuxt:internal:dev:context') {

--- a/packages/nuxt-cli/src/utils/console.ts
+++ b/packages/nuxt-cli/src/utils/console.ts
@@ -4,7 +4,7 @@ import process from 'node:process'
 
 import { consola } from 'consola'
 
-import { isBrokenPipe } from './errors'
+import { isRemotePeerError } from './errors'
 import { debug } from './logger'
 
 // Filter out unwanted logs
@@ -68,8 +68,8 @@ export function restoreRawMode(): void {
 }
 
 function report(label: string, error: unknown) {
-  if (isBrokenPipe(error)) {
-    debug(`${label} ignoring broken pipe:`, error)
+  if (isRemotePeerError(error)) {
+    debug(`${label} ignoring remote peer error:`, error)
     return
   }
   consola.error(label, error)

--- a/packages/nuxt-cli/src/utils/errors.ts
+++ b/packages/nuxt-cli/src/utils/errors.ts
@@ -8,3 +8,15 @@ export function isBrokenPipe(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | undefined)?.code
   return code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED'
 }
+
+/**
+ * A client hanging up mid-request is normal traffic for a dev server: a browser
+ * reloading while a page is still streaming, a proxied websocket dropped when a
+ * worker is replaced, or a tab closed mid-navigation. Like a broken pipe, this
+ * says something about the other end of the connection rather than about this
+ * process, so it must not be treated as a crash or trigger a restart.
+ */
+export function isAbortedConnection(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return code === 'ECONNRESET' || code === 'ECONNABORTED' || code === 'ERR_STREAM_PREMATURE_CLOSE'
+}

--- a/packages/nuxt-cli/src/utils/errors.ts
+++ b/packages/nuxt-cli/src/utils/errors.ts
@@ -1,22 +1,18 @@
-/**
- * A pipe closing early is a property of the other end of the pipe, not a fault
- * in the dev server: a clipboard tool that exited before we wrote to it, or
- * `nuxt dev | head` closing stdout. Such errors should never be reported as
- * crashes or trigger a restart.
- */
-export function isBrokenPipe(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | undefined)?.code
-  return code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED'
-}
+const REMOTE_PEER_ERROR_CODES = new Set([
+  'EPIPE',
+  'ERR_STREAM_DESTROYED',
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ERR_STREAM_PREMATURE_CLOSE',
+])
 
 /**
- * A client hanging up mid-request is normal traffic for a dev server: a browser
- * reloading while a page is still streaming, a proxied websocket dropped when a
- * worker is replaced, or a tab closed mid-navigation. Like a broken pipe, this
- * says something about the other end of the connection rather than about this
- * process, so it must not be treated as a crash or trigger a restart.
+ * Errors that say something about the other end of a connection rather than
+ * about this process: a broken pipe, a client hanging up mid-request, a tab
+ * closed mid-navigation. These should not be reported as crashes or trigger
+ * a restart.
  */
-export function isAbortedConnection(error: unknown): boolean {
+export function isRemotePeerError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | undefined)?.code
-  return code === 'ECONNRESET' || code === 'ECONNABORTED' || code === 'ERR_STREAM_PREMATURE_CLOSE'
+  return !!code && REMOTE_PEER_ERROR_CODES.has(code)
 }

--- a/packages/nuxt-cli/test/unit/errors.spec.ts
+++ b/packages/nuxt-cli/test/unit/errors.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { stripCwd } from '../../src/dev/error'
-import { isBrokenPipe } from '../../src/utils/errors'
+import { isAbortedConnection, isBrokenPipe } from '../../src/utils/errors'
 
 describe('isBrokenPipe', () => {
   it('should detect closed pipes', () => {
@@ -13,6 +13,20 @@ describe('isBrokenPipe', () => {
     expect(isBrokenPipe(new Error('boom'))).toBe(false)
     expect(isBrokenPipe(Object.assign(new Error('nope'), { code: 'ENOENT' }))).toBe(false)
     expect(isBrokenPipe(undefined)).toBe(false)
+  })
+})
+
+describe('isAbortedConnection', () => {
+  it('should detect connections dropped by the other end', () => {
+    expect(isAbortedConnection(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))).toBe(true)
+    expect(isAbortedConnection(Object.assign(new Error('aborted'), { code: 'ECONNABORTED' }))).toBe(true)
+    expect(isAbortedConnection(Object.assign(new Error('premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))).toBe(true)
+  })
+
+  it('should ignore other errors', () => {
+    expect(isAbortedConnection(new Error('boom'))).toBe(false)
+    expect(isAbortedConnection(Object.assign(new Error('nope'), { code: 'EADDRINUSE' }))).toBe(false)
+    expect(isAbortedConnection(undefined)).toBe(false)
   })
 })
 

--- a/packages/nuxt-cli/test/unit/errors.spec.ts
+++ b/packages/nuxt-cli/test/unit/errors.spec.ts
@@ -1,32 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
 import { stripCwd } from '../../src/dev/error'
-import { isAbortedConnection, isBrokenPipe } from '../../src/utils/errors'
+import { isRemotePeerError } from '../../src/utils/errors'
 
-describe('isBrokenPipe', () => {
-  it('should detect closed pipes', () => {
-    expect(isBrokenPipe(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).toBe(true)
-    expect(isBrokenPipe(Object.assign(new Error('destroyed'), { code: 'ERR_STREAM_DESTROYED' }))).toBe(true)
+describe('isRemotePeerError', () => {
+  it('should detect errors from the other end of a connection', () => {
+    expect(isRemotePeerError(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).toBe(true)
+    expect(isRemotePeerError(Object.assign(new Error('destroyed'), { code: 'ERR_STREAM_DESTROYED' }))).toBe(true)
+    expect(isRemotePeerError(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))).toBe(true)
+    expect(isRemotePeerError(Object.assign(new Error('aborted'), { code: 'ECONNABORTED' }))).toBe(true)
+    expect(isRemotePeerError(Object.assign(new Error('premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))).toBe(true)
   })
 
   it('should ignore other errors', () => {
-    expect(isBrokenPipe(new Error('boom'))).toBe(false)
-    expect(isBrokenPipe(Object.assign(new Error('nope'), { code: 'ENOENT' }))).toBe(false)
-    expect(isBrokenPipe(undefined)).toBe(false)
-  })
-})
-
-describe('isAbortedConnection', () => {
-  it('should detect connections dropped by the other end', () => {
-    expect(isAbortedConnection(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))).toBe(true)
-    expect(isAbortedConnection(Object.assign(new Error('aborted'), { code: 'ECONNABORTED' }))).toBe(true)
-    expect(isAbortedConnection(Object.assign(new Error('premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))).toBe(true)
-  })
-
-  it('should ignore other errors', () => {
-    expect(isAbortedConnection(new Error('boom'))).toBe(false)
-    expect(isAbortedConnection(Object.assign(new Error('nope'), { code: 'EADDRINUSE' }))).toBe(false)
-    expect(isAbortedConnection(undefined)).toBe(false)
+    expect(isRemotePeerError(new Error('boom'))).toBe(false)
+    expect(isRemotePeerError(Object.assign(new Error('nope'), { code: 'ENOENT' }))).toBe(false)
+    expect(isRemotePeerError(undefined)).toBe(false)
   })
 })
 

--- a/packages/nuxt-cli/test/unit/restart-hook.spec.ts
+++ b/packages/nuxt-cli/test/unit/restart-hook.spec.ts
@@ -48,7 +48,7 @@ describe('restart hook', () => {
     expect(callback).toHaveBeenCalledExactlyOnceWith({ type: 'shortcut' })
   })
 
-  it('should restart on an error that is not a broken pipe or an aborted connection', () => {
+  it('should restart on an error that is not a remote peer error', () => {
     const source = new EventEmitter()
     const callback = vi.fn()
     arm(source, callback)
@@ -129,11 +129,12 @@ describe('rejection handler', () => {
     expect(report).toHaveBeenCalledExactlyOnceWith('Unhandled Rejection')
   })
 
-  it('should keep the process alive when a client aborted the connection', () => {
+  it('should keep the process alive on remote peer errors', () => {
     const report = vi.fn()
     const stop = vi.fn()
     const handle = createRejectionHandler(report, stop)
 
+    handle(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
     handle(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))
     handle(Object.assign(new Error('premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))
 

--- a/packages/nuxt-cli/test/unit/restart-hook.spec.ts
+++ b/packages/nuxt-cli/test/unit/restart-hook.spec.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createRestartHook } from '../../src/dev'
+import { createRejectionHandler, createRestartHook } from '../../src/dev'
 
 const ERROR_EVENTS = ['uncaughtException', 'unhandledRejection'] as const
 
@@ -107,5 +107,37 @@ describe('restart hook', () => {
     source.emit('restart')
     expect(first).not.toHaveBeenCalled()
     expect(second).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('rejection handler', () => {
+  it('should report the rejection and stop', () => {
+    const report = vi.fn()
+    const stop = vi.fn()
+
+    createRejectionHandler(report, stop)(new Error('boom'))
+
+    expect(report).toHaveBeenCalledExactlyOnceWith(expect.stringContaining('boom'))
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('should describe a rejection that is not an error', () => {
+    const report = vi.fn()
+
+    createRejectionHandler(report, vi.fn())('nope')
+
+    expect(report).toHaveBeenCalledExactlyOnceWith('Unhandled Rejection')
+  })
+
+  it('should keep the process alive when a client aborted the connection', () => {
+    const report = vi.fn()
+    const stop = vi.fn()
+    const handle = createRejectionHandler(report, stop)
+
+    handle(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))
+    handle(Object.assign(new Error('premature close'), { code: 'ERR_STREAM_PREMATURE_CLOSE' }))
+
+    expect(report).not.toHaveBeenCalled()
+    expect(stop).not.toHaveBeenCalled()
   })
 })

--- a/packages/nuxt-cli/test/unit/restart-hook.spec.ts
+++ b/packages/nuxt-cli/test/unit/restart-hook.spec.ts
@@ -48,13 +48,16 @@ describe('restart hook', () => {
     expect(callback).toHaveBeenCalledExactlyOnceWith({ type: 'shortcut' })
   })
 
-  it('should restart on an error that is not a broken pipe', () => {
+  it('should restart on an error that is not a broken pipe or an aborted connection', () => {
     const source = new EventEmitter()
     const callback = vi.fn()
     arm(source, callback)
 
     const [onError] = [...installed]
     onError!(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))
+    expect(callback).not.toHaveBeenCalled()
+
+    onError!(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }))
     expect(callback).not.toHaveBeenCalled()
 
     onError!(new Error('boom'))


### PR DESCRIPTION
### Problem

`nuxt dev` can restart itself in a loop with:

```
 ERROR  [unhandledRejection] read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
    at TCP.callbackTrampoline (node:internal/async_hooks:130:17)

●  Restarting Nuxt due to error: Error: read ECONNRESET
```

A client hanging up mid-request is ordinary dev-server traffic — a browser reloading while a page is still streaming, a tab closed mid-navigation, a stale client from another project reconnecting to a port this server now owns. When such an error surfaces as an unhandled rejection, both places that watch for one treat it as fatal:

- `createRestartHook` schedules a hard restart;
- the forked dev process reports it over IPC and calls `process.exit()`.

With a client that keeps reconnecting, this loops until the dev server is unusable — every reconnect kills the session that was just rebuilt.

### Where the rejection comes from

I traced the origin in a real project by wrapping the candidate call sites and logging which one rejects. It is `NodeDevWorker.handleUpgrade` in nitro, which returns `proxy.ws(...)` without awaiting or catching it:

```js
// nitropack/dist/core/index.mjs
handleUpgrade(req, socket, head) {
  if (!this.ready) { return }
  return this.#proxy.proxy.ws(req, socket, { target: this.#address, xfwd: true }, head)
}
```

When the Nitro dev worker is replaced, every proxied websocket dies and that promise rejects. Adding a `.catch()` there removed the rejections entirely (8 in 30s → 0) and the restarts with them, so the leak itself belongs in nitro and I am happy to open that separately.

This PR is the guard on the other side: whatever leaks it, a connection the peer dropped should not end the dev session.

### Change

`isBrokenPipe` already encodes exactly this rule — *"a property of the other end of the pipe, not a fault in the dev server"*. This adds a sibling predicate for aborted connections (`ECONNRESET`, `ECONNABORTED`, `ERR_STREAM_PREMATURE_CLOSE`) and applies it in both fatal paths.

The IPC handler also moves from `once` to `on`, so an ignored connection error no longer consumes the listener and leaves a later genuine rejection unreported.

Logging is deliberately untouched: the error still reaches the reporter, so the event stays visible in the terminal — it just no longer ends the session.

### Tests

- `errors.spec.ts` — coverage for the new predicate.
- `restart-hook.spec.ts` — an `ECONNRESET` no longer triggers the restart callback, while an unrelated error still does.

`pnpm lint`, `pnpm test:types` and `pnpm test:knip` are clean. `pnpm test:unit` passes except for two pre-existing failures in `test/e2e/commands.spec.ts` (`dev`, `works with dev server`, both expecting 200 and getting 404) — I confirmed those fail identically on an unmodified `main` in my environment, so they are unrelated to this change.
