### PR TITLE
perf: keep youch, the registry and the update check off startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "nf3": "^0.3.23",
     "nuxt": "^4.5.1",
     "pkg-pr-new": "^0.0.80",
+    "rolldown": "^1.2.0",
     "rollup-plugin-visualizer": "^7.0.1",
     "std-env": "^4.2.0",
     "tinyexec": "^1.2.4",

--- a/packages/nuxt-cli/bin/nuxi.mjs
+++ b/packages/nuxt-cli/bin/nuxi.mjs
@@ -2,6 +2,8 @@
 
 import inspector from 'node:inspector'
 import nodeModule from 'node:module'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
@@ -11,16 +13,22 @@ process.env.MIMALLOC_ARENA_EAGER_COMMIT ||= '0'
 
 // https://nodejs.org/api/module.html#moduleenablecompilecachecachedir
 // https://github.com/nodejs/node/pull/54501
+//
+// handle `<tmpdir>/node-compile-cache` if owned by another user
 if (nodeModule.enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
-  try {
-    const { directory } = nodeModule.enableCompileCache()
-    if (directory) {
-      // allow child process to share the same cache directory
-      process.env.NODE_COMPILE_CACHE ||= directory
+  for (const candidate of [undefined, join(homedir(), '.cache', 'nuxt', 'compile-cache')]) {
+    let directory
+    try {
+      ({ directory } = nodeModule.enableCompileCache(candidate))
     }
-  }
-  catch {
-    // Ignore errors
+    catch {
+      continue
+    }
+    if (directory) {
+      // allow child processes to share the same cache directory
+      process.env.NODE_COMPILE_CACHE ||= directory
+      break
+    }
   }
 }
 

--- a/packages/nuxt-cli/src/dev/error-lazy.ts
+++ b/packages/nuxt-cli/src/dev/error-lazy.ts
@@ -1,0 +1,11 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+export async function renderError(req: IncomingMessage, res: ServerResponse, error: unknown): Promise<void> {
+  const { renderError } = await import('./error')
+  return renderError(req, res, error)
+}
+
+export async function renderErrorAnsi(error: unknown): Promise<string> {
+  const { renderErrorAnsi } = await import('./error')
+  return renderErrorAnsi(error)
+}

--- a/packages/nuxt-cli/src/dev/listen.ts
+++ b/packages/nuxt-cli/src/dev/listen.ts
@@ -13,11 +13,9 @@ import { getPort } from 'get-port-please'
 import colors from 'picocolors'
 
 import { debug, logger } from '../utils/logger'
-import { resolveCertificate } from './cert'
 import { detectIsolatedEnvironment, isWsl } from './environment'
 import { resolvePortlessURLs } from './portless'
 import { resolveStackblitzURL } from './stackblitz'
-import { startTunnel } from './tunnel'
 
 export interface ListenOptions {
   port?: string | number
@@ -162,7 +160,11 @@ export async function listen(handler: RequestListener, options: ListenOptions = 
     : await resolvePort(requestedPort, hostname, options.strictPort)
 
   const httpsOptions = options.https === true ? {} : options.https
-  const certificate = httpsOptions ? await resolveCertificate(httpsOptions) : false
+  // `cert` and `tunnel` reach `dev/binaries.ts`, which pulls in `rc9` and the
+  // clack spinner. Neither is wanted unless `--https` or `--tunnel` is passed.
+  const certificate = httpsOptions
+    ? await import('./cert').then(({ resolveCertificate }) => resolveCertificate(httpsOptions))
+    : false
   const server = certificate
     ? createSecureServer(certificate, handler)
     : createHttpServer(handler)
@@ -184,6 +186,7 @@ export async function listen(handler: RequestListener, options: ListenOptions = 
 
   let tunnel: Tunnel | undefined
   if (options.tunnel) {
+    const { startTunnel } = await import('./tunnel')
     tunnel = await startTunnel(`${protocol}://localhost:${address.port}`, !!certificate)
   }
 

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -31,7 +31,7 @@ import { acquireLock, formatLockError, updateLock } from '../utils/lockfile'
 import { debug } from '../utils/logger'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
 import { withNodePath } from '../utils/paths'
-import { renderError, renderErrorAnsi } from './error'
+import { renderError, renderErrorAnsi } from './error-lazy'
 import { listen } from './listen'
 import { resolvePortlessURLs } from './portless'
 import { formatChangedKeys, formatRestartReason, formatSkippedReload, mergeRestartReasons, withConfigKeys } from './reason'
@@ -231,7 +231,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
     this.handler = async (req, res) => {
       if (this.#loadingError) {
-        renderError(req, res, this.#loadingError)
+        void renderError(req, res, this.#loadingError)
         return
       }
       await _initPromise

--- a/packages/nuxt-cli/src/main.ts
+++ b/packages/nuxt-cli/src/main.ts
@@ -20,8 +20,7 @@ import { debug, logger } from './utils/logger'
 import { setupProxySupport } from './utils/network'
 import { resolveProjectDir } from './utils/paths'
 import { templateNames } from './utils/templates/names'
-import { scheduleUpdateNudge } from './utils/update'
-import { scheduleSelfUpdateNudge } from './utils/update-check'
+import { scheduleSelfUpdateNudge, scheduleUpdateNudge } from './utils/update-lazy'
 
 // Node.js only reads `NODE_USE_ENV_PROXY` during bootstrap, so this cannot make
 // the current process proxy-aware; it propagates the setting to child processes

--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -3,7 +3,7 @@ import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import colors from 'picocolors'
 
 import { logger } from './logger'
-import { getPkgJSON, getPkgVersion } from './versions'
+import { getPkgJSON, getPkgVersion } from './pkg'
 
 export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string } {
   switch (builder) {

--- a/packages/nuxt-cli/src/utils/pkg.ts
+++ b/packages/nuxt-cli/src/utils/pkg.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs'
+import { resolveModulePath } from 'exsolve'
+
+import { tryResolveNuxt } from './kit'
+
+export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string[] }) {
+  const pkgJSON = getPkgJSON(cwd, pkg, options)
+  return pkgJSON?.version ?? ''
+}
+
+/**
+ * Resolve a package.json, optionally walking a dependency chain.
+ *
+ * `via` is an array of `[startingPoint, ...intermediates]` describing
+ * the dependency path to walk before resolving `pkg`. For example:
+ *
+ *   // vite is a dep of @nuxt/vite-builder, which is a dep of nuxt
+ *   getPkgJSON(cwd, 'vite', { via: ['nuxt', '@nuxt/vite-builder'] })
+ *
+ *   // webpack is a dep of @nuxt/webpack-builder, which the user installs
+ *   getPkgJSON(cwd, 'webpack', { via: ['@nuxt/webpack-builder'] })
+ *
+ * Each entry is resolved from the location of the previous one,
+ * starting from cwd. Falls back to direct resolution from cwd/nuxt.
+ */
+export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string[] }) {
+  // Build list of locations to try resolving pkg from.
+  // When `via` is provided, walk the chain first; then fall back to cwd/nuxt.
+  const roots: string[] = []
+
+  if (options?.via && options.via.length > 0) {
+    let from: string | undefined = cwd
+    for (const step of options.via) {
+      from = resolveModulePath(step, { from, try: true }) ?? undefined
+      if (!from) {
+        break
+      }
+    }
+    if (from) {
+      roots.push(from)
+    }
+  }
+
+  // Fallback: direct resolution from cwd or nuxt's location
+  roots.push(cwd)
+  const nuxtPath = tryResolveNuxt(cwd)
+  if (nuxtPath) {
+    roots.push(nuxtPath)
+  }
+
+  for (const root of roots) {
+    const p = resolveModulePath(`${pkg}/package.json`, { from: root, try: true })
+    if (p) {
+      return JSON.parse(readFileSync(p, 'utf-8'))
+    }
+  }
+
+  return null
+}

--- a/packages/nuxt-cli/src/utils/update-lazy.ts
+++ b/packages/nuxt-cli/src/utils/update-lazy.ts
@@ -1,0 +1,28 @@
+import type { SelfUpdateNudgeOptions } from './update-check'
+
+/**
+ * The update check pulls in `rc9`, `@clack/prompts`, `verkit` and the registry
+ * client, and then reads `.nuxtrc` and queries the registry. Its only output is
+ * rendered at process exit, so on a long-running command none of that needs to
+ * compete with startup.
+ */
+const STARTUP_GRACE_MS = 3000
+
+export function scheduleUpdateNudge(cwd: string, command?: string): Promise<void> {
+  return afterStartup(() => import('./update').then(({ scheduleUpdateNudge }) => scheduleUpdateNudge(cwd, command)))
+}
+
+/**
+ * Unlike the project check this one runs straight away, because `init` can
+ * finish well inside the grace period and the nudge would be dropped with it.
+ */
+export function scheduleSelfUpdateNudge(name: string, current: string, options: SelfUpdateNudgeOptions): Promise<void> {
+  return import('./update-check').then(({ scheduleSelfUpdateNudge }) => scheduleSelfUpdateNudge(name, current, options))
+}
+
+function afterStartup(run: () => Promise<void>): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    // Unref'd so a pending check never keeps a short command alive.
+    setTimeout(() => void run().then(resolve, reject), STARTUP_GRACE_MS).unref()
+  })
+}

--- a/packages/nuxt-cli/src/utils/versions.ts
+++ b/packages/nuxt-cli/src/utils/versions.ts
@@ -1,12 +1,9 @@
-import { readFileSync } from 'node:fs'
-import { resolveModulePath } from 'exsolve'
 import { readPackageJSON } from 'pkg-types'
 import { joinURL } from 'ufo'
 import { coerce, findMaxSatisfying } from 'verkit'
 
 import { resolveCatalogEntry } from './catalog'
 import { fetchJson } from './fetch'
-import { tryResolveNuxt } from './kit'
 import { debug } from './logger'
 import { readDependencyPackageJson } from './package-json'
 import { detectNpmRegistry } from './registry'
@@ -67,59 +64,4 @@ export async function resolveRegistryVersion(pkg: string, range: string): Promis
     // the registry lists versions in publication order, so a backported patch can
     // appear after a newer major and must not win
     ?? findMaxSatisfying(Object.keys(packument.versions ?? {}), range) ?? undefined
-}
-
-export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string[] }) {
-  const pkgJSON = getPkgJSON(cwd, pkg, options)
-  return pkgJSON?.version ?? ''
-}
-
-/**
- * Resolve a package.json, optionally walking a dependency chain.
- *
- * `via` is an array of `[startingPoint, ...intermediates]` describing
- * the dependency path to walk before resolving `pkg`. For example:
- *
- *   // vite is a dep of @nuxt/vite-builder, which is a dep of nuxt
- *   getPkgJSON(cwd, 'vite', { via: ['nuxt', '@nuxt/vite-builder'] })
- *
- *   // webpack is a dep of @nuxt/webpack-builder, which the user installs
- *   getPkgJSON(cwd, 'webpack', { via: ['@nuxt/webpack-builder'] })
- *
- * Each entry is resolved from the location of the previous one,
- * starting from cwd. Falls back to direct resolution from cwd/nuxt.
- */
-export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string[] }) {
-  // Build list of locations to try resolving pkg from.
-  // When `via` is provided, walk the chain first; then fall back to cwd/nuxt.
-  const roots: string[] = []
-
-  if (options?.via && options.via.length > 0) {
-    let from: string | undefined = cwd
-    for (const step of options.via) {
-      from = resolveModulePath(step, { from, try: true }) ?? undefined
-      if (!from) {
-        break
-      }
-    }
-    if (from) {
-      roots.push(from)
-    }
-  }
-
-  // Fallback: direct resolution from cwd or nuxt's location
-  roots.push(cwd)
-  const nuxtPath = tryResolveNuxt(cwd)
-  if (nuxtPath) {
-    roots.push(nuxtPath)
-  }
-
-  for (const root of roots) {
-    const p = resolveModulePath(`${pkg}/package.json`, { from: root, try: true })
-    if (p) {
-      return JSON.parse(readFileSync(p, 'utf-8'))
-    }
-  }
-
-  return null
 }

--- a/packages/nuxt-cli/test/unit/compile-cache.spec.ts
+++ b/packages/nuxt-cli/test/unit/compile-cache.spec.ts
@@ -20,7 +20,11 @@ function runBin(env: NodeJS.ProcessEnv): Promise<string> {
     child.stderr.setEncoding('utf8')
     child.stderr.on('data', chunk => stderr += chunk)
     child.on('error', reject)
-    child.on('exit', () => {
+    child.on('close', (code, signal) => {
+      if (code !== 0) {
+        reject(new Error(`\`nuxi --version\` exited with ${signal ?? code}: ${stderr}`))
+        return
+      }
       const match = stderr.match(/CACHEDIR=(.*)/)
       resolve(match?.[1]?.trim() ?? 'none')
     })

--- a/packages/nuxt-cli/test/unit/compile-cache.spec.ts
+++ b/packages/nuxt-cli/test/unit/compile-cache.spec.ts
@@ -1,0 +1,63 @@
+import { spawn } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const binPath = fileURLToPath(new URL('../../bin/nuxi.mjs', import.meta.url))
+const probePath = fileURLToPath(new URL('./fixtures/compile-cache-probe.mjs', import.meta.url))
+
+function runBin(env: NodeJS.ProcessEnv): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['--import', probePath, binPath, '--version'], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+    let stderr = ''
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', chunk => stderr += chunk)
+    child.on('error', reject)
+    child.on('exit', () => {
+      const match = stderr.match(/CACHEDIR=(.*)/)
+      resolve(match?.[1]?.trim() ?? 'none')
+    })
+  })
+}
+
+describe.skipIf(process.platform === 'win32')('compile cache', () => {
+  let scratch: string
+  let home: string
+  let blockedTmp: string
+
+  beforeEach(async () => {
+    scratch = await mkdtemp(join(tmpdir(), 'nuxi-compile-cache-'))
+    home = join(scratch, 'home')
+    blockedTmp = join(scratch, 'tmp')
+    await mkdir(home, { recursive: true })
+    await mkdir(blockedTmp, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await chmod(blockedTmp, 0o700).catch(() => {})
+    await rm(scratch, { recursive: true, force: true })
+  })
+
+  it('should use the default cache directory when it is writable', async () => {
+    const directory = await runBin({ TMPDIR: blockedTmp, HOME: home, NODE_COMPILE_CACHE: '' })
+    expect(directory.startsWith(blockedTmp)).toBe(true)
+  })
+
+  it('should fall back to a per-user directory when the shared default is unwritable', async () => {
+    await chmod(blockedTmp, 0o500)
+    const directory = await runBin({ TMPDIR: blockedTmp, HOME: home, NODE_COMPILE_CACHE: '' })
+    expect(directory.startsWith(join(home, '.cache', 'nuxt', 'compile-cache'))).toBe(true)
+  })
+
+  it('should stay disabled when `NODE_DISABLE_COMPILE_CACHE` is set', async () => {
+    const directory = await runBin({ TMPDIR: blockedTmp, HOME: home, NODE_DISABLE_COMPILE_CACHE: '1', NODE_COMPILE_CACHE: '' })
+    expect(directory).toBe('none')
+  })
+})

--- a/packages/nuxt-cli/test/unit/fixtures/compile-cache-probe.mjs
+++ b/packages/nuxt-cli/test/unit/fixtures/compile-cache-probe.mjs
@@ -1,0 +1,6 @@
+import nodeModule from 'node:module'
+import process from 'node:process'
+
+process.on('exit', () => {
+  process._rawDebug(`CACHEDIR=${nodeModule.getCompileCacheDir() ?? 'none'}`)
+})

--- a/packages/nuxt-cli/test/unit/listen-lazy.spec.ts
+++ b/packages/nuxt-cli/test/unit/listen-lazy.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const evaluated = vi.hoisted(() => new Set<string>())
+
+vi.mock('../../src/dev/cert', () => {
+  evaluated.add('cert')
+  return { resolveCertificate: vi.fn(async () => false) }
+})
+
+vi.mock('../../src/dev/tunnel', () => {
+  evaluated.add('tunnel')
+  return { startTunnel: vi.fn(async () => ({ url: 'https://example.test', close: async () => {} })) }
+})
+
+describe('listen module graph', () => {
+  it('should not evaluate the certificate or tunnel modules unless the options ask for them', async () => {
+    const { listen } = await import('../../src/dev/listen')
+    expect([...evaluated]).toEqual([])
+
+    const listener = await listen((_req, res) => res.end('ok'), { port: 0, showURL: false })
+    try {
+      expect([...evaluated]).toEqual([])
+    }
+    finally {
+      await listener.close()
+    }
+  })
+
+  it('should pull in the certificate module when https is requested', async () => {
+    const { listen } = await import('../../src/dev/listen')
+
+    const listener = await listen((_req, res) => res.end('ok'), { port: 0, https: true, showURL: false })
+    try {
+      expect(evaluated.has('cert')).toBe(true)
+      expect(evaluated.has('tunnel')).toBe(false)
+    }
+    finally {
+      await listener.close()
+    }
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/banner.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/banner.spec.ts
@@ -15,7 +15,7 @@ const VERSIONS: Record<string, string> = {
   'vue': '3.5.39',
 }
 
-vi.mock('../../../src/utils/versions', () => ({
+vi.mock('../../../src/utils/pkg', () => ({
   getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string[] }) => {
     if (pkg === 'vite' && options?.via?.includes('@nuxt/vite-builder')) {
       return { name: 'vite', version: '7.3.1' }

--- a/packages/nuxt-cli/test/unit/utils/update-lazy.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/update-lazy.spec.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const scheduleUpdateNudgeImpl = vi.hoisted(() => vi.fn(async () => {}))
+
+vi.mock('../../../src/utils/update', () => ({
+  scheduleUpdateNudge: scheduleUpdateNudgeImpl,
+}))
+
+const { scheduleUpdateNudge } = await import('../../../src/utils/update-lazy')
+
+describe('scheduleUpdateNudge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    scheduleUpdateNudgeImpl.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should not touch the update module until the startup grace period elapses', async () => {
+    const pending = scheduleUpdateNudge('/project', 'dev')
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(scheduleUpdateNudgeImpl).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(3000)
+    await pending
+    expect(scheduleUpdateNudgeImpl).toHaveBeenCalledWith('/project', 'dev')
+  })
+
+  it('should propagate failures from the deferred check', async () => {
+    scheduleUpdateNudgeImpl.mockRejectedValueOnce(new Error('boom'))
+
+    const pending = scheduleUpdateNudge('/project', 'dev')
+    const assertion = expect(pending).rejects.toThrow('boom')
+
+    await vi.advanceTimersByTimeAsync(3000)
+    await assertion
+  })
+})

--- a/packages/nuxt-cli/tsdown.config.ts
+++ b/packages/nuxt-cli/tsdown.config.ts
@@ -4,6 +4,10 @@ import { defineCliConfig, PARSER_PACKAGES, PARSER_SPECIFIERS } from '../../scrip
 export const packaging: PackagingContract = {
   traced: ['youch', 'youch-core'],
   external: PARSER_SPECIFIERS,
+  lazy: {
+    'dist/index.mjs': ['rc9'],
+    'dist/dev/index.mjs': ['youch', 'youch-core', 'source-map-js', 'rc9'],
+  },
 }
 
 export default defineCliConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       pkg-pr-new:
         specifier: ^0.0.80
         version: 0.0.80
+      rolldown:
+        specifier: 1.2.0
+        version: 1.2.0
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.2.0)(rollup@4.62.3)

--- a/scripts/check-dist.ts
+++ b/scripts/check-dist.ts
@@ -1,10 +1,12 @@
 import type { PackagingContract } from './tsdown.ts'
 
+import { readFileSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { dirname, relative, resolve, sep } from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
+import { parseSync } from 'rolldown/utils'
 
 /**
  * Assert the built output of the package in the current directory still matches
@@ -46,6 +48,46 @@ for (const name of packaging.traced ?? []) {
   }
 }
 
+/** Specifiers a module pulls in eagerly, i.e. everything but `import()`. */
+function staticModuleRequests(path: string, source: string): string[] {
+  const { module } = parseSync(path, source)
+  return [
+    ...module.staticImports.map(entry => entry.moduleRequest.value),
+    ...module.staticExports.flatMap(statement => statement.entries.flatMap(entry => entry.moduleRequest ? [entry.moduleRequest.value] : [])),
+  ]
+}
+
+/**
+ * Every chunk reachable from `from` through static imports, mapped to the bare
+ * specifiers it imports statically.
+ */
+function collectStaticImports(from: string, seen = new Map<string, Set<string>>()): Map<string, Set<string>> {
+  if (seen.has(from)) {
+    return seen
+  }
+  const bare = new Set<string>()
+  seen.set(from, bare)
+
+  let source: string
+  try {
+    source = readFileSync(from, 'utf8')
+  }
+  catch {
+    return seen
+  }
+
+  for (const specifier of staticModuleRequests(from, source)) {
+    if (specifier.startsWith('.')) {
+      collectStaticImports(resolve(dirname(from), specifier), seen)
+    }
+    else {
+      bare.add(specifier)
+    }
+  }
+
+  return seen
+}
+
 const chunks = (await readdir(distDir, { recursive: true, withFileTypes: true }))
   .filter(entry => entry.isFile() && entry.name.endsWith('.mjs') && !resolve(entry.parentPath, entry.name).includes(`${sep}node_modules${sep}`))
   .map(entry => resolve(entry.parentPath, entry.name))
@@ -54,6 +96,17 @@ const sources = await Promise.all(chunks.map(path => readFile(path, 'utf8')))
 for (const specifier of packaging.external ?? []) {
   if (!sources.some(source => source.includes(`"${specifier}"`) || source.includes(`'${specifier}'`))) {
     fail(`no chunk imports \`${specifier}\` as an external specifier; it was bundled or dropped`)
+  }
+}
+
+for (const [entryPath, specifiers] of Object.entries(packaging.lazy ?? {})) {
+  const lazyEntry = resolve(packageDir, entryPath)
+  const eager = collectStaticImports(lazyEntry)
+  for (const specifier of specifiers) {
+    const importer = [...eager].find(([, imported]) => imported.has(specifier))
+    if (importer) {
+      fail(`\`${specifier}\` is statically imported by ${relative(distDir, importer[0])}, which is reachable from ${entryPath}; it should only be reached through a dynamic import`)
+    }
   }
 }
 

--- a/scripts/tsdown.ts
+++ b/scripts/tsdown.ts
@@ -26,6 +26,12 @@ export interface PackagingContract {
   traced?: string[]
   /** Specifiers that must survive the build as bare imports. */
   external?: string[]
+  /**
+   * Per emitted entry, the bare specifiers that must not be reachable from it
+   * through static imports alone, i.e. that may only be pulled in by a dynamic
+   * `import()`.
+   */
+  lazy?: Record<string, string[]>
 }
 
 const isAnalysingSize = process.env.BUNDLE_SIZE === 'true'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this defers unneeded code from being parsed when loading the cli initially

| | main | branch | delta |
| - | - | - | - |
| nuxt dev --help | 82.5ms | 47.0ms | -43%  |
| nuxt --help | 99.9ms | 82.6ms | -17%  |
| nuxt --version | 49.2ms | 41.3ms | -16%  |

it's a bit tricky as rolldown can hoist lazy imports so we split out into two levels of dynamic import 🤦 