### PR TITLE
feat(dev): take over a dev server already running on this project 

### DIFF
--- a/packages/nuxt-cli/src/commands/build.ts
+++ b/packages/nuxt-cli/src/commands/build.ts
@@ -11,7 +11,7 @@ import { overrideEnv } from '../utils/env'
 import { formatDuration } from '../utils/formatting'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
-import { acquireLock, formatLockError } from '../utils/lockfile'
+import { acquireLock, acquireOutputLock, formatLockError } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 import { resolveRootDir } from '../utils/paths'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile'
@@ -51,7 +51,7 @@ export default defineCommand({
       await startCpuProfile()
     }
 
-    let releaseLock: (() => void) | undefined
+    const releaseLocks: Array<() => void> = []
     try {
       intro(styleText('cyan', 'Building Nuxt for production...'))
 
@@ -94,10 +94,20 @@ export default defineCommand({
         logger.error(formatLockError(lock.existing))
         throw new Error(`Another Nuxt ${lock.existing.command} is already running (PID ${lock.existing.pid}).`)
       }
-      releaseLock = lock.release
+      releaseLocks.push(lock.release)
 
       const nitro = kit.useNitro()
       logger.info(`Nitro preset: ${styleText('cyan', nitro.options.preset)}`)
+
+      const outputLock = acquireOutputLock(nuxt.options.rootDir, nitro.options.output.dir, {
+        command: 'build',
+        cwd,
+      })
+      if (outputLock.existing) {
+        logger.error(formatLockError(outputLock.existing))
+        throw new Error(`Another Nuxt build is already writing to ${relative(process.cwd(), nitro.options.output.dir)} (PID ${outputLock.existing.pid}).`)
+      }
+      releaseLocks.push(outputLock.release)
 
       await clearBuildDir(nuxt.options.buildDir)
 
@@ -128,7 +138,9 @@ export default defineCommand({
       }
     }
     finally {
-      releaseLock?.()
+      for (const release of releaseLocks) {
+        release()
+      }
       if (profileArg) {
         await stopCpuProfile(cwd, 'build')
       }

--- a/packages/nuxt-cli/src/commands/dev.ts
+++ b/packages/nuxt-cli/src/commands/dev.ts
@@ -8,6 +8,7 @@ import type { NuxtDevContext } from '../dev/utils'
 import process from 'node:process'
 
 import { defineCommand } from 'citty'
+import { resolve } from 'pathe'
 
 import { isBun, isTest } from 'std-env'
 import { satisfies } from 'verkit'
@@ -18,6 +19,7 @@ import { isReusePortSupported } from '../dev/listen'
 import { ForkPool } from '../dev/pool'
 import { formatRestartReason } from '../dev/reason'
 import { setupShortcuts } from '../dev/shortcuts'
+import { formatTakeoverRefusal, takeOverDevServer } from '../dev/takeover'
 import { debug, logger } from '../utils/logger'
 import { resolveRootDir } from '../utils/paths'
 import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
@@ -62,6 +64,11 @@ const command = defineCommand({
       type: 'string',
       description: 'Port to listen on (default: `NUXT_PORT || NITRO_PORT || PORT || nuxtOptions.devServer.port`)',
       alias: ['p'],
+    },
+    'takeover': {
+      type: 'boolean',
+      description: 'Stop a dev server already running on this project and take its place',
+      negativeDescription: 'Never stop a dev server already running on this project',
     },
     'strictPort': {
       type: 'boolean',
@@ -148,6 +155,21 @@ const command = defineCommand({
 
     const listenOverrides = resolveListenOverrides(ctx.args)
 
+    const takeover = await takeOverDevServer(resolveDevBuildDir(cwd), {
+      requestedPort: parseRequestedPort(listenOverrides.port),
+      takeover: ctx.args.takeover,
+    })
+    if (takeover.action === 'refused') {
+      logger.error(formatTakeoverRefusal(takeover.existing, takeover.reason))
+      process.exit(1)
+    }
+    if (takeover.action === 'start-anyway') {
+      process.env.NUXT_IGNORE_LOCK = '1'
+    }
+    if (takeover.action === 'taken') {
+      listenOverrides.port = takeover.port
+    }
+
     // With `SO_REUSEPORT` an incoming fork can bind the port before this process
     // releases it, so a hard restart never leaves the port unserved.
     const reusePort = ctx.args.fork && !ctx.args.profile && await isReusePortSupported()
@@ -161,7 +183,7 @@ const command = defineCommand({
     }
 
     // Start the initial dev server in-process with listener
-    const { listener, close, reload, onRestart, onReady, onFileChange } = await initialize({ cwd, args: ctx.args }, {
+    const { listener, close, reload, onRestart, onReady, onFileChange } = await initialize({ cwd, args: ctx.args, handoverFrom: takeover.action === 'taken' ? takeover.pid : undefined }, {
       data: ctx.data,
       listenOverrides,
       showBanner: true,
@@ -352,6 +374,21 @@ function setupSignalHandlers(close: () => Promise<void>): void {
         })
     })
   }
+}
+
+/**
+ * The lock lives in the build directory, which is only known once `nuxt.config`
+ * has been resolved. Resolving it here would mean loading the config twice, so
+ * a project with a custom `buildDir` gets the plain lock error instead of the
+ * cross-terminal takeover.
+ */
+function resolveDevBuildDir(cwd: string): string {
+  return resolve(cwd, '.nuxt')
+}
+
+function parseRequestedPort(port: string | number | undefined): number | undefined {
+  const parsed = Number(port)
+  return port === undefined || port === '' || !Number.isInteger(parsed) || parsed <= 0 ? undefined : parsed
 }
 
 function resolveForkPoolSize(): number | undefined {

--- a/packages/nuxt-cli/src/commands/prepare.ts
+++ b/packages/nuxt-cli/src/commands/prepare.ts
@@ -5,6 +5,7 @@ import { defineCommand } from 'citty'
 
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
+import { readActiveLock } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 import { relativeToProcess, resolveRootDir } from '../utils/paths'
 import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
@@ -41,7 +42,14 @@ export default defineCommand({
         ...ctx.data?.overrides,
       },
     })
-    await clearBuildDir(nuxt.options.buildDir)
+    const owner = readActiveLock(nuxt.options.buildDir)
+    if (owner) {
+      const label = owner.command === 'dev' ? 'dev server' : 'build'
+      logger.info(`A ${label} (PID ${owner.pid}) is using ${colors.cyan(relativeToProcess(nuxt.options.buildDir))}; refreshing templates in place without clearing it.`)
+    }
+    else {
+      await clearBuildDir(nuxt.options.buildDir)
+    }
 
     await buildNuxt(nuxt)
     await writeTypes(nuxt)

--- a/packages/nuxt-cli/src/commands/prepare.ts
+++ b/packages/nuxt-cli/src/commands/prepare.ts
@@ -45,7 +45,7 @@ export default defineCommand({
     const owner = readActiveLock(nuxt.options.buildDir)
     if (owner) {
       const label = owner.command === 'dev' ? 'dev server' : 'build'
-      logger.info(`A ${label} (PID ${owner.pid}) is using ${colors.cyan(relativeToProcess(nuxt.options.buildDir))}; refreshing templates in place without clearing it.`)
+      logger.info(`A ${label} (PID ${owner.pid}) is using ${styleText('cyan', relativeToProcess(nuxt.options.buildDir))}; refreshing templates in place without clearing it.`)
     }
     else {
       await clearBuildDir(nuxt.options.buildDir)

--- a/packages/nuxt-cli/src/dev/binaries.ts
+++ b/packages/nuxt-cli/src/dev/binaries.ts
@@ -10,7 +10,7 @@ import { confirm, isCancel, progress, spinner } from '@clack/prompts'
 import { basename, dirname, join } from 'pathe'
 import { readUser, updateUser } from 'rc9'
 
-import { restoreRawMode } from '../utils/console'
+import { restoreRawMode, withDirectStdout } from '../utils/console'
 import { debug, logger } from '../utils/logger'
 import { logNetworkError } from '../utils/network'
 
@@ -32,7 +32,13 @@ interface ConsentOptions {
  * `cacheName` overrides the cached filename, so version-pinned tools can key
  * their cache entry by version without affecting the `PATH` lookup.
  */
-export async function resolveTool(name: string, options: { url?: string, archive?: boolean, cacheName?: string, consent: ConsentOptions }): Promise<string | undefined> {
+export function resolveTool(name: string, options: { url?: string, archive?: boolean, cacheName?: string, consent: ConsentOptions }): Promise<string | undefined> {
+  // The consent prompt and the download indicator both redraw by moving the
+  // cursor, so they need stdout back from consola for the duration.
+  return withDirectStdout(() => locateTool(name, options))
+}
+
+async function locateTool(name: string, options: { url?: string, archive?: boolean, cacheName?: string, consent: ConsentOptions }): Promise<string | undefined> {
   const existing = findInPath(name)
   if (existing) {
     return existing

--- a/packages/nuxt-cli/src/dev/shortcuts.ts
+++ b/packages/nuxt-cli/src/dev/shortcuts.ts
@@ -6,7 +6,7 @@ import { createInterface } from 'node:readline'
 import { styleText } from 'node:util'
 import { isCI, isTest } from 'std-env'
 
-import { restoreRawMode } from '../utils/console'
+import { restoreRawMode, withDirectStdout } from '../utils/console'
 import { copyURL, openBrowser, printQRCode } from './listen'
 
 export interface ShortcutContext {
@@ -58,8 +58,8 @@ const shortcuts: Shortcut[] = [
   {
     keys: ['c', 'clear'],
     description: 'clear the console',
-    action: (context) => {
-      process.stdout.write('\u001B[2J\u001B[3J\u001B[H')
+    action: async (context) => {
+      await withDirectStdout(() => process.stdout.write('\u001B[2J\u001B[3J\u001B[H'))
       context.listener.showURLs()
     },
   },

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -72,8 +72,8 @@ export async function takeOverDevServer(buildDir: string, options: TakeoverOptio
   }
 
   // Signalling a `build` is never on the table, and neither is a server on a
-  // port we were not asked for: an explicit `--port` that differs means the user
-  // wants a second server.
+  // port we were not asked for: an explicit `--port` that differs skips the
+  // takeover, and the ordinary lock check decides whether starting is allowed.
   if (existing.command !== 'dev' || !existing.port) {
     return { action: 'none' }
   }

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -1,0 +1,233 @@
+import type { LockInfo } from '../utils/lockfile'
+
+import process from 'node:process'
+
+import { cancel, isCancel, select } from '@clack/prompts'
+import { checkPort } from 'get-port-please'
+import colors from 'picocolors'
+
+import { restoreRawMode } from '../utils/console'
+import { isInteractiveSession, isLockEnabled, markTakenOver, readLock } from '../utils/lockfile'
+import { logger } from '../utils/logger'
+
+/** How long the outgoing dev server has to exit and release its port. */
+const TAKEOVER_TIMEOUT_MS = 5000
+/** How long a `SIGKILL`ed process has to disappear before we give up. */
+const TAKEOVER_KILL_TIMEOUT_MS = 1000
+const TAKEOVER_POLL_INTERVAL_MS = 100
+
+export type TakeoverRefusalReason
+  /** The holder was started in a terminal and we cannot ask this user. */
+  = | 'holder-interactive'
+  /** The user declined at the prompt. */
+    | 'declined'
+  /** `--no-takeover` was passed. */
+    | 'disabled'
+  /** The holder ignored both signals, or something else still has the port. */
+    | 'timeout'
+
+export type TakeoverResult
+  /** Nothing to take over, or nothing we are willing to touch. */
+  = | { action: 'none' }
+  /** A lock was found but its owner is gone; it will be cleaned up on acquire. */
+    | { action: 'stale' }
+  /** The previous server is gone and its port is ours. */
+    | { action: 'taken', port: number, pid: number }
+  /** The caller should print `formatTakeoverRefusal` and exit non-zero. */
+    | { action: 'refused', existing: LockInfo, reason: TakeoverRefusalReason }
+  /** The user chose to run a second server anyway, without the lock. */
+    | { action: 'start-anyway', existing: LockInfo }
+
+export type TakeoverChoice = 'takeover' | 'abort' | 'start-anyway'
+
+export interface TakeoverOptions {
+  /** Port this invocation was explicitly asked to use, if any. */
+  requestedPort?: number
+  /** `--takeover` / `--no-takeover`; either skips the prompt. */
+  takeover?: boolean
+  /** Whether this invocation can prompt. Defaults to the current terminal. */
+  interactive?: boolean
+  /** Overridable so the decision table can be tested without a TTY. */
+  prompt?: (existing: LockInfo, defaultChoice: TakeoverChoice) => Promise<TakeoverChoice>
+  /** How long to wait for the outgoing server, in ms. Overridable for tests. */
+  timeouts?: { graceful?: number, force?: number }
+}
+
+/**
+ * Decide what to do about an existing dev server on this build directory, and
+ * carry out a takeover if that is the answer.
+ *
+ * Must be called before anything binds a port or writes to the build directory,
+ * because a takeover adopts the port the outgoing server was using.
+ */
+export async function takeOverDevServer(buildDir: string, options: TakeoverOptions = {}): Promise<TakeoverResult> {
+  if (!isLockEnabled('dev')) {
+    return { action: 'none' }
+  }
+
+  const existing = readLock(buildDir)
+  if (!existing || existing.pid === process.pid) {
+    return { action: 'none' }
+  }
+
+  // Signalling a `build` is never on the table, and neither is a server on a
+  // port we were not asked for: an explicit `--port` that differs means the user
+  // wants a second server.
+  if (existing.command !== 'dev' || !existing.port) {
+    return { action: 'none' }
+  }
+  if (options.requestedPort !== undefined && options.requestedPort !== existing.port) {
+    return { action: 'none' }
+  }
+
+  if (!isProcessAlive(existing.pid)) {
+    return { action: 'stale' }
+  }
+
+  // An alive PID with a free port means the PID was recycled inside the lock's
+  // trust window and belongs to an unrelated process. Signalling it would kill
+  // a stranger.
+  if (await isPortFree(existing.port, existing.hostname)) {
+    return { action: 'stale' }
+  }
+
+  if (options.takeover === false) {
+    return { action: 'refused', existing, reason: 'disabled' }
+  }
+
+  if (options.takeover !== true) {
+    const interactive = options.interactive ?? isInteractiveSession()
+    // The holder's flag can be stale: a server started in a terminal that has
+    // since closed still claims to be interactive. That is deliberate. Such a
+    // process is usually SIGHUPed (and then fails the checks above), and for a
+    // `nohup`ed survivor refusing to kill it is the right default, with
+    // `--takeover` as the way out.
+    if (!interactive) {
+      if (existing.interactive) {
+        return { action: 'refused', existing, reason: 'holder-interactive' }
+      }
+    }
+    else {
+      const prompt = options.prompt ?? promptForTakeover
+      // Nothing ends an interactive session on a bare enter, so the default
+      // depends on whether a person is watching the other server.
+      const choice = await prompt(existing, existing.interactive ? 'abort' : 'takeover')
+      if (choice === 'abort') {
+        return { action: 'refused', existing, reason: 'declined' }
+      }
+      if (choice === 'start-anyway') {
+        logger.warn(`Starting a second dev server: both will write to ${colors.cyan(buildDir)}, which is unsupported and may corrupt the build.`)
+        return { action: 'start-anyway', existing }
+      }
+    }
+  }
+
+  return performTakeover(buildDir, existing, options.timeouts)
+}
+
+async function performTakeover(buildDir: string, existing: LockInfo, timeouts: TakeoverOptions['timeouts'] = {}): Promise<TakeoverResult> {
+  const port = existing.port!
+  const startedAt = new Date(existing.startedAt).toLocaleTimeString()
+  logger.info(`Taking over the dev server on port ${port} (PID ${existing.pid}, started ${startedAt}).`)
+
+  markTakenOver(buildDir, process.pid)
+
+  const pids = existing.parentPid && existing.parentPid !== existing.pid
+    ? [existing.pid, existing.parentPid]
+    : [existing.pid]
+
+  // On Windows `SIGTERM` is not delivered as a signal and terminates the process
+  // outright, so the graceful window below simply passes quickly there.
+  signalAll(pids, 'SIGTERM')
+  if (await waitForRelease(pids, port, existing.hostname, timeouts.graceful ?? TAKEOVER_TIMEOUT_MS)) {
+    return { action: 'taken', port, pid: existing.pid }
+  }
+
+  signalAll(pids, 'SIGKILL')
+  if (await waitForRelease(pids, port, existing.hostname, timeouts.force ?? TAKEOVER_KILL_TIMEOUT_MS)) {
+    return { action: 'taken', port, pid: existing.pid }
+  }
+
+  return { action: 'refused', existing, reason: 'timeout' }
+}
+
+/** Human-readable explanation for a refusal, including how to override it. */
+export function formatTakeoverRefusal(existing: LockInfo, reason: TakeoverRefusalReason): string {
+  const location = existing.url ? existing.url : 'starting up (no URL yet)'
+  const lines = [
+    '',
+    reason === 'timeout'
+      ? `The dev server on port ${existing.port} did not exit, so this one will not start.`
+      : 'Another Nuxt dev server is already running:',
+    '',
+    `  URL:     ${location}`,
+    `  PID:     ${existing.pid}`,
+    `  Dir:     ${existing.cwd}`,
+    `  Started: ${new Date(existing.startedAt).toLocaleString()}${existing.interactive ? ' (in a terminal)' : ''}`,
+    '',
+  ]
+
+  if (reason === 'holder-interactive') {
+    lines.push('It was started interactively, so it is not stopped automatically.')
+  }
+  if (reason !== 'timeout') {
+    lines.push('Pass `--takeover` to stop it and start this server in its place, or `NUXT_IGNORE_LOCK=1` to run a second server (unsupported).')
+  }
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+async function promptForTakeover(existing: LockInfo, defaultChoice: TakeoverChoice): Promise<TakeoverChoice> {
+  const location = existing.url || 'starting up (no URL yet)'
+  const choice = await select<TakeoverChoice>({
+    message: `A Nuxt dev server is already running here (PID ${existing.pid}, ${location}). What would you like to do?`,
+    initialValue: defaultChoice,
+    options: [
+      { value: 'takeover', label: `Take over port ${existing.port}`, hint: 'stops the running server (--takeover)' },
+      { value: 'abort', label: 'Do not start', hint: '--no-takeover' },
+      { value: 'start-anyway', label: 'Start anyway', hint: 'unsupported: both servers share the build directory' },
+    ],
+  })
+  restoreRawMode()
+  // Ctrl-C must never be the thing that stops the other server.
+  if (isCancel(choice)) {
+    cancel('Not starting a second dev server.')
+    return 'abort'
+  }
+  return choice
+}
+
+function signalAll(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal)
+    }
+    catch {}
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  }
+  catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+async function isPortFree(port: number, hostname?: string): Promise<boolean> {
+  return await checkPort(port, hostname || 'localhost') !== false
+}
+
+async function waitForRelease(pids: number[], port: number, hostname: string | undefined, timeout: number): Promise<boolean> {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    if (!pids.some(isProcessAlive) && await isPortFree(port, hostname)) {
+      return true
+    }
+    await new Promise(resolve => setTimeout(resolve, TAKEOVER_POLL_INTERVAL_MS))
+  }
+  return false
+}

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -2,9 +2,9 @@ import type { LockInfo } from '../utils/lockfile'
 
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, isCancel, select, spinner } from '@clack/prompts'
 import { checkPort } from 'get-port-please'
-import colors from 'picocolors'
 import { isCI } from 'std-env'
 
 import { restoreRawMode } from '../utils/console'
@@ -125,7 +125,7 @@ export async function takeOverDevServer(buildDir: string, options: TakeoverOptio
         return { action: 'refused', existing, reason: 'declined' }
       }
       if (choice === 'start-anyway') {
-        logger.warn(`Starting a second dev server: both will write to ${colors.cyan(buildDir)}, which is unsupported and may corrupt the build.`)
+        logger.warn(`Starting a second dev server: both will write to ${styleText('cyan', buildDir)}, which is unsupported and may corrupt the build.`)
         return { action: 'start-anyway', existing }
       }
     }
@@ -230,9 +230,9 @@ function describeLocation(existing: LockInfo): string {
 }
 
 async function promptForTakeover(existing: LockInfo, defaultChoice: TakeoverChoice): Promise<TakeoverChoice> {
-  const location = describeLocation(existing)
+  logger.info(`A Nuxt dev server is already running here (PID ${existing.pid}, ${describeLocation(existing)}).`)
   const choice = await select<TakeoverChoice>({
-    message: `A Nuxt dev server is already running here (PID ${existing.pid}, ${location}). What would you like to do?`,
+    message: 'What would you like to do?',
     initialValue: defaultChoice,
     options: [
       { value: 'takeover', label: `Take over port ${existing.port}`, hint: 'stops the running server (--takeover)' },

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -61,7 +61,7 @@ export interface TakeoverOptions {
  * because a takeover adopts the port the outgoing server was using.
  */
 export async function takeOverDevServer(buildDir: string, options: TakeoverOptions = {}): Promise<TakeoverResult> {
-  if (!isLockEnabled('dev')) {
+  if (!isLockEnabled()) {
     return { action: 'none' }
   }
 

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -8,7 +8,7 @@ import colors from 'picocolors'
 import { isCI } from 'std-env'
 
 import { restoreRawMode } from '../utils/console'
-import { clearTakeover, isInteractiveSession, isLockEnabled, markTakenOver, readLock } from '../utils/lockfile'
+import { clearTakeover, isInteractiveSession, isLockEnabled, isProcessAlive, markTakenOver, readLock } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 
 /** How long the outgoing dev server has to exit and release its port. */
@@ -195,7 +195,7 @@ function startProgress(message: string): TakeoverProgress {
 
 /** Human-readable explanation for a refusal, including how to override it. */
 export function formatTakeoverRefusal(existing: LockInfo, reason: TakeoverRefusalReason): string {
-  const location = existing.url ? existing.url : 'starting up (no URL yet)'
+  const location = describeLocation(existing)
   const lines = [
     '',
     reason === 'timeout'
@@ -220,8 +220,12 @@ export function formatTakeoverRefusal(existing: LockInfo, reason: TakeoverRefusa
   return lines.join('\n')
 }
 
+function describeLocation(existing: LockInfo): string {
+  return existing.url || 'starting up (no URL yet)'
+}
+
 async function promptForTakeover(existing: LockInfo, defaultChoice: TakeoverChoice): Promise<TakeoverChoice> {
-  const location = existing.url || 'starting up (no URL yet)'
+  const location = describeLocation(existing)
   const choice = await select<TakeoverChoice>({
     message: `A Nuxt dev server is already running here (PID ${existing.pid}, ${location}). What would you like to do?`,
     initialValue: defaultChoice,
@@ -246,16 +250,6 @@ function signalAll(pids: number[], signal: NodeJS.Signals): void {
       process.kill(pid, signal)
     }
     catch {}
-  }
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0)
-    return true
-  }
-  catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM'
   }
 }
 

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -82,6 +82,9 @@ export async function takeOverDevServer(buildDir: string, options: TakeoverOptio
   }
 
   if (!isProcessAlive(existing.pid)) {
+    if (!await isPortFree(existing.port, existing.hostname)) {
+      logger.warn(`The dev server that was using port ${existing.port} is gone, but something is still listening there.`)
+    }
     return { action: 'stale' }
   }
 

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -7,7 +7,7 @@ import { cancel, isCancel, select, spinner } from '@clack/prompts'
 import { checkPort } from 'get-port-please'
 import { isCI } from 'std-env'
 
-import { restoreRawMode } from '../utils/console'
+import { restoreRawMode, withDirectStdout } from '../utils/console'
 import { clearStaleLock, clearTakeover, isInteractiveSession, isLockEnabled, isProcessAlive, markTakenOver, readLock } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 
@@ -61,7 +61,13 @@ export interface TakeoverOptions {
  * Must be called before anything binds a port or writes to the build directory,
  * because a takeover adopts the port the outgoing server was using.
  */
-export async function takeOverDevServer(buildDir: string, options: TakeoverOptions = {}): Promise<TakeoverResult> {
+export function takeOverDevServer(buildDir: string, options: TakeoverOptions = {}): Promise<TakeoverResult> {
+  // The prompt and the spinner below both redraw by moving the cursor, so they
+  // need stdout back from consola for the duration.
+  return withDirectStdout(() => resolveTakeover(buildDir, options))
+}
+
+async function resolveTakeover(buildDir: string, options: TakeoverOptions): Promise<TakeoverResult> {
   if (!isLockEnabled()) {
     return { action: 'none' }
   }

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -8,7 +8,7 @@ import colors from 'picocolors'
 import { isCI } from 'std-env'
 
 import { restoreRawMode } from '../utils/console'
-import { clearTakeover, isInteractiveSession, isLockEnabled, isProcessAlive, markTakenOver, readLock } from '../utils/lockfile'
+import { clearStaleLock, clearTakeover, isInteractiveSession, isLockEnabled, isProcessAlive, markTakenOver, readLock } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 
 /** How long the outgoing dev server has to exit and release its port. */
@@ -30,7 +30,7 @@ export type TakeoverRefusalReason
 export type TakeoverResult
   /** Nothing to take over, or nothing we are willing to touch. */
   = | { action: 'none' }
-  /** A lock was found but its owner is gone; it will be cleaned up on acquire. */
+  /** A lock was found but its owner is gone, so it has been removed. */
     | { action: 'stale' }
   /** The previous server is gone and its port is ours. */
     | { action: 'taken', port: number, pid: number }
@@ -71,28 +71,33 @@ export async function takeOverDevServer(buildDir: string, options: TakeoverOptio
     return { action: 'none' }
   }
 
-  // Signalling a `build` is never on the table, and neither is a server on a
-  // port we were not asked for: an explicit `--port` that differs skips the
-  // takeover, and the ordinary lock check decides whether starting is allowed.
+  // Signalling a `build` is never on the table, and a dev server that has not
+  // bound a port yet cannot be identified well enough to touch.
   if (existing.command !== 'dev' || !existing.port) {
     return { action: 'none' }
   }
-  if (options.requestedPort !== undefined && options.requestedPort !== existing.port) {
-    return { action: 'none' }
-  }
 
-  if (!isProcessAlive(existing.pid)) {
-    if (!await isPortFree(existing.port, existing.hostname)) {
+  const alive = isProcessAlive(existing.pid)
+  const portFree = await isPortFree(existing.port, existing.hostname)
+
+  // Either signal alone means the recorded server is gone: an exited process
+  // cannot come back, and a free port means the PID was recycled inside the
+  // lock's trust window, so it now belongs to a stranger we must not signal.
+  // The lock is dropped here because `acquireLock` only judges liveness by PID
+  // and would otherwise refuse to start on behalf of a server that is not there.
+  if (!alive || portFree) {
+    if (!alive && !portFree) {
       logger.warn(`The dev server that was using port ${existing.port} is gone, but something is still listening there.`)
     }
+    clearStaleLock(buildDir, existing)
     return { action: 'stale' }
   }
 
-  // An alive PID with a free port means the PID was recycled inside the lock's
-  // trust window and belongs to an unrelated process. Signalling it would kill
-  // a stranger.
-  if (await isPortFree(existing.port, existing.hostname)) {
-    return { action: 'stale' }
+  // A live server on a port we were not asked for is left alone: an explicit
+  // `--port` that differs skips the takeover, and the ordinary lock check
+  // decides whether starting is allowed.
+  if (options.requestedPort !== undefined && options.requestedPort !== existing.port) {
+    return { action: 'none' }
   }
 
   if (options.takeover === false) {

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -8,7 +8,7 @@ import colors from 'picocolors'
 import { isCI } from 'std-env'
 
 import { restoreRawMode } from '../utils/console'
-import { isInteractiveSession, isLockEnabled, markTakenOver, readLock } from '../utils/lockfile'
+import { clearTakeover, isInteractiveSession, isLockEnabled, markTakenOver, readLock } from '../utils/lockfile'
 import { logger } from '../utils/logger'
 
 /** How long the outgoing dev server has to exit and release its port. */
@@ -153,6 +153,7 @@ async function performTakeover(buildDir: string, existing: LockInfo, timeouts: T
   }
 
   progress.fail(`Could not stop the dev server on port ${port}`)
+  clearTakeover(buildDir, process.pid)
   return { action: 'refused', existing, reason: 'timeout' }
 }
 

--- a/packages/nuxt-cli/src/dev/takeover.ts
+++ b/packages/nuxt-cli/src/dev/takeover.ts
@@ -2,9 +2,10 @@ import type { LockInfo } from '../utils/lockfile'
 
 import process from 'node:process'
 
-import { cancel, isCancel, select } from '@clack/prompts'
+import { cancel, isCancel, select, spinner } from '@clack/prompts'
 import { checkPort } from 'get-port-please'
 import colors from 'picocolors'
+import { isCI } from 'std-env'
 
 import { restoreRawMode } from '../utils/console'
 import { isInteractiveSession, isLockEnabled, markTakenOver, readLock } from '../utils/lockfile'
@@ -128,7 +129,7 @@ export async function takeOverDevServer(buildDir: string, options: TakeoverOptio
 async function performTakeover(buildDir: string, existing: LockInfo, timeouts: TakeoverOptions['timeouts'] = {}): Promise<TakeoverResult> {
   const port = existing.port!
   const startedAt = new Date(existing.startedAt).toLocaleTimeString()
-  logger.info(`Taking over the dev server on port ${port} (PID ${existing.pid}, started ${startedAt}).`)
+  const progress = startProgress(`Taking over the dev server on port ${port} (PID ${existing.pid}, started ${startedAt})`)
 
   markTakenOver(buildDir, process.pid)
 
@@ -140,15 +141,52 @@ async function performTakeover(buildDir: string, existing: LockInfo, timeouts: T
   // outright, so the graceful window below simply passes quickly there.
   signalAll(pids, 'SIGTERM')
   if (await waitForRelease(pids, port, existing.hostname, timeouts.graceful ?? TAKEOVER_TIMEOUT_MS)) {
+    progress.stop(`Stopped the dev server on port ${port} (PID ${existing.pid})`)
     return { action: 'taken', port, pid: existing.pid }
   }
 
+  progress.update(`Waiting for the dev server on port ${port} to exit`)
   signalAll(pids, 'SIGKILL')
   if (await waitForRelease(pids, port, existing.hostname, timeouts.force ?? TAKEOVER_KILL_TIMEOUT_MS)) {
+    progress.stop(`Stopped the dev server on port ${port} (PID ${existing.pid})`)
     return { action: 'taken', port, pid: existing.pid }
   }
 
+  progress.fail(`Could not stop the dev server on port ${port}`)
   return { action: 'refused', existing, reason: 'timeout' }
+}
+
+interface TakeoverProgress {
+  update: (message: string) => void
+  stop: (message: string) => void
+  fail: (message: string) => void
+}
+
+/**
+ * Stopping the outgoing server can take several seconds, so a terminal gets a
+ * spinner. Anywhere else (CI, an agent, a piped log) the frames are noise, so
+ * the same information is logged as plain lines.
+ */
+function startProgress(message: string): TakeoverProgress {
+  if (!process.stdout.isTTY || isCI) {
+    logger.info(`${message}.`)
+    return {
+      update: text => logger.info(`${text}.`),
+      stop: text => logger.info(`${text}.`),
+      fail: text => logger.error(`${text}.`),
+    }
+  }
+  const indicator = spinner()
+  indicator.start(message)
+  const finish = (report: (text: string) => void) => (text: string) => {
+    report(text)
+    restoreRawMode()
+  }
+  return {
+    update: text => indicator.message(text),
+    stop: finish(text => indicator.stop(text)),
+    fail: finish(text => indicator.error(text)),
+  }
 }
 
 /** Human-readable explanation for a refusal, including how to override it. */

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -27,8 +27,8 @@ import { joinURL } from 'ufo'
 import { showBanner } from '../utils/banner'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
-import { acquireLock, formatLockError, updateLock } from '../utils/lockfile'
-import { debug } from '../utils/logger'
+import { acquireLock, formatLockError, getTakeoverPid, updateLock } from '../utils/lockfile'
+import { debug, logger } from '../utils/logger'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
 import { withNodePath } from '../utils/paths'
 import { renderError, renderErrorAnsi } from './error-lazy'
@@ -77,6 +77,15 @@ interface NuxtDevServerOptions {
   showBanner?: boolean
   listenOverrides?: DevListenOverrides
   handoverFrom?: number
+}
+
+/**
+ * PID of the process supervising this one, when this is a dev fork. Recorded in
+ * the lock so a takeover stops the supervisor too, rather than leaving it
+ * running with nothing to serve.
+ */
+function devForkParentPid(): number | undefined {
+  return process.env.__NUXT__FORK && process.send ? process.ppid : undefined
 }
 
 // https://regex101.com/r/7HkR5c/1
@@ -661,6 +670,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     updateLock(currentBuildDir, {
       command: 'dev',
       cwd: this.options.cwd,
+      parentPid: devForkParentPid(),
       port: addr.port,
       hostname: addr.address,
       url: serverUrl,
@@ -677,6 +687,10 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
   /** Release the lock file. Call only on final shutdown, not during reloads. */
   releaseLock(): void {
+    const takenOverBy = this.#lockedBuildDir && getTakeoverPid(this.#lockedBuildDir)
+    if (takenOverBy) {
+      logger.info(`Handed over to another \`nuxt dev\` (PID ${takenOverBy}).`)
+    }
     this.#lockCleanup?.()
     this.#lockCleanup = undefined
     this.#lockedBuildDir = undefined
@@ -686,6 +700,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     const lock = acquireLock(buildDir, {
       command: 'dev',
       cwd: this.options.cwd,
+      parentPid: devForkParentPid(),
     }, {
       // During a handover the outgoing dev server still holds the lock until
       // this process is ready to serve.

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -28,7 +28,7 @@ import { showBanner } from '../utils/banner'
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
 import { acquireLock, formatLockError, getTakeoverPid, updateLock } from '../utils/lockfile'
-import { debug, logger } from '../utils/logger'
+import { debug, writeNotice } from '../utils/logger'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
 import { withNodePath } from '../utils/paths'
 import { renderError, renderErrorAnsi } from './error-lazy'
@@ -694,7 +694,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   releaseLock(): void {
     const takenOverBy = this.#lockedBuildDir && getTakeoverPid(this.#lockedBuildDir)
     if (takenOverBy) {
-      logger.info(`Handed over to another \`nuxt dev\` (PID ${takenOverBy}).`)
+      writeNotice(`Handed over to another \`nuxt dev\` (PID ${takenOverBy}).`)
     }
     this.#lockCleanup?.()
     this.#lockCleanup = undefined

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -85,7 +85,12 @@ interface NuxtDevServerOptions {
  * running with nothing to serve.
  */
 function devForkParentPid(): number | undefined {
-  return process.env.__NUXT__FORK && process.send ? process.ppid : undefined
+  if (!process.env.__NUXT__FORK || !process.send) {
+    return undefined
+  }
+  // A supervisor that already exited leaves us reparented to init, which must
+  // never be signalled.
+  return process.ppid > 1 ? process.ppid : undefined
 }
 
 // https://regex101.com/r/7HkR5c/1

--- a/packages/nuxt-cli/src/utils/console.ts
+++ b/packages/nuxt-cli/src/utils/console.ts
@@ -6,6 +6,7 @@ import { consola } from 'consola'
 
 import { isRemotePeerError } from './errors'
 import { debug } from './logger'
+import { trackOutputSpacing } from './stdout'
 
 // Filter out unwanted logs
 // TODO: Use better API from consola for intercepting logs
@@ -34,6 +35,7 @@ export function setupGlobalConsole(opts: { dev?: boolean } = {}) {
 
   // Wrap all console logs with consola for better DX
   if (opts.dev) {
+    trackOutputSpacing()
     consola.wrapAll()
   }
   else {
@@ -64,6 +66,31 @@ export function restoreRawMode(): void {
   }
   if (process.stdin.isRaw) {
     process.stdin.setRawMode(false)
+  }
+}
+
+/**
+ * Run `fn` with `process.stdout` and `process.stderr` writing straight to the
+ * terminal again.
+ *
+ * `consola.wrapAll()` swaps `stream.write` for a call that trims each chunk and
+ * logs it as a line of its own. That is fine for stray `console.log`s, but it
+ * breaks anything that positions the cursor itself: clack redraws a frame with
+ * several small writes (a cursor move, an erase, the new lines) and every one of
+ * them would come back with a newline attached, so each keypress pushes the
+ * prompt further down the screen.
+ */
+export async function withDirectStdout<T>(fn: () => T | Promise<T>): Promise<T> {
+  const wrapped = process.stdout as typeof process.stdout & { __write?: typeof process.stdout.write }
+  if (!wrapped.__write || wrapped.write === wrapped.__write) {
+    return fn()
+  }
+  consola.restoreStd()
+  try {
+    return await fn()
+  }
+  finally {
+    consola.wrapStd()
   }
 }
 

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -65,6 +65,25 @@ export function readActiveLock(buildDir: string): LockInfo | undefined {
 }
 
 /**
+ * Remove a lock whose holder has gone away, so the next `acquireLock` is not
+ * refused on behalf of a process that cannot come back. Liveness is the
+ * caller's judgement: a dead PID is not the only way for a holder to be gone,
+ * and the port a dev server recorded is the more reliable signal.
+ *
+ * The lock is re-read and matched on identity, so one that has been replaced
+ * since the caller inspected it is left alone.
+ */
+export function clearStaleLock(buildDir: string, info: LockInfo): boolean {
+  const lockPath = join(buildDir, LOCK_FILENAME)
+  const current = readLockFile(lockPath)
+  if (!current || current.pid !== info.pid || current.startedAt !== info.startedAt) {
+    return false
+  }
+  tryUnlink(lockPath)
+  return true
+}
+
+/**
  * Record that `byPid` is taking the lock over, so the outgoing holder can
  * explain its own shutdown. Only ever annotates a lock owned by another
  * process, and never creates one.

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -72,17 +72,19 @@ function isLockActive(info: LockInfo): boolean {
 }
 
 /**
- * Locking is enabled for agents by default. `NUXT_LOCK=1` forces it on for
- * non-agents; `NUXT_IGNORE_LOCK=1` forces it off.
+ * Locking is always enabled for `dev`, because two dev servers sharing one
+ * build directory corrupt each other's output. `build` locking stays limited to
+ * agents. `NUXT_LOCK=1` forces it on, `NUXT_IGNORE_LOCK=1` and `NUXT_LOCK=0`
+ * force it off.
  */
-export function isLockEnabled(): boolean {
-  if (process.env.NUXT_IGNORE_LOCK) {
+export function isLockEnabled(command: LockInfo['command'] = 'dev'): boolean {
+  if (process.env.NUXT_IGNORE_LOCK || process.env.NUXT_LOCK === '0' || process.env.NUXT_LOCK === 'false') {
     return false
   }
   if (process.env.NUXT_LOCK === '1' || process.env.NUXT_LOCK === 'true') {
     return true
   }
-  return isAgent
+  return command === 'dev' || isAgent
 }
 
 type LockResult
@@ -104,7 +106,7 @@ export function acquireLock(
   info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
   options: AcquireLockOptions = {},
 ): LockResult {
-  if (!isLockEnabled()) {
+  if (!isLockEnabled(info.command)) {
     return { release: () => {} }
   }
 
@@ -160,7 +162,7 @@ export function updateLock(
   buildDir: string,
   info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
 ): void {
-  if (!isLockEnabled()) {
+  if (!isLockEnabled(info.command)) {
     return
   }
   const lockPath = join(buildDir, LOCK_FILENAME)

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -54,6 +54,12 @@ export function readLock(buildDir: string): LockInfo | undefined {
   return readLockFile(join(buildDir, LOCK_FILENAME))
 }
 
+/** The lock on `buildDir` when another process is currently holding it. */
+export function readActiveLock(buildDir: string): LockInfo | undefined {
+  const info = readLock(buildDir)
+  return info && isLockActive(info) ? info : undefined
+}
+
 /**
  * Record that `byPid` is taking the lock over, so the outgoing holder can
  * explain its own shutdown. Only ever annotates a lock owned by another

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -74,10 +74,28 @@ export function markTakenOver(buildDir: string, byPid: number): void {
   writeLockFile(lockPath, { ...current, takenOverBy: byPid })
 }
 
+/**
+ * Drop a takeover claim this process wrote, once it has given up on it. Another
+ * process's claim is left alone.
+ */
+export function clearTakeover(buildDir: string, byPid: number): void {
+  const lockPath = join(buildDir, LOCK_FILENAME)
+  const current = readLockFile(lockPath)
+  if (!current || current.takenOverBy !== byPid) {
+    return
+  }
+  const { takenOverBy: _claim, ...rest } = current
+  writeLockFile(lockPath, rest)
+}
+
 /** PID that claimed our own lock, if this process is being taken over. */
 export function getTakeoverPid(buildDir: string): number | undefined {
   const current = readLock(buildDir)
-  return current?.pid === process.pid ? current.takenOverBy : undefined
+  if (current?.pid !== process.pid || !current.takenOverBy) {
+    return undefined
+  }
+  // A claimer that gave up and exited never took anything over.
+  return isProcessAlive(current.takenOverBy) ? current.takenOverBy : undefined
 }
 
 function readLockFile(lockPath: string): LockInfo | undefined {

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
 import { join } from 'pathe'
-import { isAgent, isCI } from 'std-env'
+import { isCI } from 'std-env'
 
 export interface LockInfo {
   pid: number
@@ -107,19 +107,12 @@ function isLockActive(info: LockInfo): boolean {
 }
 
 /**
- * Locking is always enabled for `dev`, because two dev servers sharing one
- * build directory corrupt each other's output. `build` locking stays limited to
- * agents. `NUXT_LOCK=1` forces it on, `NUXT_IGNORE_LOCK=1` and `NUXT_LOCK=0`
- * force it off.
+ * Locking is always enabled: `dev` and `build` share one build directory, and
+ * two processes writing it corrupt each other's output. `NUXT_IGNORE_LOCK=1`
+ * and `NUXT_LOCK=0` opt out.
  */
-export function isLockEnabled(command: LockInfo['command'] = 'dev'): boolean {
-  if (process.env.NUXT_IGNORE_LOCK || process.env.NUXT_LOCK === '0' || process.env.NUXT_LOCK === 'false') {
-    return false
-  }
-  if (process.env.NUXT_LOCK === '1' || process.env.NUXT_LOCK === 'true') {
-    return true
-  }
-  return command === 'dev' || isAgent
+export function isLockEnabled(): boolean {
+  return !process.env.NUXT_IGNORE_LOCK && process.env.NUXT_LOCK !== '0' && process.env.NUXT_LOCK !== 'false'
 }
 
 type LockResult
@@ -141,7 +134,7 @@ export function acquireLock(
   info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
   options: AcquireLockOptions = {},
 ): LockResult {
-  if (!isLockEnabled(info.command)) {
+  if (!isLockEnabled()) {
     return { release: () => {} }
   }
 
@@ -197,7 +190,7 @@ export function updateLock(
   buildDir: string,
   info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
 ): void {
-  if (!isLockEnabled(info.command)) {
+  if (!isLockEnabled()) {
     return
   }
   const lockPath = join(buildDir, LOCK_FILENAME)

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -154,7 +154,14 @@ function isLockActive(info: LockInfo): boolean {
  * and `NUXT_LOCK=0` opt out.
  */
 export function isLockEnabled(): boolean {
-  return !process.env.NUXT_IGNORE_LOCK && process.env.NUXT_LOCK !== '0' && process.env.NUXT_LOCK !== 'false'
+  if (isEnvFlagSet(process.env.NUXT_IGNORE_LOCK)) {
+    return false
+  }
+  return process.env.NUXT_LOCK !== '0' && process.env.NUXT_LOCK !== 'false'
+}
+
+function isEnvFlagSet(value: string | undefined): boolean {
+  return !!value && value !== '0' && value !== 'false'
 }
 
 type LockResult

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
 import { join } from 'pathe'
@@ -65,10 +65,7 @@ export function markTakenOver(buildDir: string, byPid: number): void {
   if (!current || current.pid === byPid) {
     return
   }
-  try {
-    writeFileSync(lockPath, JSON.stringify({ ...current, takenOverBy: byPid }, null, 2))
-  }
-  catch {}
+  writeLockFile(lockPath, { ...current, takenOverBy: byPid })
 }
 
 /** PID that claimed our own lock, if this process is being taken over. */
@@ -83,6 +80,23 @@ function readLockFile(lockPath: string): LockInfo | undefined {
   }
   catch {
     return undefined
+  }
+}
+
+/**
+ * Replace a lock we own. Writing a sibling temp file and renaming it into place
+ * keeps the window where a reader could see a truncated file from existing: a
+ * partial read looks like a corrupted lock, which another process would treat as
+ * stale and claim.
+ */
+function writeLockFile(lockPath: string, info: LockInfo): void {
+  const tmpPath = `${lockPath}.${process.pid}.tmp`
+  try {
+    writeFileSync(tmpPath, JSON.stringify(info, null, 2))
+    renameSync(tmpPath, lockPath)
+  }
+  catch {
+    tryUnlink(tmpPath)
   }
 }
 
@@ -206,10 +220,7 @@ export function updateLock(
     takenOverBy: current?.takenOverBy,
     ...info,
   }
-  try {
-    writeFileSync(lockPath, JSON.stringify(next, null, 2))
-  }
-  catch {}
+  writeLockFile(lockPath, next)
 }
 
 function makeRelease(lockPath: string): () => void {

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -41,7 +41,7 @@ export function isInteractiveSession(): boolean {
   return !!process.stdin.isTTY && !isCI
 }
 
-function isProcessAlive(pid: number): boolean {
+export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0)
     return true
@@ -222,6 +222,11 @@ function acquireLockAt(
   }
   catch {}
 
+  const blockingLock = (): LockInfo | undefined => {
+    const existing = readLockFile(lockPath)
+    return existing && existing.pid !== options.takeoverFrom && isLockActive(existing) ? existing : undefined
+  }
+
   // Try exclusive-create up to twice: the first attempt may race with a stale
   // lock that we then clean up and retry.
   for (let attempt = 0; attempt < 2; attempt++) {
@@ -233,8 +238,8 @@ function acquireLockAt(
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
         throw err
       }
-      const existing = readLockFile(lockPath)
-      if (existing && existing.pid !== options.takeoverFrom && isLockActive(existing)) {
+      const existing = blockingLock()
+      if (existing) {
         return { existing }
       }
       // Stale, corrupted, self-owned, or handed over; remove and retry.
@@ -242,12 +247,8 @@ function acquireLockAt(
     }
   }
 
-  // Two failures in a row; surface whatever we can read.
-  const existing = readLockFile(lockPath)
-  if (existing && existing.pid !== options.takeoverFrom && isLockActive(existing)) {
-    return { existing }
-  }
-  return { release: () => {} }
+  const existing = blockingLock()
+  return existing ? { existing } : { release: () => {} }
 }
 
 /**
@@ -296,8 +297,7 @@ function makeRelease(lockPath: string): () => void {
   // `exit` fires on normal termination, including after Node's default signal
   // handling (SIGINT → exit 130) when no custom signal handler runs. We
   // deliberately do not install SIGINT/SIGTERM listeners: that would suppress
-  // Node's default signal behavior and other shutdown logic, which was the
-  // cause of the earlier review concern.
+  // Node's default signal behavior and other shutdown logic.
   process.on('exit', release)
 
   return release

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -4,7 +4,7 @@ import process from 'node:process'
 import { join } from 'pathe'
 import { isAgent, isCI } from 'std-env'
 
-interface LockInfo {
+export interface LockInfo {
   pid: number
   startedAt: number
   command: 'dev' | 'build'
@@ -18,6 +18,13 @@ interface LockInfo {
   port?: number
   hostname?: string
   url?: string
+  /**
+   * PID of the process supervising the holder, when the holder is a dev fork.
+   * Signalling the holder alone would leave its supervisor running.
+   */
+  parentPid?: number
+  /** PID of the process that claimed this lock, written before it signals us. */
+  takenOverBy?: number
 }
 
 const LOCK_FILENAME = 'nuxt.lock'
@@ -40,6 +47,34 @@ function isProcessAlive(pid: number): boolean {
     // Treat it as alive so we don't clobber locks held by other accounts.
     return (err as NodeJS.ErrnoException).code === 'EPERM'
   }
+}
+
+/** Read the lock held for `buildDir`, if there is one. */
+export function readLock(buildDir: string): LockInfo | undefined {
+  return readLockFile(join(buildDir, LOCK_FILENAME))
+}
+
+/**
+ * Record that `byPid` is taking the lock over, so the outgoing holder can
+ * explain its own shutdown. Only ever annotates a lock owned by another
+ * process, and never creates one.
+ */
+export function markTakenOver(buildDir: string, byPid: number): void {
+  const lockPath = join(buildDir, LOCK_FILENAME)
+  const current = readLockFile(lockPath)
+  if (!current || current.pid === byPid) {
+    return
+  }
+  try {
+    writeFileSync(lockPath, JSON.stringify({ ...current, takenOverBy: byPid }, null, 2))
+  }
+  catch {}
+}
+
+/** PID that claimed our own lock, if this process is being taken over. */
+export function getTakeoverPid(buildDir: string): number | undefined {
+  const current = readLock(buildDir)
+  return current?.pid === process.pid ? current.takenOverBy : undefined
 }
 
 function readLockFile(lockPath: string): LockInfo | undefined {
@@ -175,6 +210,7 @@ export function updateLock(
     pid: process.pid,
     startedAt: current?.startedAt ?? Date.now(),
     interactive: isInteractiveSession(),
+    takenOverBy: current?.takenOverBy,
     ...info,
   }
   try {

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -2,13 +2,19 @@ import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
 import { join } from 'pathe'
-import { isAgent } from 'std-env'
+import { isAgent, isCI } from 'std-env'
 
 interface LockInfo {
   pid: number
   startedAt: number
   command: 'dev' | 'build'
   cwd: string
+  /**
+   * Whether the holder was started from a terminal a user is sitting at. Only
+   * the holder can know this, so it is recorded here for other invocations to
+   * read.
+   */
+  interactive: boolean
   port?: number
   hostname?: string
   url?: string
@@ -18,6 +24,11 @@ const LOCK_FILENAME = 'nuxt.lock'
 // PID recycling safety net. Locks older than this cannot be trusted because a
 // recycled PID could match a dead build's record.
 const MAX_LOCK_AGE_MS = 24 * 60 * 60 * 1000
+
+/** Whether this process is attached to a terminal a user can answer prompts on. */
+export function isInteractiveSession(): boolean {
+  return !!process.stdin.isTTY && !isCI
+}
 
 function isProcessAlive(pid: number): boolean {
   try {
@@ -90,7 +101,7 @@ export interface AcquireLockOptions {
  */
 export function acquireLock(
   buildDir: string,
-  info: Omit<LockInfo, 'pid' | 'startedAt'>,
+  info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
   options: AcquireLockOptions = {},
 ): LockResult {
   if (!isLockEnabled()) {
@@ -101,6 +112,7 @@ export function acquireLock(
   const fullInfo: LockInfo = {
     pid: process.pid,
     startedAt: Date.now(),
+    interactive: isInteractiveSession(),
     ...info,
   }
 
@@ -146,7 +158,7 @@ export function acquireLock(
  */
 export function updateLock(
   buildDir: string,
-  info: Omit<LockInfo, 'pid' | 'startedAt'>,
+  info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
 ): void {
   if (!isLockEnabled()) {
     return
@@ -160,6 +172,7 @@ export function updateLock(
   const next: LockInfo = {
     pid: process.pid,
     startedAt: current?.startedAt ?? Date.now(),
+    interactive: isInteractiveSession(),
     ...info,
   }
   try {

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
@@ -28,6 +29,9 @@ export interface LockInfo {
 }
 
 const LOCK_FILENAME = 'nuxt.lock'
+// Somewhere durable to key build-output locks from: outside every directory a
+// build clears, and already a Nuxt-owned cache location.
+const OUTPUT_LOCK_DIRNAME = 'node_modules/.cache/nuxt'
 // PID recycling safety net. Locks older than this cannot be trusted because a
 // recycled PID could match a dead build's record.
 const MAX_LOCK_AGE_MS = 24 * 60 * 60 * 1000
@@ -172,11 +176,38 @@ export function acquireLock(
   info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
   options: AcquireLockOptions = {},
 ): LockResult {
+  return acquireLockAt(join(buildDir, LOCK_FILENAME), buildDir, info, options)
+}
+
+/**
+ * Claim the build output directory for the duration of a build.
+ *
+ * Two builds of one project can resolve different build directories, because
+ * `loadNuxtConfig` moves a production build out of `.nuxt` when that already
+ * exists, yet they still write the same output. The marker is keyed by output
+ * path so unrelated outputs stay independent, and is kept outside the directory
+ * it guards because the build empties that.
+ */
+export function acquireOutputLock(
+  rootDir: string,
+  outputDir: string,
+  info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
+): LockResult {
+  const dir = join(rootDir, OUTPUT_LOCK_DIRNAME)
+  const key = createHash('sha256').update(outputDir).digest('hex').slice(0, 8)
+  return acquireLockAt(join(dir, `output-${key}.lock`), dir, info)
+}
+
+function acquireLockAt(
+  lockPath: string,
+  dir: string,
+  info: Omit<LockInfo, 'pid' | 'startedAt' | 'interactive'>,
+  options: AcquireLockOptions = {},
+): LockResult {
   if (!isLockEnabled()) {
     return { release: () => {} }
   }
 
-  const lockPath = join(buildDir, LOCK_FILENAME)
   const fullInfo: LockInfo = {
     pid: process.pid,
     startedAt: Date.now(),
@@ -184,10 +215,10 @@ export function acquireLock(
     ...info,
   }
 
-  // The build dir may not exist yet (e.g. `rimraf .nuxt && nuxt dev`); the
-  // lock is acquired before `clearBuildDir` runs, so create it lazily.
+  // The directory may not exist yet (e.g. `rimraf .nuxt && nuxt dev`); the lock
+  // is acquired before `clearBuildDir` runs, so create it lazily.
   try {
-    mkdirSync(buildDir, { recursive: true })
+    mkdirSync(dir, { recursive: true })
   }
   catch {}
 

--- a/packages/nuxt-cli/src/utils/lockfile.ts
+++ b/packages/nuxt-cli/src/utils/lockfile.ts
@@ -95,7 +95,7 @@ export function clearTakeover(buildDir: string, byPid: number): void {
 /** PID that claimed our own lock, if this process is being taken over. */
 export function getTakeoverPid(buildDir: string): number | undefined {
   const current = readLock(buildDir)
-  if (current?.pid !== process.pid || !current.takenOverBy) {
+  if (!current || current.pid !== process.pid || !current.takenOverBy) {
     return undefined
   }
   // A claimer that gave up and exited never took anything over.

--- a/packages/nuxt-cli/src/utils/logger.ts
+++ b/packages/nuxt-cli/src/utils/logger.ts
@@ -1,5 +1,27 @@
-import { log } from '@clack/prompts'
+import process from 'node:process'
+
+import { styleText } from 'node:util'
+import { log, S_INFO } from '@clack/prompts'
 import { createDebug } from 'obug'
+
+import { blankLineBefore } from './stdout'
 
 export const logger = log
 export const debug = createDebug('nuxi')
+
+/**
+ * Write a standalone info line, optionally followed by an indented instruction
+ * on a line of its own so the user can select whatever they need to type.
+ *
+ * Unlike {@link logger}`.info` this leaves no connecting `│` and aligns the text
+ * two columns in, which is what the standalone notices at the end of a command
+ * share.
+ *
+ * Commands leave the cursor in different places (`init` ends on the blank line
+ * after clack's outro, `dev` and `build` on the line after their last log), so
+ * the leading gap is measured rather than assumed.
+ */
+export function writeNotice(headline: string, instruction?: string): void {
+  const body = instruction ? `${headline}\n  ${instruction}\n` : `${headline}\n`
+  process.stdout.write(`${blankLineBefore()}${styleText('blue', S_INFO)} ${body}`)
+}

--- a/packages/nuxt-cli/src/utils/logger.ts
+++ b/packages/nuxt-cli/src/utils/logger.ts
@@ -1,10 +1,8 @@
-import process from 'node:process'
-
 import { styleText } from 'node:util'
 import { log, S_INFO } from '@clack/prompts'
 import { createDebug } from 'obug'
 
-import { blankLineBefore } from './stdout'
+import { blankLineBefore, writeDirect } from './stdout'
 
 export const logger = log
 export const debug = createDebug('nuxi')
@@ -23,5 +21,5 @@ export const debug = createDebug('nuxi')
  */
 export function writeNotice(headline: string, instruction?: string): void {
   const body = instruction ? `${headline}\n  ${instruction}\n` : `${headline}\n`
-  process.stdout.write(`${blankLineBefore()}${styleText('blue', S_INFO)} ${body}`)
+  writeDirect(`${blankLineBefore()}${styleText('blue', S_INFO)} ${body}`)
 }

--- a/packages/nuxt-cli/src/utils/stdout.ts
+++ b/packages/nuxt-cli/src/utils/stdout.ts
@@ -58,3 +58,13 @@ export function trackOutputSpacing(): void {
     return (write as (...args: unknown[]) => boolean)(chunk, encoding, callback)
   }) as typeof process.stdout.write
 }
+
+/**
+ * Write to stdout bypassing consola's line wrapping, for output that carries its
+ * own newlines (see {@link withDirectStdout}). Consola would trim the chunk,
+ * dropping any deliberate leading or trailing blank line.
+ */
+export function writeDirect(chunk: string): void {
+  const stdout = process.stdout as typeof process.stdout & { __write?: typeof process.stdout.write }
+  ;(stdout.__write || stdout.write).call(process.stdout, chunk)
+}

--- a/packages/nuxt-cli/src/utils/update-check.ts
+++ b/packages/nuxt-cli/src/utils/update-check.ts
@@ -1,16 +1,16 @@
 import process from 'node:process'
 
 import { styleText } from 'node:util'
-import { S_INFO } from '@clack/prompts'
+
 import { readUser, updateUser } from 'rc9'
 import { isCI, isTest, provider } from 'std-env'
 import { joinURL } from 'ufo'
 import { isGreater, tryParse } from 'verkit'
 
 import { fetchJson } from './fetch'
-import { debug } from './logger'
+import { debug, writeNotice } from './logger'
 import { detectNpmRegistry } from './registry'
-import { blankLineBefore, trackOutputSpacing } from './stdout'
+import { trackOutputSpacing } from './stdout'
 
 const RC_FILE = '.nuxtrc'
 const CACHE_KEY = 'updateCheck'
@@ -146,25 +146,13 @@ export interface UpdateNudgeOptions {
   command?: string
 }
 
-/**
- * Both nudges are written as a labelled line plus an indented instruction, so
- * whatever the user needs to type is on a line of its own that they can select.
- *
- * Commands leave the cursor in different places (`init` ends on the blank line
- * after clack's outro, `dev` and `build` on the line after their last log), so
- * the leading gap is measured rather than assumed.
- */
-function writeNudge(headline: string, instruction: string): void {
-  process.stdout.write(`${blankLineBefore()}${styleText('blue', S_INFO)} ${headline}\n  ${instruction}\n`)
-}
-
 function describeUpdate({ current, latest }: NuxtUpdate, name: string): string {
   return `a new version of ${name} is available: ${styleText('green', latest)} ${styleText('gray', `(you are on ${current})`)}`
 }
 
 export function renderUpdateNudge(update: NuxtUpdate, options: UpdateNudgeOptions = {}): void {
   const { name = 'Nuxt', command = 'nuxt upgrade' } = options
-  writeNudge(describeUpdate(update, name), `run ${styleText('cyan', command)} to update`)
+  writeNotice(describeUpdate(update, name), `run ${styleText('cyan', command)} to update`)
 }
 
 /**
@@ -173,7 +161,7 @@ export function renderUpdateNudge(update: NuxtUpdate, options: UpdateNudgeOption
  */
 export function renderSelfUpdateNudge(update: NuxtUpdate, options: UpdateNudgeOptions = {}): void {
   const { name = 'the Nuxt CLI', command = 'nuxt upgrade' } = options
-  writeNudge(describeUpdate(update, name), `next time, run ${styleText('cyan', command)} to use the latest version`)
+  writeNotice(describeUpdate(update, name), `next time, run ${styleText('cyan', command)} to use the latest version`)
 }
 
 export interface SelfUpdateNudgeOptions extends UpdateNudgeOptions {

--- a/packages/nuxt-cli/test/unit/commands/prepare.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/prepare.spec.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+import { runCommand } from 'citty'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import prepare from '../../../src/commands/prepare'
+
+const { loadNuxt, buildNuxt, writeTypes, clearBuildDir } = vi.hoisted(() => ({
+  loadNuxt: vi.fn(),
+  buildNuxt: vi.fn(),
+  writeTypes: vi.fn(),
+  clearBuildDir: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/kit', () => ({
+  loadKit: () => Promise.resolve({ loadNuxt, buildNuxt, writeTypes }),
+}))
+
+vi.mock('../../../src/utils/fs', () => ({ clearBuildDir }))
+
+let cwd: string
+let buildDir: string
+
+async function writeLock(info: Record<string, unknown>) {
+  await writeFile(join(buildDir, 'nuxt.lock'), JSON.stringify({
+    pid: 424242,
+    startedAt: Date.now(),
+    command: 'dev',
+    cwd,
+    interactive: false,
+    ...info,
+  }))
+}
+
+describe('prepare', () => {
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'nuxt-prepare-test-'))
+    buildDir = await mkdtemp(join(tmpdir(), 'nuxt-prepare-build-'))
+    loadNuxt.mockResolvedValue({ options: { buildDir } })
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    await Promise.all([rm(cwd, { recursive: true, force: true }), rm(buildDir, { recursive: true, force: true })])
+  })
+
+  it('clears the build directory when nothing owns it', async () => {
+    await runCommand(prepare, { rawArgs: [`--cwd=${cwd}`] })
+    expect(clearBuildDir).toHaveBeenCalledWith(buildDir)
+    expect(buildNuxt).toHaveBeenCalled()
+  })
+
+  it('clears the build directory when the lock is stale', async () => {
+    await writeLock({ pid: 999999999 })
+    await runCommand(prepare, { rawArgs: [`--cwd=${cwd}`] })
+    expect(clearBuildDir).toHaveBeenCalled()
+  })
+
+  it('refreshes in place while a dev server is using the build directory', async () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => true as unknown as true)
+    await writeLock({ command: 'dev' })
+    await runCommand(prepare, { rawArgs: [`--cwd=${cwd}`] })
+    expect(clearBuildDir).not.toHaveBeenCalled()
+    expect(buildNuxt).toHaveBeenCalled()
+    expect(writeTypes).toHaveBeenCalled()
+  })
+
+  it('refreshes in place while a build is using the build directory', async () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => true as unknown as true)
+    await writeLock({ command: 'build' })
+    await runCommand(prepare, { rawArgs: [`--cwd=${cwd}`] })
+    expect(clearBuildDir).not.toHaveBeenCalled()
+  })
+})

--- a/packages/nuxt-cli/test/unit/help.spec.ts
+++ b/packages/nuxt-cli/test/unit/help.spec.ts
@@ -203,6 +203,8 @@ describe('help', () => {
                                         -f, --fork    Enable forked mode (Default: false)                                                                                                                 
                                  --no-f, --no-fork    Disable forked mode                                                                                                                                 
                                  -p, --port=<port>    Port to listen on (default: \`NUXT_PORT || NITRO_PORT || PORT || nuxtOptions.devServer.port\`)                                                        
+                                        --takeover    Stop a dev server already running on this project and take its place                                                                                
+                                     --no-takeover    Never stop a dev server already running on this project                                                                                             
                                       --strictPort    Exit if the requested port is unavailable instead of using another one (Default: false)                                                             
                                  -h, --host=<host>    Host to listen on (default: \`NUXT_HOST || NITRO_HOST || HOST || nuxtOptions.devServer?.host\`)                                                       
                                         -o, --open    Open the URL in the browser (Default: false)                                                                                                        

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -12,7 +12,7 @@ vi.mock('std-env', async (importOriginal) => {
   return { ...original, isCI: false }
 })
 
-const { acquireLock, formatLockError, isLockEnabled, updateLock } = await import('../../src/utils/lockfile')
+const { acquireLock, formatLockError, isLockEnabled, readActiveLock, updateLock } = await import('../../src/utils/lockfile')
 
 describe('lockfile', () => {
   let tempDir: string
@@ -321,6 +321,50 @@ describe('lockfile', () => {
       updateLock(tempDir, { command: 'dev', cwd: '/project', port: 3000 })
       expect(readdirSync(tempDir)).toEqual(['nuxt.lock'])
       lock.release!()
+    })
+  })
+
+  describe('readActiveLock', () => {
+    it('returns the lock when another live process holds it', () => {
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true as unknown as true)
+      try {
+        writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+          pid: 424242,
+          command: 'dev',
+          cwd: '/other',
+          startedAt: Date.now(),
+          interactive: false,
+        }))
+
+        expect(readActiveLock(tempDir)?.pid).toBe(424242)
+      }
+      finally {
+        killSpy.mockRestore()
+      }
+    })
+
+    it('ignores a dead holder and our own lock', () => {
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: 999999999,
+        command: 'dev',
+        cwd: '/other',
+        startedAt: Date.now(),
+        interactive: false,
+      }))
+      expect(readActiveLock(tempDir)).toBeUndefined()
+
+      writeFileSync(join(tempDir, 'nuxt.lock'), JSON.stringify({
+        pid: process.pid,
+        command: 'dev',
+        cwd: '/project',
+        startedAt: Date.now(),
+        interactive: false,
+      }))
+      expect(readActiveLock(tempDir)).toBeUndefined()
+    })
+
+    it('returns nothing when there is no lock', () => {
+      expect(readActiveLock(tempDir)).toBeUndefined()
     })
   })
 

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -37,6 +37,11 @@ describe('lockfile', () => {
       expect(isLockEnabled()).toBe(false)
     })
 
+    it('nUXT_IGNORE_LOCK=0 keeps locking enabled', () => {
+      process.env.NUXT_IGNORE_LOCK = '0'
+      expect(isLockEnabled()).toBe(true)
+    })
+
     it('nUXT_LOCK=1 forces locking on', () => {
       process.env.NUXT_LOCK = '1'
       expect(isLockEnabled()).toBe(true)

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -314,6 +314,13 @@ describe('lockfile', () => {
       process.env.NUXT_IGNORE_LOCK = '1'
       updateLock(tempDir, { command: 'dev', cwd: '/project' })
       expect(existsSync(join(tempDir, 'nuxt.lock'))).toBe(false)
+    })
+
+    it('leaves no temporary files behind', () => {
+      const lock = acquireLock(tempDir, { command: 'dev', cwd: '/project' })
+      updateLock(tempDir, { command: 'dev', cwd: '/project', port: 3000 })
+      expect(readdirSync(tempDir)).toEqual(['nuxt.lock'])
+      lock.release!()
     })
   })
 

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -12,7 +12,7 @@ vi.mock('std-env', async (importOriginal) => {
   return { ...original, isCI: false }
 })
 
-const { acquireLock, formatLockError, isLockEnabled, readActiveLock, updateLock } = await import('../../src/utils/lockfile')
+const { acquireLock, acquireOutputLock, formatLockError, isLockEnabled, readActiveLock, updateLock } = await import('../../src/utils/lockfile')
 
 describe('lockfile', () => {
   let tempDir: string
@@ -267,6 +267,63 @@ describe('lockfile', () => {
       expect(process.listenerCount('exit')).toBe(before + 1)
       lock.release!()
       expect(process.listenerCount('exit')).toBe(before)
+    })
+  })
+
+  describe('acquireOutputLock', () => {
+    const outputDir = '/project/.output'
+
+    function foreignHolder(rootDir: string) {
+      const dir = join(rootDir, 'node_modules', '.cache', 'nuxt')
+      const [name] = readdirSync(dir)
+      const lockPath = join(dir, name!)
+      const current = JSON.parse(readFileSync(lockPath, 'utf-8'))
+      writeFileSync(lockPath, JSON.stringify({ ...current, pid: 424242 }))
+      return vi.spyOn(process, 'kill').mockImplementation(() => true as unknown as true)
+    }
+
+    it('refuses a second build writing to the same output directory', () => {
+      const first = acquireOutputLock(tempDir, outputDir, { command: 'build', cwd: '/project' })
+      expect(first.release).toBeDefined()
+
+      const killSpy = foreignHolder(tempDir)
+      try {
+        const second = acquireOutputLock(tempDir, outputDir, { command: 'build', cwd: '/project' })
+        expect(second.existing?.pid).toBe(424242)
+      }
+      finally {
+        killSpy.mockRestore()
+      }
+    })
+
+    it('keys the lock by output path, so unrelated outputs are independent', () => {
+      const first = acquireOutputLock(tempDir, outputDir, { command: 'build', cwd: '/project' })
+      const killSpy = foreignHolder(tempDir)
+      try {
+        const other = acquireOutputLock(tempDir, '/project/.output-staging', { command: 'build', cwd: '/project' })
+        expect(other.existing).toBeUndefined()
+        other.release!()
+      }
+      finally {
+        killSpy.mockRestore()
+      }
+      first.release?.()
+    })
+
+    it('releases the lock when the build finishes', () => {
+      const lock = acquireOutputLock(tempDir, outputDir, { command: 'build', cwd: '/project' })
+      const dir = join(tempDir, 'node_modules', '.cache', 'nuxt')
+      expect(readdirSync(dir)).toHaveLength(1)
+      lock.release!()
+      expect(readdirSync(dir)).toHaveLength(0)
+    })
+
+    it('is a no-op when locking is disabled', () => {
+      process.env.NUXT_IGNORE_LOCK = '1'
+      const lock = acquireOutputLock(tempDir, outputDir, { command: 'build', cwd: '/project' })
+      expect(lock.release).toBeDefined()
+      expect(existsSync(join(tempDir, 'node_modules'))).toBe(false)
+      lock.release!()
     })
   })
 

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -9,7 +9,7 @@ const isWindows = process.platform === 'win32'
 
 vi.mock('std-env', async (importOriginal) => {
   const original = await importOriginal<typeof import('std-env')>()
-  return { ...original, isAgent: true, isCI: false }
+  return { ...original, isCI: false }
 })
 
 const { acquireLock, formatLockError, isLockEnabled, updateLock } = await import('../../src/utils/lockfile')
@@ -28,12 +28,8 @@ describe('lockfile', () => {
   })
 
   describe('isLockEnabled', () => {
-    it('is enabled for dev by default', () => {
-      expect(isLockEnabled('dev')).toBe(true)
-    })
-
-    it('is enabled for build when isAgent is true (mocked)', () => {
-      expect(isLockEnabled('build')).toBe(true)
+    it('is enabled by default', () => {
+      expect(isLockEnabled()).toBe(true)
     })
 
     it('nUXT_IGNORE_LOCK=1 disables locking', () => {
@@ -48,7 +44,7 @@ describe('lockfile', () => {
 
     it('nUXT_LOCK=0 disables locking', () => {
       process.env.NUXT_LOCK = '0'
-      expect(isLockEnabled('dev')).toBe(false)
+      expect(isLockEnabled()).toBe(false)
     })
 
     it('nUXT_IGNORE_LOCK takes precedence over NUXT_LOCK', () => {

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -28,8 +28,12 @@ describe('lockfile', () => {
   })
 
   describe('isLockEnabled', () => {
-    it('is enabled when isAgent is true (mocked)', () => {
-      expect(isLockEnabled()).toBe(true)
+    it('is enabled for dev by default', () => {
+      expect(isLockEnabled('dev')).toBe(true)
+    })
+
+    it('is enabled for build when isAgent is true (mocked)', () => {
+      expect(isLockEnabled('build')).toBe(true)
     })
 
     it('nUXT_IGNORE_LOCK=1 disables locking', () => {
@@ -40,6 +44,11 @@ describe('lockfile', () => {
     it('nUXT_LOCK=1 forces locking on', () => {
       process.env.NUXT_LOCK = '1'
       expect(isLockEnabled()).toBe(true)
+    })
+
+    it('nUXT_LOCK=0 disables locking', () => {
+      process.env.NUXT_LOCK = '0'
+      expect(isLockEnabled('dev')).toBe(false)
     })
 
     it('nUXT_IGNORE_LOCK takes precedence over NUXT_LOCK', () => {

--- a/packages/nuxt-cli/test/unit/lockfile.spec.ts
+++ b/packages/nuxt-cli/test/unit/lockfile.spec.ts
@@ -9,7 +9,7 @@ const isWindows = process.platform === 'win32'
 
 vi.mock('std-env', async (importOriginal) => {
   const original = await importOriginal<typeof import('std-env')>()
-  return { ...original, isAgent: true }
+  return { ...original, isAgent: true, isCI: false }
 })
 
 const { acquireLock, formatLockError, isLockEnabled, updateLock } = await import('../../src/utils/lockfile')
@@ -62,6 +62,7 @@ describe('lockfile', () => {
       expect(written.command).toBe('dev')
       expect(written.cwd).toBe('/project')
       expect(typeof written.startedAt).toBe('number')
+      expect(typeof written.interactive).toBe('boolean')
 
       lock.release!()
       expect(existsSync(lockPath)).toBe(false)
@@ -109,6 +110,21 @@ describe('lockfile', () => {
       }
       finally {
         killSpy.mockRestore()
+      }
+    })
+
+    it('records whether the acquiring process is interactive', () => {
+      const original = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+      try {
+        const lock = acquireLock(tempDir, { command: 'dev', cwd: '/project' })
+        const written = JSON.parse(readFileSync(join(tempDir, 'nuxt.lock'), 'utf-8'))
+        // `isCI` is mocked false via the `std-env` mock above.
+        expect(written.interactive).toBe(true)
+        lock.release!()
+      }
+      finally {
+        Object.defineProperty(process.stdin, 'isTTY', { value: original, configurable: true })
       }
     })
 
@@ -302,6 +318,7 @@ describe('lockfile', () => {
         pid: 12345,
         command: 'dev',
         cwd: '/my/project',
+        interactive: false,
         port: 3000,
         hostname: '127.0.0.1',
         url: 'http://127.0.0.1:3000',
@@ -321,6 +338,7 @@ describe('lockfile', () => {
         pid: 12345,
         command: 'build',
         cwd: '/my/project',
+        interactive: false,
         startedAt: Date.now(),
       })
 

--- a/packages/nuxt-cli/test/unit/takeover.spec.ts
+++ b/packages/nuxt-cli/test/unit/takeover.spec.ts
@@ -96,6 +96,27 @@ describe('takeOverDevServer', () => {
     const proc = mockProcess()
     expect(await takeOverDevServer(buildDir, { requestedPort: 4000, interactive: false })).toEqual({ action: 'none' })
     expect(proc.signals).toHaveLength(0)
+    expect(readLock(buildDir)).toBeDefined()
+  })
+
+  it('drops a stale lock even when a different port was requested', async () => {
+    writeLock(buildDir)
+    checkPort.mockResolvedValue(3000)
+    mockProcess()
+    expect(await takeOverDevServer(buildDir, { requestedPort: 4000, interactive: false })).toEqual({ action: 'stale' })
+    expect(readLock(buildDir)).toBeUndefined()
+  })
+
+  it('leaves a lock that was replaced while it was inspected', async () => {
+    writeLock(buildDir)
+    checkPort.mockResolvedValue(3000)
+    mockProcess({ alive: false })
+    checkPort.mockImplementation(async () => {
+      writeLock(buildDir, { pid: 555555, startedAt: Date.now() + 1 })
+      return 3000
+    })
+    expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
+    expect(readLock(buildDir)).toMatchObject({ pid: 555555 })
   })
 
   it('takes over when the explicit port matches the holder\'s', async () => {
@@ -110,6 +131,7 @@ describe('takeOverDevServer', () => {
     const proc = mockProcess({ alive: false })
     expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
     expect(proc.signals).toHaveLength(0)
+    expect(readLock(buildDir)).toBeUndefined()
   })
 
   it('warns when the holder is gone but its port is still taken', async () => {
@@ -135,6 +157,7 @@ describe('takeOverDevServer', () => {
     const proc = mockProcess()
     expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
     expect(proc.signals).toHaveLength(0)
+    expect(readLock(buildDir)).toBeUndefined()
   })
 
   describe('decision matrix', () => {

--- a/packages/nuxt-cli/test/unit/takeover.spec.ts
+++ b/packages/nuxt-cli/test/unit/takeover.spec.ts
@@ -13,6 +13,7 @@ const checkPort = vi.hoisted(() => vi.fn<(port: number, host?: string) => Promis
 vi.mock('get-port-please', () => ({ checkPort }))
 
 const { formatTakeoverRefusal, takeOverDevServer } = await import('../../src/dev/takeover')
+const { logger } = await import('../../src/utils/logger')
 const { getTakeoverPid, markTakenOver, readLock, updateLock } = await import('../../src/utils/lockfile')
 
 const HOLDER_PID = 424242
@@ -109,6 +110,23 @@ describe('takeOverDevServer', () => {
     const proc = mockProcess({ alive: false })
     expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
     expect(proc.signals).toHaveLength(0)
+  })
+
+  it('warns when the holder is gone but its port is still taken', async () => {
+    writeLock(buildDir)
+    mockProcess({ alive: false })
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('still listening'))
+  })
+
+  it('does not warn when the holder is gone and its port is free', async () => {
+    writeLock(buildDir)
+    checkPort.mockResolvedValue(3000)
+    mockProcess({ alive: false })
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
+    expect(warn).not.toHaveBeenCalled()
   })
 
   it('reports a stale lock when the port is free (recycled PID)', async () => {

--- a/packages/nuxt-cli/test/unit/takeover.spec.ts
+++ b/packages/nuxt-cli/test/unit/takeover.spec.ts
@@ -1,0 +1,269 @@
+import type { TakeoverChoice } from '../../src/dev/takeover'
+import type { LockInfo } from '../../src/utils/lockfile'
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const checkPort = vi.hoisted(() => vi.fn<(port: number, host?: string) => Promise<number | false>>())
+
+vi.mock('get-port-please', () => ({ checkPort }))
+
+const { formatTakeoverRefusal, takeOverDevServer } = await import('../../src/dev/takeover')
+const { markTakenOver, readLock, updateLock } = await import('../../src/utils/lockfile')
+
+const HOLDER_PID = 424242
+
+function writeLock(buildDir: string, info: Partial<LockInfo> = {}): LockInfo {
+  const lock: LockInfo = {
+    pid: HOLDER_PID,
+    startedAt: Date.now(),
+    command: 'dev',
+    cwd: '/other',
+    interactive: false,
+    port: 3000,
+    hostname: '127.0.0.1',
+    url: 'http://127.0.0.1:3000',
+    ...info,
+  }
+  mkdirSync(buildDir, { recursive: true })
+  writeFileSync(join(buildDir, 'nuxt.lock'), JSON.stringify(lock))
+  return lock
+}
+
+/** Simulate a process that is alive until it is signalled. */
+function mockProcess({ alive = true, diesOn }: { alive?: boolean, diesOn?: NodeJS.Signals | 'never' } = {}) {
+  let isAlive = alive
+  const signals: Array<[number, string | number]> = []
+  const kill = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+    if (signal === 0 || signal === undefined) {
+      if (pid === process.pid) {
+        return true as never
+      }
+      if (!isAlive) {
+        throw Object.assign(new Error('no such process'), { code: 'ESRCH' })
+      }
+      return true as never
+    }
+    signals.push([pid as number, signal])
+    if (diesOn !== 'never' && signal === (diesOn ?? 'SIGTERM')) {
+      isAlive = false
+      checkPort.mockResolvedValue(3000)
+    }
+    return true as never
+  })
+  return { signals, kill }
+}
+
+describe('takeOverDevServer', () => {
+  let buildDir: string
+
+  beforeEach(async () => {
+    buildDir = await mkdtemp(join(tmpdir(), 'nuxt-takeover-test-'))
+    delete process.env.NUXT_IGNORE_LOCK
+    delete process.env.NUXT_LOCK
+    // Port in use by default: an active dev server holds it.
+    checkPort.mockResolvedValue(false)
+  })
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await rm(buildDir, { recursive: true, force: true })
+  })
+
+  it('does nothing when there is no lock', async () => {
+    expect(await takeOverDevServer(buildDir)).toEqual({ action: 'none' })
+  })
+
+  it('does nothing when locking is disabled', async () => {
+    process.env.NUXT_IGNORE_LOCK = '1'
+    writeLock(buildDir)
+    expect(await takeOverDevServer(buildDir)).toEqual({ action: 'none' })
+  })
+
+  it('never takes over a build lock', async () => {
+    writeLock(buildDir, { command: 'build', port: undefined, url: undefined })
+    mockProcess()
+    expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'none' })
+  })
+
+  it('never takes over when an explicit port differs from the holder\'s', async () => {
+    writeLock(buildDir)
+    const proc = mockProcess()
+    expect(await takeOverDevServer(buildDir, { requestedPort: 4000, interactive: false })).toEqual({ action: 'none' })
+    expect(proc.signals).toHaveLength(0)
+  })
+
+  it('takes over when the explicit port matches the holder\'s', async () => {
+    writeLock(buildDir)
+    mockProcess()
+    expect(await takeOverDevServer(buildDir, { requestedPort: 3000, interactive: false }))
+      .toEqual({ action: 'taken', port: 3000, pid: HOLDER_PID })
+  })
+
+  it('reports a stale lock when the holder is dead', async () => {
+    writeLock(buildDir)
+    const proc = mockProcess({ alive: false })
+    expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
+    expect(proc.signals).toHaveLength(0)
+  })
+
+  it('reports a stale lock when the port is free (recycled PID)', async () => {
+    writeLock(buildDir)
+    checkPort.mockResolvedValue(3000)
+    const proc = mockProcess()
+    expect(await takeOverDevServer(buildDir, { interactive: false })).toEqual({ action: 'stale' })
+    expect(proc.signals).toHaveLength(0)
+  })
+
+  describe('decision matrix', () => {
+    it('non-interactive holder, non-interactive caller: takes over', async () => {
+      writeLock(buildDir, { interactive: false })
+      const proc = mockProcess()
+      expect(await takeOverDevServer(buildDir, { interactive: false }))
+        .toEqual({ action: 'taken', port: 3000, pid: HOLDER_PID })
+      expect(proc.signals).toEqual([[HOLDER_PID, 'SIGTERM']])
+    })
+
+    it('non-interactive holder, interactive caller: prompts, defaulting to takeover', async () => {
+      writeLock(buildDir, { interactive: false })
+      mockProcess()
+      const prompt = vi.fn(async (_lock: LockInfo, fallback: TakeoverChoice) => fallback)
+      const result = await takeOverDevServer(buildDir, { interactive: true, prompt })
+      expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ pid: HOLDER_PID }), 'takeover')
+      expect(result).toEqual({ action: 'taken', port: 3000, pid: HOLDER_PID })
+    })
+
+    it('interactive holder, non-interactive caller: refuses', async () => {
+      writeLock(buildDir, { interactive: true })
+      const proc = mockProcess()
+      const result = await takeOverDevServer(buildDir, { interactive: false })
+      expect(result).toMatchObject({ action: 'refused', reason: 'holder-interactive' })
+      expect(proc.signals).toHaveLength(0)
+    })
+
+    it('interactive holder, interactive caller: prompts, defaulting to not starting', async () => {
+      writeLock(buildDir, { interactive: true })
+      const proc = mockProcess()
+      const prompt = vi.fn(async (_lock: LockInfo, fallback: TakeoverChoice) => fallback)
+      const result = await takeOverDevServer(buildDir, { interactive: true, prompt })
+      expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ pid: HOLDER_PID }), 'abort')
+      expect(result).toMatchObject({ action: 'refused', reason: 'declined' })
+      expect(proc.signals).toHaveLength(0)
+    })
+  })
+
+  describe('flags', () => {
+    it('`--takeover` skips the prompt even for an interactive holder', async () => {
+      writeLock(buildDir, { interactive: true })
+      const proc = mockProcess()
+      const prompt = vi.fn(async () => 'abort' as const)
+      expect(await takeOverDevServer(buildDir, { takeover: true, interactive: true, prompt }))
+        .toEqual({ action: 'taken', port: 3000, pid: HOLDER_PID })
+      expect(prompt).not.toHaveBeenCalled()
+      expect(proc.signals).toEqual([[HOLDER_PID, 'SIGTERM']])
+    })
+
+    it('`--no-takeover` refuses without signalling anything', async () => {
+      writeLock(buildDir, { interactive: false })
+      const proc = mockProcess()
+      const prompt = vi.fn(async () => 'takeover' as const)
+      expect(await takeOverDevServer(buildDir, { takeover: false, interactive: true, prompt }))
+        .toMatchObject({ action: 'refused', reason: 'disabled' })
+      expect(prompt).not.toHaveBeenCalled()
+      expect(proc.signals).toHaveLength(0)
+    })
+
+    it('`start anyway` proceeds without a takeover', async () => {
+      writeLock(buildDir, { interactive: true })
+      const proc = mockProcess()
+      const result = await takeOverDevServer(buildDir, { interactive: true, prompt: async () => 'start-anyway' })
+      expect(result).toMatchObject({ action: 'start-anyway' })
+      expect(proc.signals).toHaveLength(0)
+      expect(readLock(buildDir)?.pid).toBe(HOLDER_PID)
+    })
+  })
+
+  describe('performing the takeover', () => {
+    it('marks the lock so the outgoing process can explain itself', async () => {
+      writeLock(buildDir)
+      mockProcess()
+      await takeOverDevServer(buildDir, { interactive: false })
+      expect(readLock(buildDir)?.takenOverBy).toBe(process.pid)
+    })
+
+    it('escalates to SIGKILL when SIGTERM is ignored', async () => {
+      writeLock(buildDir)
+      const proc = mockProcess({ diesOn: 'SIGKILL' })
+      expect(await takeOverDevServer(buildDir, { interactive: false, timeouts: { graceful: 200, force: 200 } }))
+        .toEqual({ action: 'taken', port: 3000, pid: HOLDER_PID })
+      expect(proc.signals).toEqual([[HOLDER_PID, 'SIGTERM'], [HOLDER_PID, 'SIGKILL']])
+    })
+
+    it('refuses to start when the port is still held after the deadline', async () => {
+      writeLock(buildDir)
+      const proc = mockProcess({ diesOn: 'never' })
+      expect(await takeOverDevServer(buildDir, { interactive: false, timeouts: { graceful: 200, force: 200 } }))
+        .toMatchObject({ action: 'refused', reason: 'timeout' })
+      expect(proc.signals).toEqual([[HOLDER_PID, 'SIGTERM'], [HOLDER_PID, 'SIGKILL']])
+    })
+
+    it('also signals the supervising process of a dev fork', async () => {
+      writeLock(buildDir, { parentPid: 424243 })
+      const proc = mockProcess()
+      await takeOverDevServer(buildDir, { interactive: false })
+      expect(proc.signals).toEqual([[HOLDER_PID, 'SIGTERM'], [424243, 'SIGTERM']])
+    })
+  })
+
+  describe('formatTakeoverRefusal', () => {
+    const lock: LockInfo = {
+      pid: HOLDER_PID,
+      startedAt: Date.now(),
+      command: 'dev',
+      cwd: '/my/project',
+      interactive: true,
+      port: 3000,
+      url: 'http://localhost:3000',
+    }
+
+    it('explains an interactive holder and how to override it', () => {
+      const message = formatTakeoverRefusal(lock, 'holder-interactive')
+      expect(message).toContain('http://localhost:3000')
+      expect(message).toContain('/my/project')
+      expect(message).toContain('in a terminal')
+      expect(message).toContain('--takeover')
+      expect(message).toContain('NUXT_IGNORE_LOCK=1')
+    })
+
+    it('does not print `undefined` for a server without a URL yet', () => {
+      const message = formatTakeoverRefusal({ ...lock, url: undefined }, 'declined')
+      expect(message).not.toContain('undefined')
+      expect(message).toContain('no URL yet')
+    })
+
+    it('explains a holder that would not exit', () => {
+      const message = formatTakeoverRefusal(lock, 'timeout')
+      expect(message).toContain('did not exit')
+      expect(message).not.toContain('--takeover')
+    })
+  })
+
+  describe('outgoing side', () => {
+    it('reports the takeover to the process being taken over', async () => {
+      const { getTakeoverPid } = await import('../../src/utils/lockfile')
+      updateLock(buildDir, { command: 'dev', cwd: '/project', port: 3000 })
+      markTakenOver(buildDir, HOLDER_PID)
+      expect(getTakeoverPid(buildDir)).toBe(HOLDER_PID)
+    })
+
+    it('does not annotate a lock owned by the taking-over process', () => {
+      writeLock(buildDir)
+      markTakenOver(buildDir, HOLDER_PID)
+      expect(readLock(buildDir)?.takenOverBy).toBeUndefined()
+    })
+  })
+})

--- a/packages/nuxt-cli/test/unit/takeover.spec.ts
+++ b/packages/nuxt-cli/test/unit/takeover.spec.ts
@@ -13,7 +13,7 @@ const checkPort = vi.hoisted(() => vi.fn<(port: number, host?: string) => Promis
 vi.mock('get-port-please', () => ({ checkPort }))
 
 const { formatTakeoverRefusal, takeOverDevServer } = await import('../../src/dev/takeover')
-const { markTakenOver, readLock, updateLock } = await import('../../src/utils/lockfile')
+const { getTakeoverPid, markTakenOver, readLock, updateLock } = await import('../../src/utils/lockfile')
 
 const HOLDER_PID = 424242
 
@@ -211,6 +211,15 @@ describe('takeOverDevServer', () => {
       expect(proc.signals).toEqual([[HOLDER_PID, 'SIGTERM'], [HOLDER_PID, 'SIGKILL']])
     })
 
+    it('leaves the holder identifiable after giving up', async () => {
+      writeLock(buildDir)
+      mockProcess({ diesOn: 'never' })
+      await takeOverDevServer(buildDir, { interactive: false, timeouts: { graceful: 200, force: 200 } })
+      const lock = readLock(buildDir)
+      expect(lock?.pid).toBe(HOLDER_PID)
+      expect(lock?.takenOverBy).toBeUndefined()
+    })
+
     it('also signals the supervising process of a dev fork', async () => {
       writeLock(buildDir, { parentPid: 424243 })
       const proc = mockProcess()
@@ -253,11 +262,17 @@ describe('takeOverDevServer', () => {
   })
 
   describe('outgoing side', () => {
-    it('reports the takeover to the process being taken over', async () => {
-      const { getTakeoverPid } = await import('../../src/utils/lockfile')
+    it('reports the takeover to the process being taken over', () => {
+      vi.spyOn(process, 'kill').mockImplementation(() => true as never)
       updateLock(buildDir, { command: 'dev', cwd: '/project', port: 3000 })
       markTakenOver(buildDir, HOLDER_PID)
       expect(getTakeoverPid(buildDir)).toBe(HOLDER_PID)
+    })
+
+    it('does not report a handover to a process that has since exited', () => {
+      updateLock(buildDir, { command: 'dev', cwd: '/project', port: 3000 })
+      markTakenOver(buildDir, 999999999)
+      expect(getTakeoverPid(buildDir)).toBeUndefined()
     })
 
     it('does not annotate a lock owned by the taking-over process', () => {


### PR DESCRIPTION
### 🔗 Linked issue

closes https://github.com/nuxt/cli/pull/1337 (and incorporates some of it ❤️)

### 📚 Description

this PR does a number of things. it enables the lock file (https://github.com/nuxt/cli/pull/1265) whether or not we're using an agent, and additionally records whether or not the dev server was started in an interactive console.


<details><summary><b>Video preview</b></summary>
<p>

https://github.com/user-attachments/assets/2d936e0f-8645-41f7-a739-7cf3a26613c0

</p>
</details>

we then are able to protect corruption of `.nuxt/` and `.output/` with the following rules:

| running | starting | what happens |
| --- | --- | --- |
| dev | build | both run happily |
| build | dev | refused if build was started when no `.nuxt/` dir existed |
| build | build | refused |
| dev | dev | see below |

if you start a second dev process, it's now possible for it to _take over_ the existing port, in certain conditions (based on interactivity):

| running | starting | what happens |
| --- | --- | --- |
| non-interactive | non-interactive | takes over, logged loudly |
| non-interactive | interactive | prompts, default `takeover` |
| interactive | non-interactive | refuses, exits `1`, prints where the other server is and that `--takeover` forces it |
| interactive | interactive | prompts, default `don't start` |

this is designed to allow agents to take over easily, but _not_ kill a dev server that a person is operating. and also to handle the 'too many terminals' syndrome that I have 😭 

takeover is additionally restricted by the following conditions:
- a lockfile has to exist
- the previous process pid still has to exist (if not, we ignore the lockfile)
- the previous port has to still be in use (if not, we ignore the lockfile)
- the 'target' port for both process has to be the same (if not, we refuse to start)

before taking over, we write the pid of the new process into the lockfile (so the outgoing dev server can blame why it's going silently into the dark night) and then kill it, first politely and then non-negotiably. but if that fails, we give an informative error and die.