### PR TITLE
fix: correctly report Vite version when using Vite+

### DIFF
--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -5,7 +5,7 @@ import colors from 'picocolors'
 import { logger } from './logger'
 import { getPkgJSON, getPkgVersion } from './pkg'
 
-export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string } {
+export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string, provider?: { name: string, version: string } } {
   switch (builder) {
     case 'rspack':
     case '@nuxt/rspack-builder':
@@ -18,7 +18,12 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
     default: {
       const pkgJSON = getPkgJSON(cwd, 'vite', { via: ['nuxt', '@nuxt/vite-builder'] })
       const isRolldown = pkgJSON.name.includes('rolldown')
-      return { name: isRolldown ? 'Rolldown-Vite' : 'Vite', version: pkgJSON.version || 'unknown' }
+      const isVitePlus = pkgJSON.name === '@voidzero-dev/vite-plus-core'
+      return {
+        name: isRolldown ? 'Rolldown-Vite' : 'Vite',
+        version: (isVitePlus ? pkgJSON.bundledVersions?.vite : pkgJSON.version) || 'unknown',
+        provider: isVitePlus ? { name: 'Vite+', version: pkgJSON.version || 'unknown' } : undefined,
+      }
     }
   }
 }
@@ -39,6 +44,7 @@ export function showBanner(nuxt: Nuxt) {
     + gray(' (with ')
     + (nitroVersion ? gray(`Nitro ${bold(nitroVersion)}`) : '')
     + gray(`, ${builder.name} ${bold(builder.version)}`)
+    + (builder.provider ? gray(` via ${builder.provider.name} ${bold(builder.provider.version)}`) : '')
     + (vueVersion ? gray(` and Vue ${bold(vueVersion)}`) : '')
     + gray(')'),
   )

--- a/packages/nuxt-cli/test/unit/utils/banner.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/banner.spec.ts
@@ -18,6 +18,9 @@ const VERSIONS: Record<string, string> = {
 vi.mock('../../../src/utils/pkg', () => ({
   getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string[] }) => {
     if (pkg === 'vite' && options?.via?.includes('@nuxt/vite-builder')) {
+      if (_cwd === '/vite-plus') {
+        return { name: '@voidzero-dev/vite-plus-core', version: '0.2.6', bundledVersions: { vite: '8.1.5' } }
+      }
       return { name: 'vite', version: '7.3.1' }
     }
     return null
@@ -40,6 +43,14 @@ describe('getBuilder', () => {
     expect(getBuilder('/any', 'vite')).toEqual({ name: 'Vite', version: '7.3.1' })
   })
 
+  it('resolves the bundled vite version from Vite+', () => {
+    expect(getBuilder('/vite-plus', 'vite')).toEqual({
+      name: 'Vite',
+      version: '8.1.5',
+      provider: { name: 'Vite+', version: '0.2.6' },
+    })
+  })
+
   it('resolves webpack version via @nuxt/webpack-builder', () => {
     expect(getBuilder('/any', 'webpack')).toEqual({ name: 'Webpack', version: '5.99.0' })
   })
@@ -57,6 +68,16 @@ describe('showBanner', () => {
     expect(screen(renderer)).toMatchInlineSnapshot(`
       "│
       ●  Nuxt 4.4.6 (with Nitro 2.13.4, Vite 7.3.1 and Vue 3.5.39)"
+    `)
+  })
+
+  it('should identify Vite+ as the Vite provider', async () => {
+    const renderer = await render(() =>
+      showBanner({ _version: '4.4.6', options: { rootDir: '/vite-plus', builder: 'vite' } } as unknown as Nuxt))
+
+    expect(screen(renderer)).toMatchInlineSnapshot(`
+      "│
+      ●  Nuxt 4.4.6 (with Nitro 2.13.4, Vite 8.1.5 via Vite+ 0.2.6 and Vue 3.5.39)"
     `)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Before:

<img width="670" height="186" alt="image" src="https://github.com/user-attachments/assets/e77ef690-11ff-4b8a-8e71-0c54a17c71fa" />

After:

<img width="781" height="182" alt="image" src="https://github.com/user-attachments/assets/e94426c7-cb74-42e7-b327-f76050eb6e54" />


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
