### PR TITLE
refactor: replace picocolors with node:util styleText

### DIFF
--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -48,7 +48,6 @@
     "@types/node": "^24.13.3",
     "citty": "^0.2.2",
     "jiti": "^2.7.0",
-    "picocolors": "^1.1.1",
     "std-env": "^4.2.0",
     "tinyexec": "^1.2.4",
     "tsdown": "^0.22.14",

--- a/packages/nuxi/src/main.ts
+++ b/packages/nuxi/src/main.ts
@@ -5,8 +5,8 @@ import { builtinModules, createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { runMain as _runMain, defineCommand } from 'citty'
-import colors from 'picocolors'
 import { provider } from 'std-env'
 
 import { cwdArgs } from '../../nuxt-cli/src/commands/_shared'
@@ -71,7 +71,7 @@ const _main = defineCommand({
     if (ctx.args.command && !(ctx.args.command in commands)) {
       if (isNuxiCommand(ctx.args.command)) {
         logger.error(`\`nuxt ${ctx.args.command}\` is provided by the \`@nuxt/cli\` installed with Nuxt in your project, and no usable version was found.`)
-        logger.info(`Run this command from your Nuxt project directory, or install Nuxt first (for example with ${colors.cyan('npx nuxi init')} or ${colors.cyan('npm install nuxt')}).`)
+        logger.info(`Run this command from your Nuxt project directory, or install Nuxt first (for example with ${styleText('cyan', 'npx nuxi init')} or ${styleText('cyan', 'npm install nuxt')}).`)
         process.exit(1)
       }
 

--- a/packages/nuxt-cli/package.json
+++ b/packages/nuxt-cli/package.json
@@ -74,7 +74,6 @@
     "ohash": "^2.0.11",
     "pathe": "^2.0.3",
     "perfect-debounce": "^2.1.0",
-    "picocolors": "^1.1.1",
     "pkg-types": "^2.3.1",
     "pnpm-workspace-yaml": "^1.7.0",
     "rc9": "^3.0.1",

--- a/packages/nuxt-cli/src/commands/add-template.ts
+++ b/packages/nuxt-cli/src/commands/add-template.ts
@@ -3,10 +3,10 @@ import type { TemplateName } from '../utils/templates/names'
 import { existsSync, promises as fsp } from 'node:fs'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { dirname, extname, resolve } from 'pathe'
-import colors from 'picocolors'
 
 import { loadKit } from '../utils/kit'
 import { logger } from '../utils/logger'
@@ -43,15 +43,15 @@ export default defineCommand({
   async run(ctx) {
     const cwd = resolve(ctx.args.cwd)
 
-    intro(colors.cyan('Adding template...'))
+    intro(styleText('cyan', 'Adding template...'))
 
     const templateName = ctx.args.template as TemplateName
 
     // Validate template name
     if (!templateNames.includes(templateName)) {
-      const templateNames = Object.keys(templates).map(name => colors.cyan(name))
+      const templateNames = Object.keys(templates).map(name => styleText('cyan', name))
       const lastTemplateName = templateNames.pop()
-      logger.error(`Template ${colors.cyan(templateName)} is not supported.`)
+      logger.error(`Template ${styleText('cyan', templateName)} is not supported.`)
       logger.info(`Possible values are ${templateNames.join(', ')} or ${lastTemplateName}.`)
       process.exit(1)
     }
@@ -79,15 +79,15 @@ export default defineCommand({
 
     // Ensure not overriding user code
     if (!ctx.args.force && existsSync(res.path)) {
-      logger.error(`File exists at ${colors.cyan(relativeToProcess(res.path))}.`)
-      logger.info(`Use ${colors.cyan('--force')} to override or use a different name.`)
+      logger.error(`File exists at ${styleText('cyan', relativeToProcess(res.path))}.`)
+      logger.info(`Use ${styleText('cyan', '--force')} to override or use a different name.`)
       process.exit(1)
     }
 
     // Ensure parent directory exists
     const parentDir = dirname(res.path)
     if (!existsSync(parentDir)) {
-      logger.step(`Creating directory ${colors.cyan(relativeToProcess(parentDir))}.`)
+      logger.step(`Creating directory ${styleText('cyan', relativeToProcess(parentDir))}.`)
       if (templateName === 'page') {
         logger.info('This enables vue-router functionality!')
       }
@@ -96,7 +96,7 @@ export default defineCommand({
 
     // Write file
     await fsp.writeFile(res.path, `${res.contents.trim()}\n`)
-    logger.success(`Created ${colors.cyan(relativeToProcess(res.path))}.`)
-    outro(`Generated a new ${colors.cyan(templateName)}!`)
+    logger.success(`Created ${styleText('cyan', relativeToProcess(res.path))}.`)
+    outro(`Generated a new ${styleText('cyan', templateName)}!`)
   },
 })

--- a/packages/nuxt-cli/src/commands/analyze.ts
+++ b/packages/nuxt-cli/src/commands/analyze.ts
@@ -3,12 +3,12 @@ import type { NuxtAnalyzeMeta } from '@nuxt/schema'
 import { promises as fsp } from 'node:fs'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { intro, note, outro, taskLog } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { defu } from 'defu'
 import { H3, lazyEventHandler } from 'h3-next'
 import { join } from 'pathe'
-import colors from 'picocolors'
 import { serve } from 'srvx'
 
 import { overrideEnv } from '../utils/env'
@@ -74,7 +74,7 @@ export default defineCommand({
     const name = ctx.args.name || 'default'
     const slug = name.trim().replace(NON_WORD_RE, '_')
 
-    intro(colors.cyan('Analyzing bundle size...'))
+    intro(styleText('cyan', 'Analyzing bundle size...'))
 
     const startTime = Date.now()
 
@@ -151,7 +151,7 @@ export default defineCommand({
     tasklog.success('Build complete')
 
     if (skippedPrerenderRoutes > 0) {
-      logger.info(`Skipped prerendering ${skippedPrerenderRoutes} route${skippedPrerenderRoutes === 1 ? '' : 's'}. Pass ${colors.cyan('--prerender')} to include assets emitted while prerendering.`)
+      logger.info(`Skipped prerendering ${skippedPrerenderRoutes} route${skippedPrerenderRoutes === 1 ? '' : 's'}. Pass ${styleText('cyan', '--prerender')} to include assets emitted while prerendering.`)
     }
 
     const endTime = Date.now()
@@ -169,7 +169,7 @@ export default defineCommand({
     await nuxt.callHook('build:analyze:done', meta)
     await fsp.writeFile(join(analyzeDir, 'meta.json'), JSON.stringify(meta, null, 2), 'utf-8')
 
-    note(`${relativeToProcess(analyzeDir)}\n\nDo not deploy analyze results! Use ${colors.cyan('nuxt build')} before deploying.`, 'Build location')
+    note(`${relativeToProcess(analyzeDir)}\n\nDo not deploy analyze results! Use ${styleText('cyan', 'nuxt build')} before deploying.`, 'Build location')
 
     if (ctx.args.serve !== false && !process.env.CI) {
       const app = new H3()

--- a/packages/nuxt-cli/src/commands/build.ts
+++ b/packages/nuxt-cli/src/commands/build.ts
@@ -1,10 +1,10 @@
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { intro, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { relative } from 'pathe'
 
-import colors from 'picocolors'
+import { relative } from 'pathe'
 import { showBanner } from '../utils/banner'
 
 import { overrideEnv } from '../utils/env'
@@ -53,7 +53,7 @@ export default defineCommand({
 
     let releaseLock: (() => void) | undefined
     try {
-      intro(colors.cyan('Building Nuxt for production...'))
+      intro(styleText('cyan', 'Building Nuxt for production...'))
 
       const kit = await loadKit(cwd)
       const nuxt = await kit.loadNuxt({
@@ -97,7 +97,7 @@ export default defineCommand({
       releaseLock = lock.release
 
       const nitro = kit.useNitro()
-      logger.info(`Nitro preset: ${colors.cyan(nitro.options.preset)}`)
+      logger.info(`Nitro preset: ${styleText('cyan', nitro.options.preset)}`)
 
       await clearBuildDir(nuxt.options.buildDir)
 
@@ -115,16 +115,16 @@ export default defineCommand({
 
       if (ctx.args.prerender) {
         if (!nuxt.options.ssr) {
-          logger.warn(`HTML content not prerendered because ${colors.cyan('ssr: false')} was set.`)
-          logger.info(`You can read more in ${colors.cyan('https://nuxt.com/docs/getting-started/deployment#static-hosting')}.`)
+          logger.warn(`HTML content not prerendered because ${styleText('cyan', 'ssr: false')} was set.`)
+          logger.info(`You can read more in ${styleText('cyan', 'https://nuxt.com/docs/getting-started/deployment#static-hosting')}.`)
         }
         // TODO: revisit later if/when nuxt build --prerender will output hybrid
         const dir = nitro.options.output.publicDir
         const publicDir = dir ? relative(process.cwd(), dir) : '.output/public'
-        outro(`✨ You can now deploy ${colors.cyan(publicDir)} to any static hosting! ${colors.gray(`(${formatDuration(Date.now() - start)})`)}`)
+        outro(`✨ You can now deploy ${styleText('cyan', publicDir)} to any static hosting! ${styleText('gray', `(${formatDuration(Date.now() - start)})`)}`)
       }
       else {
-        outro(`✨ Build complete in ${colors.cyan(formatDuration(Date.now() - start))}!`)
+        outro(`✨ Build complete in ${styleText('cyan', formatDuration(Date.now() - start))}!`)
       }
     }
     finally {

--- a/packages/nuxt-cli/src/commands/devtools.ts
+++ b/packages/nuxt-cli/src/commands/devtools.ts
@@ -1,8 +1,8 @@
 import process from 'node:process'
 
-import { defineCommand } from 'citty'
+import { styleText } from 'node:util'
 
-import colors from 'picocolors'
+import { defineCommand } from 'citty'
 import { x } from 'tinyexec'
 import { logger } from '../utils/logger'
 
@@ -28,7 +28,7 @@ export default defineCommand({
     const command = ctx.args.command
 
     if (!command || !['enable', 'disable'].includes(command)) {
-      logger.error(`Unknown command ${colors.cyan(command || '')}.`)
+      logger.error(`Unknown command ${styleText('cyan', command || '')}.`)
       process.exit(1)
     }
 

--- a/packages/nuxt-cli/src/commands/info.ts
+++ b/packages/nuxt-cli/src/commands/info.ts
@@ -4,11 +4,11 @@ import type { PackageJson } from 'pkg-types'
 import os from 'node:os'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { box } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { detectPackageManager } from 'nypm'
 
-import colors from 'picocolors'
+import { detectPackageManager } from 'nypm'
 import { readPackageJSON } from 'pkg-types'
 import { isBun, isDeno, isMinimal } from 'std-env'
 import { writeText } from 'tinyclip'
@@ -115,7 +115,7 @@ export default defineCommand({
       'Modules': await listModules(nuxtConfig.modules),
     }
 
-    logger.info(`Nuxt root directory: ${colors.cyan(nuxtConfig.rootDir || cwd)}\n`)
+    logger.info(`Nuxt root directory: ${styleText('cyan', nuxtConfig.rootDir || cwd)}\n`)
 
     const boxStr = formatInfoBox(infoObj)
 
@@ -144,7 +144,7 @@ export default defineCommand({
     if (copied) {
       box(
         `\n${boxStr}`,
-        ` Nuxt project info ${colors.gray('(copied to clipboard) ')}`,
+        ` Nuxt project info ${styleText('gray', '(copied to clipboard) ')}`,
         {
           contentAlign: 'left',
           titleAlign: 'left',
@@ -159,11 +159,11 @@ export default defineCommand({
       logger.info(`Nuxt project info:\n${copyStr}`, { withGuide: false })
     }
 
-    logger.info(`👉 Read documentation: ${colors.cyan('https://nuxt.com')}`)
-    logger.info(`👉 Report an issue: ${colors.cyan('https://github.com/nuxt/nuxt/issues/new?template=bug-report.yml')}`, {
+    logger.info(`👉 Read documentation: ${styleText('cyan', 'https://nuxt.com')}`)
+    logger.info(`👉 Report an issue: ${styleText('cyan', 'https://github.com/nuxt/nuxt/issues/new?template=bug-report.yml')}`, {
       spacing: 0,
     })
-    logger.info(`👉 Suggest an improvement: ${colors.cyan('https://github.com/nuxt/nuxt/discussions/new')}`, {
+    logger.info(`👉 Suggest an improvement: ${styleText('cyan', 'https://github.com/nuxt/nuxt/discussions/new')}`, {
       spacing: 0,
     })
   },

--- a/packages/nuxt-cli/src/commands/init.ts
+++ b/packages/nuxt-cli/src/commands/init.ts
@@ -8,12 +8,12 @@ import { existsSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, confirm, intro, isCancel, outro, S_BAR, select, spinner, text } from '@clack/prompts'
 import { defineCommand, showUsage } from 'citty'
 import { downloadTemplate, startShell } from 'giget'
 import { detectPackageManager } from 'nypm'
 import { basename, join, relative, resolve } from 'pathe'
-import colors from 'picocolors'
 import { findFile, readPackageJSON, writePackageJSON } from 'pkg-types'
 import { hasTTY } from 'std-env'
 import { x } from 'tinyexec'
@@ -76,12 +76,12 @@ async function reportMissingNonInteractiveArgs<T extends ArgsDef>(
   await showUsage(cmd)
   if (availableTemplates) {
     logger.info(`Available templates:\n${Object.entries(availableTemplates)
-      .map(([name, data]) => `  ${colors.cyan(name)}${data ? ` – ${data.description}` : ''}`)
+      .map(([name, data]) => `  ${styleText('cyan', name)}${data ? ` – ${data.description}` : ''}`)
       .join('\n')}`)
   }
   const label = missingArgs.length === 1 ? 'argument' : 'arguments'
   logger.error(`Non-interactive terminal detected. Missing required ${label}: ${missingArgs
-    .map(name => colors.cyan(name === 'dir' ? '<dir>' : `--${name}`))
+    .map(name => styleText('cyan', name === 'dir' ? '<dir>' : `--${name}`))
     .join(', ')}`)
 }
 
@@ -199,7 +199,7 @@ export default defineCommand({
     // of being silently ignored once a template's own package manager is
     // detected.
     if (ctx.args.packageManager && !packageManagerOptions.includes(ctx.args.packageManager as PackageManagerName)) {
-      logger.error(`Invalid package manager: ${colors.cyan(ctx.args.packageManager)}. Choose one of ${packageManagerOptions.map(pm => colors.cyan(pm)).join(', ')}.`)
+      logger.error(`Invalid package manager: ${styleText('cyan', ctx.args.packageManager)}. Choose one of ${packageManagerOptions.map(pm => styleText('cyan', pm)).join(', ')}.`)
       process.exit(ARG_ERROR_EXIT_CODE)
     }
 
@@ -214,7 +214,7 @@ export default defineCommand({
       process.stdout.write(`\n${nuxtIcon}\n\n`)
     }
 
-    intro(colors.bold(`Welcome to Nuxt!`.split('').map(m => `${themeColor}${m}`).join('')))
+    intro(styleText('bold', `Welcome to Nuxt!`.split('').map(m => `${themeColor}${m}`).join('')))
 
     let availableTemplates: Record<string, TemplateData> = {}
 
@@ -280,7 +280,7 @@ export default defineCommand({
         options: Object.entries(availableTemplates).map(([name, data]) => {
           return {
             value: name,
-            label: data ? `${colors.whiteBright(name)} – ${data.description}` : name,
+            label: data ? `${styleText('whiteBright', name)} – ${data.description}` : name,
             hint: name === DEFAULT_TEMPLATE_NAME ? 'recommended' : undefined,
           }
         }),
@@ -324,7 +324,7 @@ export default defineCommand({
 
     const cwd = resolve(ctx.args.cwd)
     let templateDownloadPath = resolve(cwd, dir)
-    logger.step(`Creating project in ${colors.cyan(relativeToProcess(templateDownloadPath))}`)
+    logger.step(`Creating project in ${styleText('cyan', relativeToProcess(templateDownloadPath))}`)
 
     let shouldForce = Boolean(ctx.args.force)
 
@@ -333,12 +333,12 @@ export default defineCommand({
     const shouldVerify = !shouldForce && existsSync(templateDownloadPath)
     if (shouldVerify) {
       if (isNonInteractive) {
-        logger.error(`The directory ${colors.cyan(relativeToProcess(templateDownloadPath))} already exists. Pass ${colors.cyan('--force')} to override it or choose a different directory.`)
+        logger.error(`The directory ${styleText('cyan', relativeToProcess(templateDownloadPath))} already exists. Pass ${styleText('cyan', '--force')} to override it or choose a different directory.`)
         process.exit(1)
       }
 
       const selectedAction = await select({
-        message: `The directory ${colors.cyan(relativeToProcess(templateDownloadPath))} already exists. What would you like to do?`,
+        message: `The directory ${styleText('cyan', relativeToProcess(templateDownloadPath))} already exists. What would you like to do?`,
         options: [
           { value: 'override', label: 'Override its contents' },
           { value: 'different', label: 'Select different directory' },
@@ -383,7 +383,7 @@ export default defineCommand({
     const registry = process.env.NUXI_INIT_REGISTRY || DEFAULT_REGISTRY
 
     const downloadSpinner = spinner()
-    downloadSpinner.start(`Downloading ${colors.cyan(templateName)} template`)
+    downloadSpinner.start(`Downloading ${styleText('cyan', templateName)} template`)
 
     try {
       template = await downloadTemplate(templateName, {
@@ -414,7 +414,7 @@ export default defineCommand({
         }
       }
 
-      downloadSpinner.stop(`Downloaded ${colors.cyan(template.name)} template`)
+      downloadSpinner.stop(`Downloaded ${styleText('cyan', template.name)} template`)
     }
     catch (err) {
       downloadSpinner.error('Template download failed')
@@ -427,7 +427,7 @@ export default defineCommand({
       logNetworkError(diagnosable, {
         url: registry,
         hints: [
-          `Retry with ${colors.cyan('--offline')} or ${colors.cyan('--preferOffline')} to use a cached template, or set ${colors.cyan('NUXI_INIT_REGISTRY')} to a reachable mirror.`,
+          `Retry with ${styleText('cyan', '--offline')} or ${styleText('cyan', '--preferOffline')} to use a cached template, or set ${styleText('cyan', 'NUXI_INIT_REGISTRY')} to a reachable mirror.`,
         ],
       })
       process.exit(1)
@@ -454,7 +454,7 @@ export default defineCommand({
 
       if (!nightlyChannelVersion) {
         nightlySpinner.error('Nightly version not found')
-        logger.error(`Nightly channel version for tag ${colors.cyan(nightlyChannelTag)} not found.`)
+        logger.error(`Nightly channel version for tag ${styleText('cyan', nightlyChannelTag)} not found.`)
         process.exit(1)
       }
 
@@ -471,7 +471,7 @@ export default defineCommand({
       }
 
       await writePackageJSON(join(packageJsonPath, 'package.json'), packageJson)
-      nightlySpinner.stop(`Updated to nightly version ${colors.cyan(nightlyChannelVersion)}`)
+      nightlySpinner.stop(`Updated to nightly version ${styleText('cyan', nightlyChannelVersion)}`)
     }
 
     let installFailure: InstallResult | undefined
@@ -508,7 +508,7 @@ export default defineCommand({
       selectedPackageManager = packageManagerArg
       if (templatePackageManager && templatePackageManager.name !== packageManagerArg) {
         skipInstallOnConflict = true
-        logger.warn(`The ${colors.cyan(template.name)} template is configured for ${colors.cyan(templatePackageManager.name)}, but ${colors.cyan(packageManagerArg)} was requested. Skipping dependency installation to avoid installing against ${colors.cyan(templatePackageManager.name)}'s lockfile and config. Reconcile the package manager (or use ${colors.cyan(templatePackageManager.name)}) and install manually.`)
+        logger.warn(`The ${styleText('cyan', template.name)} template is configured for ${styleText('cyan', templatePackageManager.name)}, but ${styleText('cyan', packageManagerArg)} was requested. Skipping dependency installation to avoid installing against ${styleText('cyan', templatePackageManager.name)}'s lockfile and config. Reconcile the package manager (or use ${styleText('cyan', templatePackageManager.name)}) and install manually.`)
       }
     }
     else if (templatePackageManager) {
@@ -516,7 +516,7 @@ export default defineCommand({
       const pinned = templatePackageManager.version
         ? `${templatePackageManager.name}@${templatePackageManager.version}`
         : templatePackageManager.name
-      logger.info(`Using ${colors.cyan(pinned)} as configured by the ${colors.cyan(template.name)} template.`)
+      logger.info(`Using ${styleText('cyan', pinned)} as configured by the ${styleText('cyan', template.name)} template.`)
     }
     else if (isNonInteractive) {
       // No explicit `--packageManager`, the template pins none, and we can't
@@ -541,7 +541,7 @@ export default defineCommand({
     }
 
     if (selectedPackageManager === 'yarn' && await useYarnNodeModulesLinker(template.dir)) {
-      logger.info(`Created ${colors.cyan('.yarnrc.yml')} with ${colors.cyan('nodeLinker: node-modules')}, as Nuxt cannot resolve its modules under Yarn's Plug'n'Play linker.`)
+      logger.info(`Created ${styleText('cyan', '.yarnrc.yml')} with ${styleText('cyan', 'nodeLinker: node-modules')}, as Nuxt cannot resolve its modules under Yarn's Plug'n'Play linker.`)
     }
 
     // Determine if we should init git
@@ -575,7 +575,7 @@ export default defineCommand({
         onCancel: () => installController.abort(),
       })
 
-      installSpinner.start(`Installing dependencies with ${colors.cyan(selectedPackageManager)}`)
+      installSpinner.start(`Installing dependencies with ${styleText('cyan', selectedPackageManager)}`)
 
       const result = await runInstall({
         cwd: template.dir,
@@ -609,14 +609,14 @@ export default defineCommand({
         }
         else {
           gitSpinner.error('Git initialization failed')
-          logger.message(git.stderr.trim().split('\n'), { symbol: colors.gray(S_BAR) })
+          logger.message(git.stderr.trim().split('\n'), { symbol: styleText('gray', S_BAR) })
         }
       }
 
       // `approve-builds` is a pnpm command, so only pnpm gets the offer even if
       // another package manager ever prints the same notice.
       if (ignoredBuilds.length > 0 && selectedPackageManager === 'pnpm') {
-        logger.warn(`${colors.cyan('pnpm')} did not run build scripts for ${ignoredBuilds.map(name => colors.cyan(name)).join(', ')}.`)
+        logger.warn(`${styleText('cyan', 'pnpm')} did not run build scripts for ${ignoredBuilds.map(name => styleText('cyan', name)).join(', ')}.`)
 
         const approve = isNonInteractive
           ? false
@@ -645,7 +645,7 @@ export default defineCommand({
     // adding them to `nuxt.config` anyway would leave it unable to boot.
     if (installFailure) {
       if (requestedModules.length) {
-        logger.warn(`Skipping module installation. Add ${requestedModules.map(mod => colors.cyan(mod)).join(', ')} with ${colors.cyan('nuxt module add')} once dependencies are installed.`)
+        logger.warn(`Skipping module installation. Add ${requestedModules.map(mod => styleText('cyan', mod)).join(', ')} with ${styleText('cyan', 'nuxt module add')} once dependencies are installed.`)
       }
     }
 
@@ -719,7 +719,7 @@ export default defineCommand({
             const { toInstall, skipped } = filterModules(modules, allDependencies)
 
             if (skipped.length) {
-              logger.info(`The following modules are already included as dependencies of another module and will not be installed: ${skipped.map(m => colors.cyan(m)).join(', ')}`)
+              logger.info(`The following modules are already included as dependencies of another module and will not be installed: ${skipped.map(m => styleText('cyan', m)).join(', ')}`)
             }
             modulesToAdd.push(...toInstall)
           }
@@ -741,10 +741,10 @@ export default defineCommand({
     }
 
     if (installFailure) {
-      logger.warn(`Created your project from the ${colors.cyan(template.name)} template, but its dependencies are not installed.`)
+      logger.warn(`Created your project from the ${styleText('cyan', template.name)} template, but its dependencies are not installed.`)
     }
     else {
-      logger.step(`Created your project from the ${colors.cyan(template.name)} template`)
+      logger.step(`Created your project from the ${styleText('cyan', template.name)} template`)
     }
 
     // The command carries no `--cwd`, so both it and the next steps are
@@ -769,7 +769,7 @@ export default defineCommand({
       })
       logger.info([
         'to scaffold this project again without prompts:',
-        ...headlessCommand.map(line => colors.dim(line)),
+        ...headlessCommand.map(line => styleText('dim', line)),
       ].join('\n'))
     }
 
@@ -783,8 +783,8 @@ export default defineCommand({
 
     logger.message([
       'Next steps:',
-      ...nextSteps.map(step => `› ${colors.cyan(step)}`),
-    ], { symbol: colors.gray(S_BAR) })
+      ...nextSteps.map(step => `› ${styleText('cyan', step)}`),
+    ], { symbol: styleText('gray', S_BAR) })
 
     outro('✨ Happy building!')
 
@@ -806,7 +806,7 @@ async function getModuleDependencies(moduleName: string) {
     return Object.keys(dependencies)
   }
   catch (err) {
-    logNetworkError(err, { url, level: 'warn', prefix: `Could not get dependencies for ${colors.cyan(moduleName)}.` })
+    logNetworkError(err, { url, level: 'warn', prefix: `Could not get dependencies for ${styleText('cyan', moduleName)}.` })
     return []
   }
 }

--- a/packages/nuxt-cli/src/commands/module/_utils.ts
+++ b/packages/nuxt-cli/src/commands/module/_utils.ts
@@ -3,9 +3,9 @@ import type { PackageJson } from 'pkg-types'
 
 import { existsSync } from 'node:fs'
 
+import { styleText } from 'node:util'
 import { confirm, isCancel } from '@clack/prompts'
 import { resolve } from 'pathe'
-import colors from 'picocolors'
 import { satisfies } from 'verkit'
 
 import { fetchJson } from '../../utils/fetch'
@@ -253,7 +253,7 @@ export async function ensureNuxtDependency(cwd: string, projectPkg: PackageJson)
     return true
   }
 
-  logger.warn(`No ${colors.cyan('nuxt')} dependency detected in ${colors.cyan(relativeToProcess(cwd))}.`)
+  logger.warn(`No ${styleText('cyan', 'nuxt')} dependency detected in ${styleText('cyan', relativeToProcess(cwd))}.`)
 
   const shouldContinue = await confirm({
     message: `Do you want to continue anyway?`,

--- a/packages/nuxt-cli/src/commands/module/add.ts
+++ b/packages/nuxt-cli/src/commands/module/add.ts
@@ -6,11 +6,11 @@ import type { RegistryMeta } from '../../utils/registry'
 import type { NuxtModule } from './_utils'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, confirm, isCancel, select, spinner } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { detectPackageManager, packageManagers } from 'nypm'
 import { resolve } from 'pathe'
-import colors from 'picocolors'
 import { readPackageJSON } from 'pkg-types'
 import { joinURL } from 'ufo'
 import { satisfies } from 'verkit'
@@ -134,7 +134,7 @@ export function defineAddCommand({ layers = false }: { layers?: boolean } = {}) 
         process.exit(1)
       }
 
-      logger.info(`Resolved ${resolvedModules.map(x => colors.cyan(x.specifier)).join(', ')}, adding ${describeModules(resolvedModules)}...`)
+      logger.info(`Resolved ${resolvedModules.map(x => styleText('cyan', x.specifier)).join(', ')}, adding ${describeModules(resolvedModules)}...`)
 
       const added = await addModules(resolvedModules, { ...ctx.args, cwd }, projectPkg)
 
@@ -171,7 +171,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
     }
 
     if (installedModules.length > 0) {
-      const installedModulesList = installedModules.map(module => colors.cyan(module.pkgName)).join(', ')
+      const installedModulesList = installedModules.map(module => styleText('cyan', module.pkgName)).join(', ')
       const are = installedModules.length > 1 ? 'are' : 'is'
       logger.info(`${installedModulesList} ${are} already installed`)
     }
@@ -179,7 +179,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
     if (notInstalledModules.length > 0) {
       const isDev = Boolean(projectPkg.devDependencies?.nuxt) || dev
 
-      const notInstalledModulesList = notInstalledModules.map(module => colors.cyan(module.pkg)).join(', ')
+      const notInstalledModulesList = notInstalledModules.map(module => styleText('cyan', module.pkg)).join(', ')
       const dependency = notInstalledModules.length > 1 ? 'dependencies' : 'dependency'
       const a = notInstalledModules.length > 1 ? '' : ' a'
       logger.info(`Installing ${notInstalledModulesList} as${a}${isDev ? ' development' : ''} ${dependency}`)
@@ -188,7 +188,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
 
       const peers = resolveRequiredPeerDependencies(notInstalledModules, dependencies)
       if (peers.length > 0) {
-        logger.info(`Also installing required peer ${peers.length > 1 ? 'dependencies' : 'dependency'} ${peers.map(peer => colors.cyan(peer)).join(', ')}`)
+        logger.info(`Also installing required peer ${peers.length > 1 ? 'dependencies' : 'dependency'} ${peers.map(peer => styleText('cyan', peer)).join(', ')}`)
       }
 
       const verbose = logLevel === 'verbose' || Boolean(process.env.DEBUG)
@@ -198,7 +198,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
         indicator: 'timer',
         onCancel: () => installController.abort(),
       })
-      installSpinner.start(`Installing with ${colors.cyan(packageManager.name)}`)
+      installSpinner.start(`Installing with ${styleText('cyan', packageManager.name)}`)
 
       const result = await runInstall({
         cwd,
@@ -216,7 +216,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
         installLog.finish(result)
         // Adding modules to `nuxt.config` without their packages installed
         // leaves a project that cannot boot, so stop here instead.
-        logger.info(`${colors.cyan('nuxt.config')} was left unchanged. Resolve the install error and try again.`)
+        logger.info(`${styleText('cyan', 'nuxt.config')} was left unchanged. Resolve the install error and try again.`)
         return false
       }
 
@@ -225,7 +225,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
 
       const ignoredBuilds = takeUnreportedIgnoredBuilds(result.ignoredBuilds)
       if (ignoredBuilds.length > 0 && packageManager.name === 'pnpm') {
-        logger.warn(`${colors.cyan('pnpm')} did not run build scripts for ${ignoredBuilds.map(name => colors.cyan(name)).join(', ')}. Run ${colors.cyan('pnpm approve-builds')} if your project needs them.`)
+        logger.warn(`${styleText('cyan', 'pnpm')} did not run build scripts for ${ignoredBuilds.map(name => styleText('cyan', name)).join(', ')}. Run ${styleText('cyan', 'pnpm approve-builds')} if your project needs them.`)
       }
     }
   }
@@ -235,7 +235,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
     try {
       let config = await readNuxtConfig(cwd)
       if (!config) {
-        logger.info(`Creating ${colors.cyan('nuxt.config.ts')}`)
+        logger.info(`Creating ${styleText('cyan', 'nuxt.config.ts')}`)
         config = await createNuxtConfig(cwd, getDefaultNuxtConfig())
       }
 
@@ -243,12 +243,12 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
       for (const resolved of modules) {
         const key = resolved.isLayer ? 'extends' : 'modules'
         if (config[key].includes(resolved.specifier)) {
-          logger.info(`${colors.cyan(resolved.specifier)} is already in the ${colors.cyan(key)}`)
+          logger.info(`${styleText('cyan', resolved.specifier)} is already in the ${styleText('cyan', key)}`)
 
           continue
         }
 
-        logger.info(`Adding ${colors.cyan(resolved.specifier)} to the ${colors.cyan(key)}`)
+        logger.info(`Adding ${styleText('cyan', resolved.specifier)} to the ${styleText('cyan', key)}`)
 
         toAdd[key] = [...toAdd[key] ?? [], resolved.specifier]
       }
@@ -256,8 +256,8 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
       await addNuxtConfigEntries(config, toAdd)
     }
     catch (error) {
-      logger.error(`Failed to update ${colors.cyan('nuxt.config')}: ${(error as Error).message}`)
-      logger.error(`Please manually add ${colors.cyan(modules.map(module => module.specifier).join(', '))} to ${colors.cyan('nuxt.config.ts')}`)
+      logger.error(`Failed to update ${styleText('cyan', 'nuxt.config')}: ${(error as Error).message}`)
+      logger.error(`Please manually add ${styleText('cyan', modules.map(module => module.specifier).join(', '))} to ${styleText('cyan', 'nuxt.config.ts')}`)
     }
   }
 
@@ -274,7 +274,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
 async function resolvePackageManager(cwd: string, name?: string): Promise<PackageManager> {
   const requested = name ? packageManagers.find(pm => pm.name === name) : undefined
   if (name && !requested) {
-    logger.warn(`Unknown package manager ${colors.cyan(name)}, detecting one instead.`)
+    logger.warn(`Unknown package manager ${styleText('cyan', name)}, detecting one instead.`)
   }
 
   const detected = await detectPackageManager(cwd, { includeParentDirs: false })
@@ -346,7 +346,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   const spec = parseModuleSpec(moduleName)
 
   if (!spec) {
-    logger.error(`Invalid package name ${colors.cyan(moduleName)}.`)
+    logger.error(`Invalid package name ${styleText('cyan', moduleName)}.`)
     return false
   }
 
@@ -383,7 +383,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
     // Check for Module Compatibility
     if (!checkNuxtCompatibility(matchedModule, nuxtVersion)) {
       logger.warn(
-        `The module ${colors.cyan(pkgName)} is not compatible with Nuxt ${colors.cyan(nuxtVersion)} (requires ${colors.cyan(matchedModule.compatibility.nuxt)})`,
+        `The module ${styleText('cyan', pkgName)} is not compatible with Nuxt ${styleText('cyan', nuxtVersion)} (requires ${styleText('cyan', matchedModule.compatibility.nuxt)})`,
       )
       const shouldContinue = await confirm({
         message: 'Do you want to continue installing incompatible version?',
@@ -404,7 +404,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
           }
           else {
             logger.warn(
-              `Recommended version of ${colors.cyan(pkgName)} for Nuxt ${colors.cyan(nuxtVersion)} is ${colors.cyan(_moduleVersion)} but you have requested ${colors.cyan(pkgVersion)}.`,
+              `Recommended version of ${styleText('cyan', pkgName)} for Nuxt ${styleText('cyan', nuxtVersion)} is ${styleText('cyan', _moduleVersion)} but you have requested ${styleText('cyan', pkgVersion)}.`,
             )
             const result = await select({
               message: 'Choose a version:',
@@ -437,7 +437,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   // TODO: spinner
   const pkgUrl = joinURL(meta.registry, `${pkgName}`)
   const pkgDetails = await fetchJson<any>(pkgUrl, { headers }).catch((err: unknown) => {
-    logNetworkError(err, { url: pkgUrl, prefix: `Failed to fetch package details for ${colors.cyan(pkgName)}.` })
+    logNetworkError(err, { url: pkgUrl, prefix: `Failed to fetch package details for ${styleText('cyan', pkgName)}.` })
     return null
   })
   if (!pkgDetails) {
@@ -460,7 +460,7 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
   }
 
   if (entry.isLayer) {
-    logger.info(`${colors.cyan(pkgName)} is a Nuxt layer, and will be added to ${colors.cyan('extends')}.`)
+    logger.info(`${styleText('cyan', pkgName)} is a Nuxt layer, and will be added to ${styleText('cyan', 'extends')}.`)
   }
 
   const pkgDependencies = Object.assign(
@@ -476,9 +476,9 @@ async function resolveModule(moduleName: string, cwd: string): Promise<ModuleRes
     && !pkgDependencies.nuxt
     && !pkgDependencies['@nuxt/kit']
   ) {
-    logger.warn(`It seems that ${colors.cyan(pkgName)} is not a Nuxt module.`)
+    logger.warn(`It seems that ${styleText('cyan', pkgName)} is not a Nuxt module.`)
     const shouldContinue = await confirm({
-      message: `Do you want to continue installing ${colors.cyan(pkgName)} anyway?`,
+      message: `Do you want to continue installing ${styleText('cyan', pkgName)} anyway?`,
       initialValue: false,
     })
     if (isCancel(shouldContinue) || !shouldContinue) {

--- a/packages/nuxt-cli/src/commands/module/remove.ts
+++ b/packages/nuxt-cli/src/commands/module/remove.ts
@@ -5,11 +5,11 @@ import type { NuxtModule } from './_utils'
 
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, confirm, isCancel, multiselect } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { detectPackageManager, removeDependency } from 'nypm'
 import { resolve } from 'pathe'
-import colors from 'picocolors'
 import { readPackageJSON } from 'pkg-types'
 
 import { runCommandDef as runCommand } from '../../run-command'
@@ -60,7 +60,7 @@ export default defineCommand({
     }
 
     if (ctx.args.skipConfig && modules.length === 0) {
-      cancel(`Specify one or more modules to remove when ${colors.cyan('--skipConfig')} is set.`)
+      cancel(`Specify one or more modules to remove when ${styleText('cyan', '--skipConfig')} is set.`)
       process.exit(1)
     }
 
@@ -79,7 +79,7 @@ export default defineCommand({
     const resolvedModules = modules.map(m => resolveModuleName(m, modulesDB, installedNames))
 
     if (resolvedModules.length > 0) {
-      logger.info(`Resolved ${resolvedModules.map(x => colors.cyan(x)).join(', ')}, removing...`)
+      logger.info(`Resolved ${resolvedModules.map(x => styleText('cyan', x)).join(', ')}, removing...`)
     }
 
     const proceed = await removeModules(resolvedModules, { ...ctx.args, cwd }, projectPkg)
@@ -102,7 +102,7 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
 
   if (!skipConfig) {
     const config = await readNuxtConfig(cwd).catch((error) => {
-      logger.error(`Failed to read ${colors.cyan('nuxt.config')}: ${(error as Error).message}`)
+      logger.error(`Failed to read ${styleText('cyan', 'nuxt.config')}: ${(error as Error).message}`)
       return undefined
     })
 
@@ -134,22 +134,22 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
           continue
         }
         for (const name of names) {
-          logger.info(`Removing ${colors.cyan(name)} from the ${colors.cyan(key)}`)
+          logger.info(`Removing ${styleText('cyan', name)} from the ${styleText('cyan', key)}`)
         }
         doomed[key] = names
         removedFromConfig.push(...names)
       }
 
       await removeNuxtConfigEntries(config, doomed).catch((error) => {
-        logger.error(`Failed to update ${colors.cyan('nuxt.config')}: ${(error as Error).message}`)
-        logger.error(`Please manually remove ${colors.cyan(modules.join(', ') || 'the relevant modules')} from ${colors.cyan('nuxt.config.ts')}`)
+        logger.error(`Failed to update ${styleText('cyan', 'nuxt.config')}: ${(error as Error).message}`)
+        logger.error(`Please manually remove ${styleText('cyan', modules.join(', ') || 'the relevant modules')} from ${styleText('cyan', 'nuxt.config.ts')}`)
       })
     }
 
     if (modules.length === 0 && removedFromConfig.length === 0) {
       cancel(config
-        ? `No modules configured in ${colors.cyan('nuxt.config')}.`
-        : `No ${colors.cyan('nuxt.config')} found in ${colors.cyan(relativeToProcess(cwd))}.`)
+        ? `No modules configured in ${styleText('cyan', 'nuxt.config')}.`
+        : `No ${styleText('cyan', 'nuxt.config')} found in ${styleText('cyan', relativeToProcess(cwd))}.`)
       return false
     }
   }
@@ -175,7 +175,7 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
     }
 
     if (notInstalledModules.length > 0) {
-      const notInstalledList = notInstalledModules.map(m => colors.cyan(m)).join(', ')
+      const notInstalledList = notInstalledModules.map(m => styleText('cyan', m)).join(', ')
       const are = notInstalledModules.length > 1 ? 'are' : 'is'
       logger.info(`${notInstalledList} ${are} not installed as a dependency`)
     }
@@ -189,7 +189,7 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
     const orphanedPeers = await findOrphanedPeers(installedModules, projectPkg, cwd)
     if (orphanedPeers.length > 0) {
       const peersList = orphanedPeers.map(({ peer, source }) =>
-        `${colors.cyan(peer)} (peer of ${colors.cyan(source)})`).join(', ')
+        `${styleText('cyan', peer)} (peer of ${styleText('cyan', source)})`).join(', ')
       const peerDep = orphanedPeers.length > 1 ? 'dependencies' : 'dependency'
       const them = orphanedPeers.length > 1 ? 'them' : 'it'
 
@@ -210,7 +210,7 @@ async function removeModules(modules: string[], { skipInstall = false, skipConfi
       }
     }
 
-    const removeList = toRemove.map(m => colors.cyan(m)).join(', ')
+    const removeList = toRemove.map(m => styleText('cyan', m)).join(', ')
     const dependency = toRemove.length > 1 ? 'dependencies' : 'dependency'
     logger.info(`Uninstalling ${removeList} ${dependency}`)
 

--- a/packages/nuxt-cli/src/commands/module/search.ts
+++ b/packages/nuxt-cli/src/commands/module/search.ts
@@ -1,9 +1,9 @@
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { box } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { byLengthAsc, Fzf } from 'fzf'
-import colors from 'picocolors'
 import { kebabCase, upperFirst } from 'scule'
 
 import { formatInfoBox } from '../../utils/formatting'
@@ -72,13 +72,13 @@ async function findModuleByKeywords(query: string, nuxtVersion: string) {
     const res: Record<string, string> = {
       name: item.name,
       package: item.npm,
-      homepage: colors.cyan(item.website),
+      homepage: styleText('cyan', item.website),
       compatibility: `nuxt: ${item.compatibility?.nuxt || '*'}`,
       repository: item.github,
       description: item.description,
       install: `npx nuxt add ${item.name}`,
-      stars: colors.yellow(formatNumber(item.stats.stars)),
-      monthlyDownloads: colors.yellow(formatNumber(item.stats.downloads)),
+      stars: styleText('yellow', formatNumber(item.stats.stars)),
+      monthlyDownloads: styleText('yellow', formatNumber(item.stats.downloads)),
     }
     if (item.github === item.website) {
       delete res.homepage
@@ -91,13 +91,13 @@ async function findModuleByKeywords(query: string, nuxtVersion: string) {
 
   if (!results.length) {
     logger.info(
-      `No Nuxt modules found matching query ${colors.magenta(query)} for Nuxt ${colors.cyan(nuxtVersion)}`,
+      `No Nuxt modules found matching query ${styleText('magenta', query)} for Nuxt ${styleText('cyan', nuxtVersion)}`,
     )
     return
   }
 
   logger.success(
-    `Found ${results.length} Nuxt ${results.length > 1 ? 'modules' : 'module'} matching ${colors.cyan(query)} ${nuxtVersion ? `for Nuxt ${colors.cyan(nuxtVersion)}` : ''}:\n`,
+    `Found ${results.length} Nuxt ${results.length > 1 ? 'modules' : 'module'} matching ${styleText('cyan', query)} ${nuxtVersion ? `for Nuxt ${styleText('cyan', nuxtVersion)}` : ''}:\n`,
   )
   for (const foundModule of results) {
     const formattedModule: Record<string, string> = {}

--- a/packages/nuxt-cli/src/commands/prepare.ts
+++ b/packages/nuxt-cli/src/commands/prepare.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { defineCommand } from 'citty'
-import colors from 'picocolors'
 
 import { clearBuildDir } from '../utils/fs'
 import { loadKit } from '../utils/kit'
@@ -45,6 +45,6 @@ export default defineCommand({
 
     await buildNuxt(nuxt)
     await writeTypes(nuxt)
-    logger.success(`Types generated in ${colors.cyan(relativeToProcess(nuxt.options.buildDir))}.`)
+    logger.success(`Types generated in ${styleText('cyan', relativeToProcess(nuxt.options.buildDir))}.`)
   },
 })

--- a/packages/nuxt-cli/src/commands/preview.ts
+++ b/packages/nuxt-cli/src/commands/preview.ts
@@ -2,10 +2,10 @@ import { existsSync, promises as fsp } from 'node:fs'
 import { dirname } from 'node:path'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { box, outro } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { resolve } from 'pathe'
-import colors from 'picocolors'
 import { x } from 'tinyexec'
 
 import { loadKit } from '../utils/kit'
@@ -73,7 +73,7 @@ const command = defineCommand({
     const nitroJSONPath = nitroJSONPaths.find(p => existsSync(p))
     if (!nitroJSONPath) {
       logger.error(
-        `Cannot find ${colors.cyan('nitro.json')}. Did you run ${colors.cyan('nuxt build')} first? Search path:\n${nitroJSONPaths.join('\n')}`,
+        `Cannot find ${styleText('cyan', 'nitro.json')}. Did you run ${styleText('cyan', 'nuxt build')} first? Search path:\n${nitroJSONPaths.join('\n')}`,
       )
       process.exit(1)
     }
@@ -97,15 +97,15 @@ const command = defineCommand({
       [
         '',
         'You are previewing a Nuxt app. In production, do not use this CLI. ',
-        `Instead, run ${colors.cyan(nitroJSON.commands.preview)} directly.`,
+        `Instead, run ${styleText('cyan', nitroJSON.commands.preview)} directly.`,
         '',
         ...info.map(
           ([label, value]) =>
-            `${label.padEnd(_infoKeyLen, ' ')} ${colors.cyan(value)}`,
+            `${label.padEnd(_infoKeyLen, ' ')} ${styleText('cyan', value)}`,
         ),
         '',
       ].join('\n'),
-      colors.yellow(' Previewing Nuxt app '),
+      styleText('yellow', ' Previewing Nuxt app '),
       {
         contentAlign: 'left',
         titleAlign: 'left',
@@ -114,7 +114,7 @@ const command = defineCommand({
         contentPadding: 2,
         rounded: true,
         withGuide: true,
-        formatBorder: (text: string) => colors.yellow(text),
+        formatBorder: (text: string) => styleText('yellow', text),
       },
     )
 
@@ -125,17 +125,17 @@ const command = defineCommand({
     if (envExists) {
       if (envLoaded) {
         logger.info(
-          `Loaded ${colors.cyan(envFileName)}. This will not be loaded when running the server in production.`,
+          `Loaded ${styleText('cyan', envFileName)}. This will not be loaded when running the server in production.`,
         )
       }
       else {
         logger.warn(
-          `Could not load Nuxt, so ${colors.cyan(envFileName)} may not be fully applied to the preview server.`,
+          `Could not load Nuxt, so ${styleText('cyan', envFileName)} may not be fully applied to the preview server.`,
         )
       }
     }
     else if (ctx.args.dotenv) {
-      logger.error(`Cannot find ${colors.cyan(envFileName)}.`)
+      logger.error(`Cannot find ${styleText('cyan', envFileName)}.`)
     }
 
     const port = ctx.args.port
@@ -143,7 +143,7 @@ const command = defineCommand({
       ?? process.env.NITRO_PORT
       ?? process.env.PORT
 
-    outro(`Running ${colors.cyan(nitroJSON.commands.preview)} in ${colors.cyan(relativeToProcess(outputPath))}`)
+    outro(`Running ${styleText('cyan', nitroJSON.commands.preview)} in ${styleText('cyan', relativeToProcess(outputPath))}`)
 
     const [command, ...commandArgs] = nitroJSON.commands.preview.split(' ')
     await x(command, commandArgs, {

--- a/packages/nuxt-cli/src/commands/typecheck.ts
+++ b/packages/nuxt-cli/src/commands/typecheck.ts
@@ -3,12 +3,12 @@ import { existsSync, readFileSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, confirm, isCancel, select, spinner } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { resolveModulePath } from 'exsolve'
 import { addDevDependency, detectPackageManager } from 'nypm'
 import { dirname, resolve } from 'pathe'
-import colors from 'picocolors'
 import { readPackageJSON, readTSConfig } from 'pkg-types'
 import { hasTTY } from 'std-env'
 import { x } from 'tinyexec'
@@ -84,7 +84,7 @@ const TYPE_CHECKERS: Record<TypeChecker, TypeCheckerBackend> = {
     packages: ['golar', '@golar/vue'],
     docs: 'https://golar.dev/languages/vue/',
     configFiles: GOLAR_CONFIG_FILES,
-    configNote: `Golar also requires a ${colors.cyan('golar.config.ts')} file. One will be created automatically the first time Golar is used.`,
+    configNote: `Golar also requires a ${styleText('cyan', 'golar.config.ts')} file. One will be created automatically the first time Golar is used.`,
     resolve(cwd, { cache = true } = {}) {
       const bin = resolveGolarBin(cwd)
       const vuePlugin = resolveModulePath('@golar/vue', { from: withNodePath(cwd), try: true, cache })
@@ -130,7 +130,7 @@ export default defineCommand({
 
     const checkerArg = ctx.args.checker
     if (checkerArg && !Object.hasOwn(TYPE_CHECKERS, checkerArg)) {
-      logger.error(`Unknown type checker ${colors.cyan(checkerArg)}. Expected one of: ${CHECKER_PRIORITY.join(', ')}.`)
+      logger.error(`Unknown type checker ${styleText('cyan', checkerArg)}. Expected one of: ${CHECKER_PRIORITY.join(', ')}.`)
       process.exitCode = 1
       return
     }
@@ -152,7 +152,7 @@ export default defineCommand({
     const useProjectReferences = ctx.args.build ?? supportsProjectReferences(tsConfig)
 
     if (ctx.args.build === undefined && !useProjectReferences && hasNuxtProjectReferences(tsConfig)) {
-      logger.warn(`Your ${colors.cyan('tsconfig.json')} references Nuxt's generated project configs but also includes source files of its own, so type-checking will not run in build mode. Add ${colors.cyan('"files": []')} to your ${colors.cyan('tsconfig.json')}, or pass ${colors.cyan('--build')} to override.`)
+      logger.warn(`Your ${styleText('cyan', 'tsconfig.json')} references Nuxt's generated project configs but also includes source files of its own, so type-checking will not run in build mode. Add ${styleText('cyan', '"files": []')} to your ${styleText('cyan', 'tsconfig.json')}, or pass ${styleText('cyan', '--build')} to override.`)
     }
 
     const start = Date.now()
@@ -163,13 +163,13 @@ export default defineCommand({
 
     if (result.exitCode === 0) {
       if (hasTTY) {
-        logger.success(`Type check passed in ${colors.cyan(duration)}.`)
+        logger.success(`Type check passed in ${styleText('cyan', duration)}.`)
       }
       return
     }
 
     if (hasTTY) {
-      logger.error(`Type check failed in ${colors.cyan(duration)}.`)
+      logger.error(`Type check failed in ${styleText('cyan', duration)}.`)
     }
     process.exitCode = result.exitCode ?? 1
   },
@@ -249,7 +249,7 @@ async function ensureGolarConfig(cwd: string) {
   const pkg = await readPackageJSON(cwd).catch(() => null)
   const filename = pkg?.type === 'module' ? 'golar.config.ts' : 'golar.config.mts'
   await writeFile(resolve(cwd, filename), GOLAR_CONFIG_TEMPLATE)
-  logger.info(`Created ${colors.cyan(filename)}`)
+  logger.info(`Created ${styleText('cyan', filename)}`)
 }
 
 async function promptTypeCheckerInstall(cwd: string, preferred?: TypeChecker): Promise<TypeCheckerSetup | undefined> {
@@ -265,7 +265,7 @@ async function promptTypeCheckerInstall(cwd: string, preferred?: TypeChecker): P
 
   let selected = preferred
   if (!selected) {
-    logger.warn(`No type checker found for ${colors.cyan('nuxt typecheck')}.`)
+    logger.warn(`No type checker found for ${styleText('cyan', 'nuxt typecheck')}.`)
 
     const answer = await select<TypeChecker>({
       message: 'Which type checker would you like to use?',
@@ -302,7 +302,7 @@ async function promptTypeCheckerInstall(cwd: string, preferred?: TypeChecker): P
 
   const resolved = TYPE_CHECKERS[selected].resolve(cwd, { cache: false })
   if (!resolved.bin) {
-    logger.error(`Failed to resolve ${colors.cyan(selected)} after installation. Please check your installation.`)
+    logger.error(`Failed to resolve ${styleText('cyan', selected)} after installation. Please check your installation.`)
     return
   }
 
@@ -312,13 +312,13 @@ async function promptTypeCheckerInstall(cwd: string, preferred?: TypeChecker): P
 }
 
 function printInstallInstructions(pmCommand: string, devFlag: string, checkers: readonly TypeChecker[]) {
-  logger.error(`A type checker is required for ${colors.cyan('nuxt typecheck')}. Install ${checkers.length > 1 ? 'one of the following' : 'it as a devDependency'}:\n`)
+  logger.error(`A type checker is required for ${styleText('cyan', 'nuxt typecheck')}. Install ${checkers.length > 1 ? 'one of the following' : 'it as a devDependency'}:\n`)
 
   for (const checker of checkers) {
     const meta = TYPE_CHECKERS[checker]
     const command = formatInstallCommand(checker, pmCommand, devFlag)
-    const docs = meta.docs ? ` (see ${colors.cyan(meta.docs)})` : ''
-    logger.info(`${colors.cyan(meta.label)}${docs}:\n\n  ${colors.bold(command)}\n`)
+    const docs = meta.docs ? ` (see ${styleText('cyan', meta.docs)})` : ''
+    logger.info(`${styleText('cyan', meta.label)}${docs}:\n\n  ${styleText('bold', command)}\n`)
     if (meta.configNote) {
       logger.info(`${meta.configNote}\n`)
     }
@@ -337,7 +337,7 @@ async function installMissingPackages(options: {
   installCommand: string
 }): Promise<boolean> {
   const { cwd, packageManager, pmName, packages, installCommand } = options
-  const list = packages.map(name => colors.cyan(name)).join(' and ')
+  const list = packages.map(name => styleText('cyan', name)).join(' and ')
   const plural = packages.length > 1
   const devDependency = plural ? 'devDependencies' : 'a devDependency'
 
@@ -347,12 +347,12 @@ async function installMissingPackages(options: {
   })
 
   if (isCancel(shouldInstall) || !shouldInstall) {
-    cancel(`Skipping installation. Run ${colors.bold(installCommand)} to install manually.`)
+    cancel(`Skipping installation. Run ${styleText('bold', installCommand)} to install manually.`)
     return false
   }
 
   const spin = spinner()
-  spin.start(`Installing ${list} with ${colors.cyan(pmName)}`)
+  spin.start(`Installing ${list} with ${styleText('cyan', pmName)}`)
   try {
     await addDevDependency(packages, { cwd, packageManager, silent: true })
     spin.stop(`Installed ${list}`)
@@ -361,7 +361,7 @@ async function installMissingPackages(options: {
   catch (error) {
     spin.error(`Failed to install ${list}`)
     logger.error(error instanceof Error ? error.message : String(error))
-    logger.info(`You can install ${plural ? 'them' : 'it'} manually with:\n\n  ${colors.bold(installCommand)}\n`)
+    logger.info(`You can install ${plural ? 'them' : 'it'} manually with:\n\n  ${styleText('bold', installCommand)}\n`)
     return false
   }
 }

--- a/packages/nuxt-cli/src/commands/upgrade.ts
+++ b/packages/nuxt-cli/src/commands/upgrade.ts
@@ -6,11 +6,11 @@ import type { InstallResult } from '../utils/install'
 import { existsSync } from 'node:fs'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { cancel, intro, isCancel, note, outro, select, spinner } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { detectPackageManager } from 'nypm'
 import { dirname, relative, resolve } from 'pathe'
-import colors from 'picocolors'
 import { findWorkspaceDir, readPackageJSON } from 'pkg-types'
 
 import { resolveCatalogEntry, updateCatalogEntries } from '../utils/catalog'
@@ -171,24 +171,24 @@ export default defineCommand({
   async run(ctx) {
     const cwd = resolveRootDir(ctx.args)
 
-    intro(colors.cyan('Upgrading Nuxt ...'))
+    intro(styleText('cyan', 'Upgrading Nuxt ...'))
 
     // Check package manager
     const [packageManager, workspaceDir = cwd] = await Promise.all([detectPackageManager(cwd), findWorkspaceDir(cwd, { try: true })])
     if (!packageManager) {
       logger.error(
-        `Unable to determine the package manager used by this project.\n\nNo lock files found in ${colors.cyan(relativeToProcess(cwd))}, and no ${colors.cyan('packageManager')} field specified in ${colors.cyan('package.json')}.`,
+        `Unable to determine the package manager used by this project.\n\nNo lock files found in ${styleText('cyan', relativeToProcess(cwd))}, and no ${styleText('cyan', 'packageManager')} field specified in ${styleText('cyan', 'package.json')}.`,
       )
-      logger.info(`Please either add the ${colors.cyan('packageManager')} field to ${colors.cyan('package.json')} or execute the installation command for your package manager. For example, you can use ${colors.cyan('pnpm i')}, ${colors.cyan('npm i')}, ${colors.cyan('bun i')}, or ${colors.cyan('yarn i')}, and then try again.`)
+      logger.info(`Please either add the ${styleText('cyan', 'packageManager')} field to ${styleText('cyan', 'package.json')} or execute the installation command for your package manager. For example, you can use ${styleText('cyan', 'pnpm i')}, ${styleText('cyan', 'npm i')}, ${styleText('cyan', 'bun i')}, or ${styleText('cyan', 'yarn i')}, and then try again.`)
       process.exit(1)
     }
     const { name: packageManagerName, lockFile: lockFileCandidates } = packageManager
     const packageManagerVersion = getPackageManagerVersion(packageManagerName)
-    logger.step(`Package manager: ${colors.cyan(packageManagerName)} ${packageManagerVersion}`)
+    logger.step(`Package manager: ${styleText('cyan', packageManagerName)} ${packageManagerVersion}`)
 
     // Check currently installed Nuxt version
     const currentVersion = (await getNuxtVersion(cwd)) || '[unknown]'
-    logger.step(`Current Nuxt version: ${colors.cyan(currentVersion)}`)
+    logger.step(`Current Nuxt version: ${styleText('cyan', currentVersion)}`)
 
     const pkg = await readPackageJSON(cwd).catch(() => null)
 
@@ -227,13 +227,13 @@ export default defineCommand({
     else {
       logger.error(
         cwd === workspaceDir
-          ? `Unable to find a ${packageManagerName} lock file in ${colors.cyan(relativeToProcess(cwd))}.`
-          : `Unable to find a ${packageManagerName} lock file in ${colors.cyan(relativeToProcess(cwd))} or any directory up to ${colors.cyan(relativeToProcess(workspaceDir))}.`,
+          ? `Unable to find a ${packageManagerName} lock file in ${styleText('cyan', relativeToProcess(cwd))}.`
+          : `Unable to find a ${packageManagerName} lock file in ${styleText('cyan', relativeToProcess(cwd))} or any directory up to ${styleText('cyan', relativeToProcess(workspaceDir))}.`,
       )
     }
 
     const forceRemovals = toRemove
-      .map(p => colors.cyan(p))
+      .map(p => styleText('cyan', p))
       .join(' and ')
 
     let method: 'force' | 'dedupe' | 'skip' | undefined = ctx.args.force ? 'force' : ctx.args.dedupe ? 'dedupe' : undefined
@@ -300,12 +300,12 @@ export default defineCommand({
       )
 
       if (unresolved.length > 0) {
-        logger.warn(`Unable to resolve a ${versionType} version for ${unresolved.map(name => colors.cyan(name)).join(', ')} from the npm registry. Their catalog entries were left unchanged.`)
-        logger.info(`Run with ${colors.cyan('DEBUG=nuxi')} to see why the lookup failed.`)
+        logger.warn(`Unable to resolve a ${versionType} version for ${unresolved.map(name => styleText('cyan', name)).join(', ')} from the npm registry. Their catalog entries were left unchanged.`)
+        logger.info(`Run with ${styleText('cyan', 'DEBUG=nuxi')} to see why the lookup failed.`)
       }
 
       if (catalogResult === 'failed') {
-        logger.warn(`Unable to update the catalog entries for ${resolved.map(({ pkg }) => colors.cyan(pkg)).join(', ')}. Check ${colors.cyan('pnpm-workspace.yaml')} is readable and valid.`)
+        logger.warn(`Unable to update the catalog entries for ${resolved.map(({ pkg }) => styleText('cyan', pkg)).join(', ')}. Check ${styleText('cyan', 'pnpm-workspace.yaml')} is readable and valid.`)
       }
 
       // Without a catalog entry pointing at the new version there is nothing for
@@ -314,7 +314,7 @@ export default defineCommand({
         ? resolved.some(({ pkg }) => pkg === 'nuxt')
         : unresolved.includes('nuxt')
       if (nuxtUpgradeFailed) {
-        logger.error(`Unable to upgrade ${colors.cyan('nuxt')} in ${colors.cyan('pnpm-workspace.yaml')}.`)
+        logger.error(`Unable to upgrade ${styleText('cyan', 'nuxt')} in ${styleText('cyan', 'pnpm-workspace.yaml')}.`)
         outro('Upgrade cancelled.')
         process.exit(1)
       }
@@ -336,7 +336,7 @@ export default defineCommand({
 
     if (installFailed) {
       if (catalogResult === 'updated') {
-        logger.info(`Your ${colors.cyan('pnpm-workspace.yaml')} catalog entries were already updated, so review them before retrying.`)
+        logger.info(`Your ${styleText('cyan', 'pnpm-workspace.yaml')} catalog entries were already updated, so review them before retrying.`)
       }
       process.exit(1)
     }
@@ -370,7 +370,7 @@ export default defineCommand({
     cleanupSpinner.stop('Build directories cleaned')
 
     if (method === 'force') {
-      logger.info(`If you encounter any issues, revert the changes and try with ${colors.cyan('--no-force')}`)
+      logger.info(`If you encounter any issues, revert the changes and try with ${styleText('cyan', '--no-force')}`)
     }
 
     // Check installed Nuxt version again
@@ -381,11 +381,11 @@ export default defineCommand({
     }
 
     if (upgradedVersion === currentVersion) {
-      outro(`You were already using the latest version of Nuxt (${colors.green(currentVersion)})`)
+      outro(`You were already using the latest version of Nuxt (${styleText('green', currentVersion)})`)
     }
     else {
       logger.success(
-        `Successfully upgraded Nuxt from ${colors.cyan(currentVersion)} to ${colors.green(upgradedVersion)}`,
+        `Successfully upgraded Nuxt from ${styleText('cyan', currentVersion)} to ${styleText('green', upgradedVersion)}`,
       )
       if (currentVersion === '[unknown]') {
         return
@@ -444,7 +444,7 @@ async function withInstallSpinner(
 
   const ignoredBuilds = takeUnreportedIgnoredBuilds(result.ignoredBuilds)
   if (ignoredBuilds.length > 0) {
-    logger.warn(`Build scripts were not run for ${ignoredBuilds.map(name => colors.cyan(name)).join(', ')}.`)
+    logger.warn(`Build scripts were not run for ${ignoredBuilds.map(name => styleText('cyan', name)).join(', ')}.`)
   }
 
   return !result.success

--- a/packages/nuxt-cli/src/dev/inspect.ts
+++ b/packages/nuxt-cli/src/dev/inspect.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import { debug, logger } from '../utils/logger'
 
 export interface InspectOptions {
@@ -100,7 +100,7 @@ export async function openInspector(options: InspectOptions): Promise<void> {
     inspector.open(options.port, options.host, options.wait)
   }
   catch (error) {
-    logger.warn(`Could not start the inspector on ${colors.cyan(`${options.host}:${options.port}`)}: ${error instanceof Error ? error.message : error}`)
+    logger.warn(`Could not start the inspector on ${styleText('cyan', `${options.host}:${options.port}`)}: ${error instanceof Error ? error.message : error}`)
   }
 }
 

--- a/packages/nuxt-cli/src/dev/listen.ts
+++ b/packages/nuxt-cli/src/dev/listen.ts
@@ -9,8 +9,8 @@ import { createServer as createHttpsServer } from 'node:https'
 import { networkInterfaces } from 'node:os'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { getPort } from 'get-port-please'
-import colors from 'picocolors'
 
 import { debug, logger } from '../utils/logger'
 import { detectIsolatedEnvironment, isWsl } from './environment'
@@ -232,22 +232,22 @@ export async function listen(handler: RequestListener, options: ListenOptions = 
   function showURLs({ qr = false }: { qr?: boolean } = {}): void {
     const urls = getURLs()
     const labels = { local: 'Local:', network: 'Network:', tunnel: 'Tunnel:', public: 'Public:' } as const
-    const labelColors = { local: colors.green, network: colors.magenta, tunnel: colors.cyan, public: colors.magenta } as const
+    const labelColors = { local: 'green', network: 'magenta', tunnel: 'cyan', public: 'magenta' } as const
     const lines: string[] = []
     const line = (color: (text: string) => string, label: string, value: string, isQR: boolean) =>
-      `  ${color('➜')} ${colors.bold(color(label.padEnd(10)))}${value}${isQR ? colors.gray(' [QR code]') : ''}`
+      `  ${color('➜')} ${styleText('bold', color(label.padEnd(10)))}${value}${isQR ? styleText('gray', ' [QR code]') : ''}`
     for (const { url: displayURL, type } of urls) {
-      lines.push(line(labelColors[type], labels[type], colors.cyan(displayURL), qr && displayURL === qrURL))
+      lines.push(line(text => styleText(labelColors[type], text), labels[type], styleText('cyan', displayURL), qr && displayURL === qrURL))
     }
     if (!anyHost && !tunnel && !portless.url && !stackblitzURL) {
       const isolated = LOOPBACK_HOSTS.has(hostname) ? detectIsolatedEnvironment() : undefined
       const hint = isolated
-        ? `use ${colors.white('--host')} to reach this server from outside ${isolated}`
-        : `use ${colors.white('--host')} to expose`
-      lines.push(line(colors.magenta, 'Network:', colors.gray(hint), false))
+        ? `use ${styleText('white', '--host')} to reach this server from outside ${isolated}`
+        : `use ${styleText('white', '--host')} to expose`
+      lines.push(line(text => styleText('magenta', text), 'Network:', styleText('gray', hint), false))
     }
     if (publicURL && publicURL !== url && !urls.some(entry => entry.url === publicURL)) {
-      lines.push(line(colors.magenta, 'Public:', colors.cyan(publicURL), qr && publicURL === qrURL))
+      lines.push(line(text => styleText('magenta', text), 'Public:', styleText('cyan', publicURL), qr && publicURL === qrURL))
     }
     // eslint-disable-next-line no-console
     console.log(`${qr ? '' : '\n'}${lines.join('\n')}\n`)
@@ -416,7 +416,7 @@ function describeBindError(error: NodeJS.ErrnoException, port: number, hostname:
 
 export async function printQRCode(url: string, { showURL = false }: { showURL?: boolean } = {}): Promise<void> {
   const { renderUnicodeCompact } = await import('uqr')
-  const caption = showURL ? `\n${centerBlock(colors.cyan(url), url.length)}` : ''
+  const caption = showURL ? `\n${centerBlock(styleText('cyan', url), url.length)}` : ''
   // eslint-disable-next-line no-console
   console.log(`\n${centerBlock(renderUnicodeCompact(url))}${caption}\n`)
 }
@@ -513,14 +513,14 @@ export function openBrowser(url: string): void {
     return
   }
   if (!hasDisplayServer()) {
-    logger.warn(`No browser is available in this environment. Open ${colors.cyan(url)} manually.`)
+    logger.warn(`No browser is available in this environment. Open ${styleText('cyan', url)} manually.`)
     return
   }
 
   const [command, args] = resolved
   const onFailure = (error: unknown) => {
     debug('Failed to open browser:', error)
-    logger.warn(`Could not open ${colors.cyan(url)} in a browser.`)
+    logger.warn(`Could not open ${styleText('cyan', url)} in a browser.`)
   }
 
   try {

--- a/packages/nuxt-cli/src/dev/shortcuts.ts
+++ b/packages/nuxt-cli/src/dev/shortcuts.ts
@@ -3,7 +3,7 @@ import type { Listener } from './listen'
 import process from 'node:process'
 import { createInterface } from 'node:readline'
 
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import { isCI, isTest } from 'std-env'
 
 import { restoreRawMode } from '../utils/console'
@@ -97,7 +97,7 @@ async function quit(context: ActionContext): Promise<void> {
 
 function printHelp(context: ActionContext): void {
   const lines = availableShortcuts(context).map(({ keys, description }) =>
-    `  ${colors.dim('press')} ${colors.bold(`${keys[0]} + enter`)} ${colors.dim(`to ${description}`)}`,
+    `  ${styleText('dim', 'press')} ${styleText('bold', `${keys[0]} + enter`)} ${styleText('dim', `to ${description}`)}`,
   )
   // eslint-disable-next-line no-console
   console.log(`\n${lines.join('\n')}\n`)
@@ -120,7 +120,7 @@ export function setupShortcuts(context: ShortcutContext): void {
 
   context.onReady(() => {
     // eslint-disable-next-line no-console
-    console.log(`\n  ${colors.dim('press')} ${colors.bold('h + enter')} ${colors.dim('to see available shortcuts')}\n`)
+    console.log(`\n  ${styleText('dim', 'press')} ${styleText('bold', 'h + enter')} ${styleText('dim', 'to see available shortcuts')}\n`)
   })
 
   restoreRawMode()

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -14,12 +14,12 @@ import { mkdir } from 'node:fs/promises'
 import process from 'node:process'
 
 import { pathToFileURL } from 'node:url'
+import { styleText } from 'node:util'
 import defu from 'defu'
 import { resolveModulePath } from 'exsolve'
 import { toNodeListener } from 'h3'
 import { join, resolve } from 'pathe'
 import { debounce } from 'perfect-debounce'
-import colors from 'picocolors'
 import { toNodeHandler } from 'srvx/node'
 import { provider } from 'std-env'
 
@@ -418,7 +418,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
     const changedKeys = reason?.type === 'config' && formatChangedKeys(reason.keys ?? [])
     if (changedKeys) {
-      lines.push(colors.dim(`  ${changedKeys}`))
+      lines.push(styleText('dim', `  ${changedKeys}`))
     }
 
     // eslint-disable-next-line no-console

--- a/packages/nuxt-cli/src/main.ts
+++ b/packages/nuxt-cli/src/main.ts
@@ -4,8 +4,8 @@ import type { TemplateName } from './utils/templates/names'
 import { resolve } from 'node:path'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { defineCommand } from 'citty'
-import colors from 'picocolors'
 import { provider } from 'std-env'
 
 import { description, name, version } from '../package.json'
@@ -62,8 +62,8 @@ const _main = defineCommand({
     }
 
     if (command === 'add' && ctx.rawArgs[1] && templateNames.includes(ctx.rawArgs[1] as TemplateName)) {
-      logger.warn(`${colors.yellow('Deprecated:')} Using ${colors.cyan('nuxt add <template> <name>')} is deprecated.`)
-      logger.info(`Please use ${colors.cyan('nuxt add-template <template> <name>')} instead.`)
+      logger.warn(`${styleText('yellow', 'Deprecated:')} Using ${styleText('cyan', 'nuxt add <template> <name>')} is deprecated.`)
+      logger.info(`Please use ${styleText('cyan', 'nuxt add-template <template> <name>')} instead.`)
       await runCommand('add-template', [...ctx.rawArgs.slice(1)]).catch((err) => {
         console.error(err.message)
         process.exit(1)

--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -1,6 +1,6 @@
 import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 
 import { logger } from './logger'
 import { getPkgJSON, getPkgVersion } from './pkg'
@@ -29,7 +29,6 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
 }
 
 export function showBanner(nuxt: Nuxt) {
-  const { bold, gray, green } = colors
   const cwd = nuxt.options.rootDir
 
   const nuxtVersion = nuxt._version || getPkgVersion(cwd, 'nuxt') || getPkgVersion(cwd, 'nuxt-nightly')
@@ -40,12 +39,12 @@ export function showBanner(nuxt: Nuxt) {
   const vueVersion = getPkgVersion(cwd, 'vue', { via: ['nuxt'] }) || null
 
   logger.info(
-    green(`Nuxt ${bold(nuxtVersion)}`)
-    + gray(' (with ')
-    + (nitroVersion ? gray(`Nitro ${bold(nitroVersion)}`) : '')
-    + gray(`, ${builder.name} ${bold(builder.version)}`)
-    + (builder.provider ? gray(` via ${builder.provider.name} ${bold(builder.provider.version)}`) : '')
-    + (vueVersion ? gray(` and Vue ${bold(vueVersion)}`) : '')
-    + gray(')'),
+    styleText('green', `Nuxt ${styleText('bold', nuxtVersion)}`)
+    + styleText('gray', ' (with ')
+    + (nitroVersion ? styleText('gray', `Nitro ${styleText('bold', nitroVersion)}`) : '')
+    + styleText('gray', `, ${builder.name} ${styleText('bold', builder.version)}`)
+    + (builder.provider ? styleText('gray', ` via ${builder.provider.name} ${styleText('bold', builder.provider.version)}`) : '')
+    + (vueVersion ? styleText('gray', ` and Vue ${styleText('bold', vueVersion)}`) : '')
+    + styleText('gray', ')'),
   )
 }

--- a/packages/nuxt-cli/src/utils/engines.ts
+++ b/packages/nuxt-cli/src/utils/engines.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 import { satisfies } from 'verkit'
 
 import { logger } from './logger'
@@ -10,7 +10,7 @@ export async function checkEngines() {
 
   if (!satisfies(currentNode, nodeRange)) {
     logger.warn(
-      `Current version of Node.js (${colors.cyan(currentNode)}) is unsupported and might cause issues.\n       Please upgrade to a compatible version ${colors.cyan(nodeRange)}.`,
+      `Current version of Node.js (${styleText('cyan', currentNode)}) is unsupported and might cause issues.\n       Please upgrade to a compatible version ${styleText('cyan', nodeRange)}.`,
     )
   }
 }

--- a/packages/nuxt-cli/src/utils/env.ts
+++ b/packages/nuxt-cli/src/utils/env.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import colors from 'picocolors'
+import { styleText } from 'node:util'
 
 import { logger } from './logger'
 
@@ -7,7 +7,7 @@ export function overrideEnv(targetEnv: string) {
   const currentEnv = process.env.NODE_ENV
   if (currentEnv && currentEnv !== targetEnv) {
     logger.warn(
-      `Changing ${colors.cyan('NODE_ENV')} from ${colors.cyan(currentEnv)} to ${colors.cyan(targetEnv)}, to avoid unintended behavior.`,
+      `Changing ${styleText('cyan', 'NODE_ENV')} from ${styleText('cyan', currentEnv)} to ${styleText('cyan', targetEnv)}, to avoid unintended behavior.`,
     )
   }
 

--- a/packages/nuxt-cli/src/utils/formatting.ts
+++ b/packages/nuxt-cli/src/utils/formatting.ts
@@ -45,7 +45,7 @@ export function formatInfoBox(infoObj: Record<string, string | undefined>): stri
   let ansiFirstColumnLength = 0
   const entries = Object.entries(infoObj).map(([label, val]) => {
     if (label.length > firstColumnLength) {
-      ansiFirstColumnLength = styleText('bold', styleText('whiteBright', label)).length + 6
+      ansiFirstColumnLength = styleText(['bold', 'whiteBright'], label).length + 6
       firstColumnLength = label.length + 6
     }
     return [label, val || '-'] as const
@@ -60,7 +60,7 @@ export function formatInfoBox(infoObj: Record<string, string | undefined>): stri
       .replace(AT_MENTION_RE, (_, r) => styleText('gray', ` ${r}`))
       .replace(BACKTICK_RE, (_, r) => r)
 
-    boxStr += (`${styleText('bold', styleText('whiteBright', label))}`).padEnd(ansiFirstColumnLength)
+    boxStr += styleText(['bold', 'whiteBright'], label).padEnd(ansiFirstColumnLength)
 
     let boxRowLength = firstColumnLength
 

--- a/packages/nuxt-cli/src/utils/formatting.ts
+++ b/packages/nuxt-cli/src/utils/formatting.ts
@@ -1,6 +1,5 @@
 import process from 'node:process'
-import { stripVTControlCharacters } from 'node:util'
-import colors from 'picocolors'
+import { stripVTControlCharacters, styleText } from 'node:util'
 
 const AT_MENTION_RE = /\b@([^, ]+)/g
 const BACKTICK_RE = /`([^`]*)`/g
@@ -46,7 +45,7 @@ export function formatInfoBox(infoObj: Record<string, string | undefined>): stri
   let ansiFirstColumnLength = 0
   const entries = Object.entries(infoObj).map(([label, val]) => {
     if (label.length > firstColumnLength) {
-      ansiFirstColumnLength = colors.bold(colors.whiteBright(label)).length + 6
+      ansiFirstColumnLength = styleText('bold', styleText('whiteBright', label)).length + 6
       firstColumnLength = label.length + 6
     }
     return [label, val || '-'] as const
@@ -58,10 +57,10 @@ export function formatInfoBox(infoObj: Record<string, string | undefined>): stri
   let boxStr = ''
   for (const [label, value] of entries) {
     const formattedValue = value
-      .replace(AT_MENTION_RE, (_, r) => colors.gray(` ${r}`))
+      .replace(AT_MENTION_RE, (_, r) => styleText('gray', ` ${r}`))
       .replace(BACKTICK_RE, (_, r) => r)
 
-    boxStr += (`${colors.bold(colors.whiteBright(label))}`).padEnd(ansiFirstColumnLength)
+    boxStr += (`${styleText('bold', styleText('whiteBright', label))}`).padEnd(ansiFirstColumnLength)
 
     let boxRowLength = firstColumnLength
 
@@ -76,7 +75,7 @@ export function formatInfoBox(infoObj: Record<string, string | undefined>): stri
       if (boxRowLength + wordLength + spaceLength > terminalWidth) {
         // Wrap to next line
         if (currentLine) {
-          boxStr += colors.cyan(currentLine)
+          boxStr += styleText('cyan', currentLine)
         }
         boxStr += `\n${' '.repeat(firstColumnLength)}`
         currentLine = word
@@ -89,7 +88,7 @@ export function formatInfoBox(infoObj: Record<string, string | undefined>): stri
     }
 
     if (currentLine) {
-      boxStr += colors.cyan(currentLine)
+      boxStr += styleText('cyan', currentLine)
     }
 
     boxStr += '\n'

--- a/packages/nuxt-cli/src/utils/install.ts
+++ b/packages/nuxt-cli/src/utils/install.ts
@@ -7,9 +7,9 @@ import { statSync } from 'node:fs'
 import { delimiter, resolve } from 'node:path'
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { log, S_BAR } from '@clack/prompts'
 import { addDependency, dedupeDependencies, installDependencies, packageManagers } from 'nypm'
-import colors from 'picocolors'
 import { provider } from 'std-env'
 import { normalizeSpawnCommand, x } from 'tinyexec'
 
@@ -179,7 +179,7 @@ export function createInstallLog({ verbose = false } = {}): InstallLog {
       }
       const output = (lines.length > 0 ? lines.join('\n') : result.output).trim()
       if (output) {
-        log.message(output.split('\n'), { symbol: colors.gray(S_BAR) })
+        log.message(output.split('\n'), { symbol: styleText('gray', S_BAR) })
       }
     },
   }

--- a/packages/nuxt-cli/src/utils/network.ts
+++ b/packages/nuxt-cli/src/utils/network.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { basename } from 'pathe'
-import colors from 'picocolors'
 import { isWindows } from 'std-env'
 
 import { logger } from './logger'
@@ -257,14 +257,14 @@ export async function probeNetworkError(url: string, timeout = 3000): Promise<un
 /** A single-line, human-readable explanation of a failed network request. */
 export function describeNetworkError(err: unknown, url?: string): string {
   const host = getHost(url)
-  const target = host ? colors.cyan(host) : 'the network'
+  const target = host ? styleText('cyan', host) : 'the network'
   const { kind, code, status } = classifyNetworkError(err)
 
   switch (kind) {
     case 'proxy-auth':
-      return `Proxy rejected the request to ${target} with status ${colors.yellow('407')} (proxy authentication required).`
+      return `Proxy rejected the request to ${target} with status ${styleText('yellow', '407')} (proxy authentication required).`
     case 'http':
-      return `Request to ${target} failed with status ${colors.yellow(String(status))}.`
+      return `Request to ${target} failed with status ${styleText('yellow', String(status))}.`
     case 'dns':
       return code === 'EAI_AGAIN'
         ? `DNS lookup for ${target} timed out.`
@@ -301,29 +301,29 @@ export function getProxyHint(kind: NetworkFailureKind = 'unknown', ctx: CommandC
   }
 
   if (kind === 'tls') {
-    return `This usually means a proxy is re-signing TLS traffic. Retry with your organisation's root certificate: ${colors.cyan(formatRetryCommand({ NODE_EXTRA_CA_CERTS: '/path/to/corporate-ca.pem' }, ctx))}`
+    return `This usually means a proxy is re-signing TLS traffic. Retry with your organisation's root certificate: ${styleText('cyan', formatRetryCommand({ NODE_EXTRA_CA_CERTS: '/path/to/corporate-ca.pem' }, ctx))}`
   }
 
   if (kind === 'proxy-auth') {
-    return `Include credentials in your proxy URL, e.g. ${colors.cyan('HTTPS_PROXY=http://user:password@proxy.example.com:8080')}.`
+    return `Include credentials in your proxy URL, e.g. ${styleText('cyan', 'HTTPS_PROXY=http://user:password@proxy.example.com:8080')}.`
   }
 
   if (!hasProxyEnv(env)) {
-    return `If you are behind a proxy, set ${colors.cyan('HTTPS_PROXY')} and ${colors.cyan('NODE_USE_ENV_PROXY=1')} (plus ${colors.cyan('NO_PROXY')} for internal hosts).`
+    return `If you are behind a proxy, set ${styleText('cyan', 'HTTPS_PROXY')} and ${styleText('cyan', 'NODE_USE_ENV_PROXY=1')} (plus ${styleText('cyan', 'NO_PROXY')} for internal hosts).`
   }
 
   if (!supportsEnvProxy(ctx.flags)) {
-    return `A proxy is configured but this version of Node.js cannot use it; upgrade to Node.js 24 (or 22.18+) to enable ${colors.cyan('NODE_USE_ENV_PROXY')}.`
+    return `A proxy is configured but this version of Node.js cannot use it; upgrade to Node.js 24 (or 22.18+) to enable ${styleText('cyan', 'NODE_USE_ENV_PROXY')}.`
   }
 
   if (!proxyInUse()) {
-    return `A proxy is configured but Node.js only reads it at startup. Retry with ${colors.cyan(formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, ctx))}`
+    return `A proxy is configured but Node.js only reads it at startup. Retry with ${styleText('cyan', formatRetryCommand({ NODE_USE_ENV_PROXY: '1' }, ctx))}`
   }
 
   // A connection dropped mid-handshake through a proxy that is genuinely in use
   // is the usual signature of TLS interception with an untrusted root.
   if (kind === 'reset') {
-    return `The proxy may be re-signing TLS traffic. Retry with your organisation's root certificate: ${colors.cyan(formatRetryCommand({ NODE_EXTRA_CA_CERTS: '/path/to/corporate-ca.pem' }, ctx))}`
+    return `The proxy may be re-signing TLS traffic. Retry with your organisation's root certificate: ${styleText('cyan', formatRetryCommand({ NODE_EXTRA_CA_CERTS: '/path/to/corporate-ca.pem' }, ctx))}`
   }
 }
 

--- a/packages/nuxt-cli/src/utils/profile.ts
+++ b/packages/nuxt-cli/src/utils/profile.ts
@@ -1,9 +1,9 @@
 import type { Session } from 'node:inspector'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
+import { styleText } from 'node:util'
 import { box } from '@clack/prompts'
 import { join, relative } from 'pathe'
-import colors from 'picocolors'
 import { themeColor } from './ascii'
 
 const RELATIVE_PATH_RE = /^(?![^.]{1,2}\/)/
@@ -67,8 +67,8 @@ export async function stopCpuProfile(outDir: string, command: string): Promise<s
           mkdirSync(outDir, { recursive: true })
           writeFileSync(outPath, JSON.stringify(params.profile))
           const nextSteps = [
-            `CPU profile written to ${colors.cyan(relativeOutPath)}.`,
-            `Open it in a CPU profile viewer like your IDE, or ${colors.cyan('https://discoveryjs.github.io/cpupro')}.`,
+            `CPU profile written to ${styleText('cyan', relativeOutPath)}.`,
+            `Open it in a CPU profile viewer like your IDE, or ${styleText('cyan', 'https://discoveryjs.github.io/cpupro')}.`,
           ]
           box(`\n${nextSteps.map(step => ` › ${step}`).join('\n')}\n`, '', {
             contentAlign: 'left',

--- a/packages/nuxt-cli/src/utils/update-check.ts
+++ b/packages/nuxt-cli/src/utils/update-check.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
+import { styleText } from 'node:util'
 import { S_INFO } from '@clack/prompts'
-import colors from 'picocolors'
 import { readUser, updateUser } from 'rc9'
 import { isCI, isTest, provider } from 'std-env'
 import { joinURL } from 'ufo'
@@ -155,16 +155,16 @@ export interface UpdateNudgeOptions {
  * the leading gap is measured rather than assumed.
  */
 function writeNudge(headline: string, instruction: string): void {
-  process.stdout.write(`${blankLineBefore()}${colors.blue(S_INFO)} ${headline}\n  ${instruction}\n`)
+  process.stdout.write(`${blankLineBefore()}${styleText('blue', S_INFO)} ${headline}\n  ${instruction}\n`)
 }
 
 function describeUpdate({ current, latest }: NuxtUpdate, name: string): string {
-  return `a new version of ${name} is available: ${colors.green(latest)} ${colors.gray(`(you are on ${current})`)}`
+  return `a new version of ${name} is available: ${styleText('green', latest)} ${styleText('gray', `(you are on ${current})`)}`
 }
 
 export function renderUpdateNudge(update: NuxtUpdate, options: UpdateNudgeOptions = {}): void {
   const { name = 'Nuxt', command = 'nuxt upgrade' } = options
-  writeNudge(describeUpdate(update, name), `run ${colors.cyan(command)} to update`)
+  writeNudge(describeUpdate(update, name), `run ${styleText('cyan', command)} to update`)
 }
 
 /**
@@ -173,7 +173,7 @@ export function renderUpdateNudge(update: NuxtUpdate, options: UpdateNudgeOption
  */
 export function renderSelfUpdateNudge(update: NuxtUpdate, options: UpdateNudgeOptions = {}): void {
   const { name = 'the Nuxt CLI', command = 'nuxt upgrade' } = options
-  writeNudge(describeUpdate(update, name), `next time, run ${colors.cyan(command)} to use the latest version`)
+  writeNudge(describeUpdate(update, name), `next time, run ${styleText('cyan', command)} to use the latest version`)
 }
 
 export interface SelfUpdateNudgeOptions extends UpdateNudgeOptions {

--- a/packages/nuxt-cli/test/unit/terminal-output.spec.ts
+++ b/packages/nuxt-cli/test/unit/terminal-output.spec.ts
@@ -8,10 +8,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { colourOf, render, screen as visibleScreen } from '../utils/terminal'
 
-// Colours have to be forced before `picocolors` is imported, so the modules
-// under test are loaded dynamically below.
-process.env.FORCE_COLOR = '3'
-
 vi.mock('std-env', () => ({ isCI: false, isTest: false, provider: undefined }))
 
 // The suite may itself run inside a container, so the environment the URL block

--- a/packages/nuxt-cli/test/unit/utils/banner.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/banner.spec.ts
@@ -4,9 +4,6 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { render, screen } from '../../utils/terminal'
 
-// Colours have to be forced before `picocolors` is imported by the module under test.
-process.env.FORCE_COLOR = '3'
-
 const VERSIONS: Record<string, string> = {
   'webpack': '5.99.0',
   '@rspack/core': '1.3.0',

--- a/packages/nuxt-cli/test/utils/terminal.ts
+++ b/packages/nuxt-cli/test/utils/terminal.ts
@@ -27,6 +27,8 @@ export async function render(run: (context: RenderContext) => unknown): Promise<
   }
 
   const log = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => capture(`${args.join(' ')}\n`))
+  const isTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
   const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
     capture(chunk as string)
     return true
@@ -43,6 +45,12 @@ export async function render(run: (context: RenderContext) => unknown): Promise<
   }
   finally {
     log.mockRestore()
+    if (isTTY) {
+      Object.defineProperty(process.stdout, 'isTTY', isTTY)
+    }
+    else {
+      Reflect.deleteProperty(process.stdout, 'isTTY')
+    }
     write.mockRestore()
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,9 +136,6 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       std-env:
         specifier: ^4.2.0
         version: 4.2.0
@@ -205,9 +202,6 @@ importers:
       perfect-debounce:
         specifier: ^2.1.0
         version: 2.1.0
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       pkg-types:
         specifier: ^2.3.1
         version: 2.3.1


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Replaces `picocolors` with native node util APIs. 
It was previously discussed on Nuxt discord: https://discord.com/channels/473401852243869706/1080872789940121732/1532045397634322493

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
