### PR TITLE
feat(dev): explain first-run failures before nuxt loads

### DIFF
--- a/packages/nuxt-cli/src/commands/dev.ts
+++ b/packages/nuxt-cli/src/commands/dev.ts
@@ -16,10 +16,12 @@ import { initialize } from '../dev'
 import { closeInspector, openInspector, resolveInspectOptions } from '../dev/inspect'
 import { isReusePortSupported, parsePort } from '../dev/listen'
 import { ForkPool } from '../dev/pool'
+import { preflight } from '../dev/preflight'
 import { formatRestartReason } from '../dev/reason'
 import { setupShortcuts } from '../dev/shortcuts'
 import { SUPERVISOR_SHUTDOWN_TIMEOUT_MS } from '../dev/shutdown'
 import { formatTakeoverRefusal, takeOverDevServer } from '../dev/takeover'
+import { replaceCwdArg } from '../utils/args'
 import { resolveLockDir } from '../utils/dev-server'
 import { summariseActiveResources } from '../utils/hang'
 import { debug, logger } from '../utils/logger'
@@ -153,7 +155,11 @@ const command = defineCommand({
   },
   async run(ctx) {
     // Prepare
-    const cwd = resolveRootDir(ctx.args)
+    const requestedCwd = resolveRootDir(ctx.args)
+    const cwd = await preflight({ cwd: requestedCwd })
+    if (cwd !== requestedCwd) {
+      replaceCwdArg(ctx.rawArgs, cwd, requestedCwd)
+    }
 
     const listenOverrides = resolveListenOverrides(ctx.args)
 

--- a/packages/nuxt-cli/src/commands/module/add.ts
+++ b/packages/nuxt-cli/src/commands/module/add.ts
@@ -9,7 +9,7 @@ import process from 'node:process'
 import { styleText } from 'node:util'
 import { cancel, confirm, isCancel, select, spinner } from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { detectPackageManager, packageManagers } from 'nypm'
+import { packageManagers } from 'nypm'
 import { resolve } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
 import { findMaxSatisfying, satisfies } from 'verkit'
@@ -17,7 +17,7 @@ import { findMaxSatisfying, satisfies } from 'verkit'
 import { runCommandDef as runCommand } from '../../run-command'
 import { addNuxtConfigEntries, createNuxtConfig, readNuxtConfig } from '../../utils/config'
 import { fetchJson } from '../../utils/fetch'
-import { createInstallLog, resolvePackageManagerDescriptor, runInstall, takeUnreportedIgnoredBuilds } from '../../utils/install'
+import { createInstallLog, detectProjectPackageManager, resolvePackageManagerDescriptor, runInstall, takeUnreportedIgnoredBuilds } from '../../utils/install'
 import { logger } from '../../utils/logger'
 import { logNetworkError } from '../../utils/network'
 import { detectNpmRegistry } from '../../utils/registry'
@@ -272,9 +272,7 @@ async function addModules(modules: ResolvedModule[], { skipInstall = false, skip
 /**
  * Resolve the package manager to install with, preferring an explicit choice
  * (e.g. the one selected during `nuxt init`) and otherwise detecting one from
- * the project itself before looking at parent directories, so a project nested
- * inside another workspace is not installed with that workspace's package
- * manager.
+ * the project.
  */
 async function resolvePackageManager(cwd: string, name?: string): Promise<PackageManager> {
   const requested = name ? packageManagers.find(pm => pm.name === name) : undefined
@@ -282,8 +280,7 @@ async function resolvePackageManager(cwd: string, name?: string): Promise<Packag
     logger.warn(`Unknown package manager ${styleText('cyan', name)}, detecting one instead.`)
   }
 
-  const detected = await detectPackageManager(cwd, { includeParentDirs: false })
-    ?? await detectPackageManager(cwd)
+  const detected = await detectProjectPackageManager(cwd)
 
   if (!requested) {
     return detected ?? resolvePackageManagerDescriptor('npm')

--- a/packages/nuxt-cli/src/dev/preflight.ts
+++ b/packages/nuxt-cli/src/dev/preflight.ts
@@ -171,21 +171,22 @@ async function resolveProjectDirectory(cwd: string, interactive: boolean): Promi
  * from whichever write happens to get there first, long after the banner.
  *
  * Only the default build directory is checked; a configured one is not known
- * until the config has been read. `W_OK` reflects neither Windows ACLs nor the
- * privileges of a root user, so on those the check passes and the write still
- * fails, as it did before.
+ * until the config has been read. Write access is not enough on its own: a
+ * directory also has to be searchable for anything inside it to be opened.
+ * Neither bit reflects Windows ACLs or the privileges of a root user, so on
+ * those the check passes and the write still fails, as it did before.
  */
 function checkWritableBuildDir(cwd: string): void {
   const buildDir = join(cwd, '.nuxt')
   const target = existsSync(buildDir) ? buildDir : cwd
   try {
-    accessSync(target, constants.W_OK)
+    accessSync(target, constants.W_OK | constants.X_OK)
   }
   catch {
     throw new ActionableError([
       `${styleText('red', 'Nuxt cannot write to')} ${styleText('cyan', target)}${styleText('red', '.')}`,
       '',
-      `Grant write access with ${styleText('cyan', `chmod u+w ${relativeTo(cwd, target, { link: false })}`)}, or remove the directory and try again.`,
+      `Grant write access with ${styleText('cyan', `chmod u+wx ${relativeTo(cwd, target, { link: false })}`)}, or remove the directory and try again.`,
     ].join('\n'))
   }
 }
@@ -195,8 +196,18 @@ async function checkDependencies(cwd: string, interactive: boolean): Promise<voi
     return
   }
 
+  // Reachable with a `nuxt.config` and no usable manifest, where an install has
+  // nothing to install from.
   const packageJson = readPackageJson(cwd)
-  if (packageJson && !declaresNuxt(packageJson)) {
+  if (!packageJson) {
+    throw new ActionableError([
+      `${styleText('red', 'There is no readable')} ${styleText('cyan', 'package.json')} ${styleText('red', 'in')} ${styleText('cyan', cwd)}${styleText('red', '.')}`,
+      '',
+      `Create or repair it, then add ${styleText('cyan', 'nuxt')} as a dependency.`,
+    ].join('\n'))
+  }
+
+  if (!declaresNuxt(packageJson)) {
     const { name } = await detectInstaller(cwd)
     throw new ActionableError([
       `${styleText('red', '`nuxt` is not a dependency of this project.')}`,

--- a/packages/nuxt-cli/src/dev/preflight.ts
+++ b/packages/nuxt-cli/src/dev/preflight.ts
@@ -1,0 +1,282 @@
+import type { PackageManager } from 'nypm'
+
+import { accessSync, constants, existsSync, readdirSync, readFileSync } from 'node:fs'
+import { styleText } from 'node:util'
+
+import { confirm, isCancel, spinner } from '@clack/prompts'
+import { dirname, join } from 'pathe'
+
+import { isInteractive, restoreRawMode, withDirectStdout } from '../utils/console'
+import { ActionableError } from '../utils/errors'
+import { tryResolveNuxt } from '../utils/kit'
+import { debug, logger } from '../utils/logger'
+import { CONFIG_EXTENSIONS } from '../utils/nuxt-config'
+import { relativeTo } from '../utils/paths'
+
+const NUXT_PACKAGES = ['nuxt', 'nuxt-nightly']
+
+/**
+ * Extensions `c12` accepts for a config it parses rather than imports. Reporting
+ * a project as missing is worse than looking in a few more places, so the whole
+ * set is checked here even though only the importable ones can be loaded.
+ */
+const DATA_CONFIG_EXTENSIONS = ['.json', '.jsonc', '.json5', '.yaml', '.yml', '.toml']
+
+const ALL_CONFIG_EXTENSIONS = [...CONFIG_EXTENSIONS, ...DATA_CONFIG_EXTENSIONS]
+
+const CONFIG_FILENAMES = new Set(ALL_CONFIG_EXTENSIONS.map(extension => `nuxt.config${extension}`))
+
+/** The same configs, under both names `c12` accepts inside `.config/`. */
+const CONFIG_DIR_FILENAMES = new Set([...CONFIG_FILENAMES, ...ALL_CONFIG_EXTENSIONS.map(extension => `nuxt${extension}`)])
+
+function containsAny(dir: string, filenames: Set<string>): boolean {
+  try {
+    return readdirSync(dir).some(entry => filenames.has(entry))
+  }
+  catch {
+    return false
+  }
+}
+
+/**
+ * Whether `dir` holds a Nuxt config in any of the places `c12` looks: alongside
+ * `package.json`, or in `.config/` as `nuxt.<ext>` or `nuxt.config.<ext>`.
+ */
+function isNuxtConfigPresent(dir: string): boolean {
+  return containsAny(dir, CONFIG_FILENAMES) || containsAny(join(dir, '.config'), CONFIG_DIR_FILENAMES)
+}
+
+function readPackageJson(dir: string): Record<string, any> | undefined {
+  try {
+    return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8'))
+  }
+  catch {
+    return undefined
+  }
+}
+
+function declaresNuxt(packageJson: Record<string, any> | undefined): boolean {
+  if (!packageJson) {
+    return false
+  }
+  const dependencies = { ...packageJson.dependencies, ...packageJson.devDependencies }
+  return NUXT_PACKAGES.some(name => name in dependencies)
+}
+
+export interface ProjectLocation {
+  /** `true` when `dir` itself looks like a Nuxt project. */
+  isProject: boolean
+  /** Nearest ancestor that looks like a Nuxt project, when `dir` does not. */
+  ancestor?: string
+}
+
+/**
+ * Decide whether `dir` is a Nuxt project, and if not, whether one of its
+ * ancestors is: running `nuxt dev` one directory too deep otherwise silently
+ * boots an unrelated, empty app rooted at the subdirectory.
+ *
+ * An ancestor has to hold a config to count. A monorepo root commonly depends on
+ * `nuxt` for tooling without being an app, and offering to run it would be worse
+ * advice than none.
+ */
+export function locateProject(dir: string): ProjectLocation {
+  if (isNuxtConfigPresent(dir) || declaresNuxt(readPackageJson(dir))) {
+    return { isProject: true }
+  }
+
+  let current = dir
+  let parent = dirname(current)
+  while (parent !== current) {
+    if (isNuxtConfigPresent(parent)) {
+      return { isProject: false, ancestor: parent }
+    }
+    current = parent
+    parent = dirname(parent)
+  }
+
+  return { isProject: false }
+}
+
+export interface PreflightOptions {
+  cwd: string
+  /** Whether questions may be asked. Defaults to {@link isInteractive}. */
+  interactive?: boolean
+}
+
+/**
+ * Check the things that stop `nuxt dev` from starting, before it starts.
+ *
+ * Problems that can be resolved without guessing are resolved (installing
+ * dependencies); the rest are reported as an error whose message contains the
+ * command to run. Everything interactive degrades to that error when there is
+ * no TTY.
+ *
+ * Returns the directory to start in, which is the one given unless the user
+ * asked to run in a project found above it.
+ *
+ * @throws {ActionableError} when the dev server cannot usefully be started.
+ */
+async function runDevPreflight(options: PreflightOptions): Promise<string> {
+  const interactive = options.interactive ?? isInteractive()
+
+  const cwd = await resolveProjectDirectory(options.cwd, interactive)
+  checkWritableBuildDir(cwd)
+  await checkDependencies(cwd, interactive)
+
+  return cwd
+}
+
+/**
+ * The project directory to start in. Running one directory too deep is a typo
+ * rather than an intent, so the project above is offered instead of refused.
+ */
+async function resolveProjectDirectory(cwd: string, interactive: boolean): Promise<string> {
+  const location = locateProject(cwd)
+  if (location.isProject) {
+    return cwd
+  }
+
+  if (location.ancestor) {
+    const relative = relativeTo(cwd, location.ancestor, { link: false })
+
+    if (interactive) {
+      logger.warn(`${styleText('cyan', cwd)} is not a Nuxt project, but ${styleText('cyan', location.ancestor)} is.`)
+      const answer = await confirm({ message: `Run there instead?`, initialValue: true })
+      restoreRawMode()
+
+      if (!isCancel(answer) && answer) {
+        return location.ancestor
+      }
+    }
+
+    throw new ActionableError([
+      `${styleText('red', 'No Nuxt project in')} ${styleText('cyan', cwd)}${styleText('red', '.')}`,
+      '',
+      `A Nuxt project was found in ${styleText('cyan', location.ancestor)}. Run it from there:`,
+      `  ${styleText('cyan', `cd ${relative} && nuxt dev`)}`,
+      `or point the CLI at it: ${styleText('cyan', `nuxt dev --cwd ${relative}`)}`,
+    ].join('\n'))
+  }
+
+  throw new ActionableError([
+    `${styleText('red', 'No Nuxt project in')} ${styleText('cyan', cwd)}${styleText('red', '.')}`,
+    '',
+    `There is no ${styleText('cyan', 'nuxt.config')} here and no ${styleText('cyan', 'nuxt')} dependency in ${styleText('cyan', 'package.json')}.`,
+    `Create one with ${styleText('cyan', 'nuxt init')}, or run ${styleText('cyan', 'nuxt dev')} from an existing project.`,
+  ].join('\n'))
+}
+
+/**
+ * A read-only `.nuxt` otherwise surfaces as an unhandled `EACCES` rejection
+ * from whichever write happens to get there first, long after the banner.
+ *
+ * Only the default build directory is checked; a configured one is not known
+ * until the config has been read. `W_OK` reflects neither Windows ACLs nor the
+ * privileges of a root user, so on those the check passes and the write still
+ * fails, as it did before.
+ */
+function checkWritableBuildDir(cwd: string): void {
+  const buildDir = join(cwd, '.nuxt')
+  const target = existsSync(buildDir) ? buildDir : cwd
+  try {
+    accessSync(target, constants.W_OK)
+  }
+  catch {
+    throw new ActionableError([
+      `${styleText('red', 'Nuxt cannot write to')} ${styleText('cyan', target)}${styleText('red', '.')}`,
+      '',
+      `Grant write access with ${styleText('cyan', `chmod u+w ${relativeTo(cwd, target, { link: false })}`)}, or remove the directory and try again.`,
+    ].join('\n'))
+  }
+}
+
+async function checkDependencies(cwd: string, interactive: boolean): Promise<void> {
+  if (tryResolveNuxt(cwd)) {
+    return
+  }
+
+  const packageJson = readPackageJson(cwd)
+  if (packageJson && !declaresNuxt(packageJson)) {
+    const { name } = await detectInstaller(cwd)
+    throw new ActionableError([
+      `${styleText('red', '`nuxt` is not a dependency of this project.')}`,
+      '',
+      `Add it with ${styleText('cyan', `${name} add nuxt`)}, or run ${styleText('cyan', 'nuxt init')} to start a new project.`,
+    ].join('\n'))
+  }
+
+  await offerInstall(cwd, interactive)
+}
+
+/**
+ * The package manager to tell the user to run. `../utils/install` is loaded on
+ * demand: it and `nypm` are only needed once something is already wrong, so they
+ * stay out of the modules a successful `nuxt dev` loads.
+ */
+async function detectInstaller(cwd: string): Promise<PackageManager> {
+  const { detectProjectPackageManager, resolvePackageManagerDescriptor } = await import('../utils/install')
+
+  return await detectProjectPackageManager(cwd) ?? resolvePackageManagerDescriptor('npm')
+}
+
+async function offerInstall(cwd: string, interactive: boolean): Promise<void> {
+  const packageManager = await detectInstaller(cwd)
+  const command = `${packageManager.name} install`
+  const reason = 'Dependencies are not installed.'
+
+  if (!interactive) {
+    throw new ActionableError(`${reason}\nRun ${styleText('cyan', command)} first.`)
+  }
+
+  logger.warn(reason)
+  const answer = await confirm({ message: `Run ${styleText('cyan', command)} now?`, initialValue: true })
+  restoreRawMode()
+
+  if (isCancel(answer) || !answer) {
+    throw new ActionableError(`${styleText('red', 'Cannot start the dev server without dependencies.')}\nRun ${styleText('cyan', command)} and try again.`)
+  }
+
+  const { createInstallLog, runInstall } = await import('../utils/install')
+
+  const controller = new AbortController()
+  const installLog = createInstallLog()
+  const installSpinner = spinner({ indicator: 'timer', onCancel: () => controller.abort() })
+  installSpinner.start(`Installing with ${styleText('cyan', packageManager.name)}`)
+
+  const result = await runInstall({
+    cwd,
+    packageManager,
+    onOutput: installLog.onOutput,
+    onStatus: message => installSpinner.message(message),
+    signal: controller.signal,
+  })
+
+  if (!result.success) {
+    installSpinner.error(result.error ?? 'Install failed')
+    installLog.finish(result)
+    throw new ActionableError(`${styleText('red', 'Dependencies could not be installed.')}\nFix the error above, then run ${styleText('cyan', command)} and try again.`)
+  }
+
+  installSpinner.stop('Dependencies installed')
+  installLog.finish(result)
+}
+
+/**
+ * Run preflight, letting its advice reach the user and swallowing anything else,
+ * and return the directory the dev server should start in.
+ *
+ * A bug in a check must never be the reason `nuxt dev` refuses to start, so only
+ * an {@link ActionableError} propagates.
+ */
+export async function preflight(options: PreflightOptions): Promise<string> {
+  try {
+    return await withDirectStdout(() => runDevPreflight(options))
+  }
+  catch (error) {
+    if (error instanceof ActionableError) {
+      throw error
+    }
+    debug('Preflight check failed:', error)
+    return options.cwd
+  }
+}

--- a/packages/nuxt-cli/src/utils/args.ts
+++ b/packages/nuxt-cli/src/utils/args.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'pathe'
+
 function cwdArgIndex(rawArgs: string[]): number {
   const end = rawArgs.indexOf('--')
   const index = rawArgs.findIndex(arg => arg === '--cwd' || arg.startsWith('--cwd='))
@@ -27,4 +29,27 @@ export function normaliseCwdArg(rawArgs: string[]): void {
 
   const separator = rawArgs.indexOf('--')
   rawArgs.splice(separator === -1 ? rawArgs.length : separator, 0, `--cwd=${cwd}`)
+}
+
+/**
+ * Point already-normalised `rawArgs` at `cwd`, so a process launched with them
+ * (a dev fork) runs against the same directory as this one.
+ *
+ * A positional resolving to `previousCwd` is dropped along with any existing
+ * `--cwd`: it named the directory being moved away from, and leaving it would
+ * disagree with the directory being moved to.
+ */
+export function replaceCwdArg(rawArgs: string[], cwd: string, previousCwd: string): void {
+  const separator = rawArgs.indexOf('--')
+  const end = separator === -1 ? rawArgs.length : separator
+
+  for (let index = end - 1; index >= 0; index--) {
+    const arg = rawArgs[index]!
+    if (arg.startsWith('--cwd=') || (!arg.startsWith('-') && resolve(arg) === previousCwd)) {
+      rawArgs.splice(index, 1)
+    }
+  }
+
+  const remaining = rawArgs.indexOf('--')
+  rawArgs.splice(remaining === -1 ? rawArgs.length : remaining, 0, `--cwd=${cwd}`)
 }

--- a/packages/nuxt-cli/src/utils/console.ts
+++ b/packages/nuxt-cli/src/utils/console.ts
@@ -4,7 +4,10 @@ import process from 'node:process'
 
 import { consola } from 'consola'
 
+import { hasTTY, isTest } from 'std-env'
+
 import { isRemotePeerError } from './errors'
+import { isInteractiveSession } from './lockfile'
 import { debug } from './logger'
 import { trackOutputSpacing } from './stdout'
 
@@ -45,6 +48,15 @@ export function setupGlobalConsole(opts: { dev?: boolean } = {}) {
   process.on('unhandledRejection', err => report('[unhandledRejection]', err))
 
   process.on('uncaughtException', err => report('[uncaughtException]', err))
+}
+
+/**
+ * Whether a question can be asked and answered right now. `hasTTY` is required
+ * as well as an interactive session, so a prompt cannot be written into a
+ * redirected stdout where nobody will see it.
+ */
+export function isInteractive(): boolean {
+  return isInteractiveSession() && hasTTY && !isTest
 }
 
 /**

--- a/packages/nuxt-cli/src/utils/errors.ts
+++ b/packages/nuxt-cli/src/utils/errors.ts
@@ -7,6 +7,20 @@ const REMOTE_PEER_ERROR_CODES = new Set([
 ])
 
 /**
+ * An error whose message already contains everything the user needs: what went
+ * wrong and the command to run. The stack is replaced with the message so the
+ * terminal shows the advice rather than frames inside `dist`.
+ */
+export class ActionableError extends Error {
+  override name = 'ActionableError'
+
+  constructor(message: string) {
+    super(message)
+    this.stack = message
+  }
+}
+
+/**
  * Errors that say something about the other end of a connection rather than
  * about this process: a broken pipe, a client hanging up mid-request, a tab
  * closed mid-navigation. These should not be reported as crashes or trigger

--- a/packages/nuxt-cli/src/utils/install.ts
+++ b/packages/nuxt-cli/src/utils/install.ts
@@ -9,7 +9,7 @@ import process from 'node:process'
 
 import { styleText } from 'node:util'
 import { log, S_BAR } from '@clack/prompts'
-import { addDependency, dedupeDependencies, installDependencies, packageManagers } from 'nypm'
+import { addDependency, dedupeDependencies, detectPackageManager, installDependencies, packageManagers } from 'nypm'
 import { provider } from 'std-env'
 import { normalizeSpawnCommand, x } from 'tinyexec'
 
@@ -44,6 +44,16 @@ export function resolvePackageManagerDescriptor(name: PackageManagerName, versio
     version: resolvedVersion,
     majorVersion: resolvedVersion?.split('.')[0] ?? descriptor?.majorVersion,
   }
+}
+
+/**
+ * Detect the package manager a project uses, looking at the project itself
+ * before its parent directories, so a project nested inside another workspace is
+ * not installed with that workspace's package manager.
+ */
+export async function detectProjectPackageManager(cwd: string): Promise<PackageManager | undefined> {
+  return await detectPackageManager(cwd, { includeParentDirs: false })
+    ?? await detectPackageManager(cwd)
 }
 
 export interface InstallOptions {

--- a/packages/nuxt-cli/src/utils/nuxt-config.ts
+++ b/packages/nuxt-cli/src/utils/nuxt-config.ts
@@ -10,7 +10,8 @@ import { join } from 'pathe'
 
 const MODULE_NOT_FOUND_CODES = new Set(['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND'])
 
-const CONFIG_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs', '.mts', '.cts']
+/** Extensions a `nuxt.config` can have, in resolution order. */
+export const CONFIG_EXTENSIONS = ['.js', '.ts', '.mjs', '.cjs', '.mts', '.cts']
 
 /**
  * Errors that mean the config needs a loader rather than that it is broken:

--- a/packages/nuxt-cli/test/unit/errors.spec.ts
+++ b/packages/nuxt-cli/test/unit/errors.spec.ts
@@ -6,7 +6,16 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { applySourceMap, stripCwd } from '../../src/dev/error'
-import { isRemotePeerError } from '../../src/utils/errors'
+import { ActionableError, isRemotePeerError } from '../../src/utils/errors'
+
+describe('actionableError', () => {
+  it('should print its advice instead of a stack trace', () => {
+    const error = new ActionableError('Run `pnpm install` first.')
+
+    expect(error.stack).toBe('Run `pnpm install` first.')
+    expect(error.message).toBe('Run `pnpm install` first.')
+  })
+})
 
 describe('isRemotePeerError', () => {
   it('should detect errors from the other end of a connection', () => {

--- a/packages/nuxt-cli/test/unit/preflight.spec.ts
+++ b/packages/nuxt-cli/test/unit/preflight.spec.ts
@@ -137,11 +137,39 @@ describe('preflight', () => {
     chmodSync(buildDir, 0o555)
 
     try {
-      await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/Nuxt cannot write to[\s\S]*chmod u\+w \.nuxt/)
+      await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/Nuxt cannot write to[\s\S]*chmod u\+wx \.nuxt/)
     }
     finally {
       chmodSync(buildDir, 0o755)
     }
+  })
+
+  it.skipIf(process.getuid?.() === 0 || process.platform === 'win32')('should explain a build directory that cannot be searched', async () => {
+    write('nuxt.config.ts')
+    installNuxt()
+    const buildDir = join(tempDir, '.nuxt')
+    mkdirSync(buildDir)
+    chmodSync(buildDir, 0o655)
+
+    try {
+      await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/Nuxt cannot write to/)
+    }
+    finally {
+      chmodSync(buildDir, 0o755)
+    }
+  })
+
+  it('should explain a missing package.json', async () => {
+    write('nuxt.config.ts')
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/no readable[\s\S]*package\.json/)
+  })
+
+  it('should explain an unparseable package.json', async () => {
+    write('nuxt.config.ts')
+    write('package.json', '{ not json')
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/no readable[\s\S]*package\.json/)
   })
 
   it('should explain that nuxt is not a dependency', async () => {

--- a/packages/nuxt-cli/test/unit/preflight.spec.ts
+++ b/packages/nuxt-cli/test/unit/preflight.spec.ts
@@ -1,0 +1,185 @@
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import process from 'node:process'
+
+import { join } from 'pathe'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const prompt = vi.hoisted(() => ({ answer: false as boolean }))
+
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@clack/prompts')>()
+  return { ...original, confirm: () => Promise.resolve(prompt.answer) }
+})
+
+const resolvedNuxt = vi.hoisted(() => ({ path: null as string | null, error: null as Error | null }))
+
+vi.mock('../../src/utils/kit', () => ({
+  tryResolveNuxt: () => {
+    if (resolvedNuxt.error) {
+      throw resolvedNuxt.error
+    }
+    return resolvedNuxt.path
+  },
+}))
+
+const { locateProject, preflight } = await import('../../src/dev/preflight')
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'nuxt-preflight-test-'))
+  resolvedNuxt.path = null
+  resolvedNuxt.error = null
+})
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+function write(relativePath: string, contents = '') {
+  const path = join(tempDir, relativePath)
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, contents)
+  return path
+}
+
+function installNuxt() {
+  resolvedNuxt.path = write('node_modules/nuxt/index.mjs', 'export default {}')
+}
+
+function createSubdirectory(name = 'app') {
+  const path = join(tempDir, name)
+  mkdirSync(path, { recursive: true })
+  return path
+}
+
+describe('locateProject', () => {
+  it('should recognise a directory with a nuxt config', () => {
+    write('nuxt.config.ts')
+
+    expect(locateProject(tempDir)).toEqual({ isProject: true })
+  })
+
+  it('should recognise a directory that only declares nuxt', () => {
+    write('package.json', JSON.stringify({ devDependencies: { 'nuxt-nightly': 'latest' } }))
+
+    expect(locateProject(tempDir)).toEqual({ isProject: true })
+  })
+
+  it('should recognise a config in `.config`', () => {
+    write('.config/nuxt.ts')
+
+    expect(locateProject(tempDir)).toEqual({ isProject: true })
+  })
+
+  it('should recognise a config `c12` parses rather than imports', () => {
+    write('nuxt.config.jsonc')
+
+    expect(locateProject(tempDir)).toEqual({ isProject: true })
+  })
+
+  it('should point at the nearest project when run from a subdirectory', () => {
+    write('nuxt.config.mjs')
+    mkdirSync(join(tempDir, 'app', 'pages'), { recursive: true })
+
+    expect(locateProject(join(tempDir, 'app', 'pages'))).toEqual({ isProject: false, ancestor: tempDir })
+  })
+
+  it('should not treat an ancestor that only declares nuxt as a project', () => {
+    write('package.json', JSON.stringify({ devDependencies: { nuxt: '^4' } }))
+
+    expect(locateProject(createSubdirectory())).toEqual({ isProject: false })
+  })
+
+  it('should report no project at all', () => {
+    write('package.json', JSON.stringify({ dependencies: { vue: '^3' } }))
+
+    expect(locateProject(tempDir)).toEqual({ isProject: false })
+  })
+
+  it('should ignore an unparseable package.json', () => {
+    write('package.json', '{ not json')
+
+    expect(locateProject(tempDir)).toEqual({ isProject: false })
+  })
+})
+
+describe('preflight', () => {
+  it('should explain that the directory is not a Nuxt project', async () => {
+    await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/No Nuxt project in[\s\S]*nuxt init/)
+  })
+
+  it('should offer to run in the project above instead', async () => {
+    write('nuxt.config.ts')
+    installNuxt()
+
+    prompt.answer = true
+    await expect(preflight({ cwd: createSubdirectory(), interactive: true })).resolves.toBe(tempDir)
+  })
+
+  it('should not move to the project above when the offer is declined', async () => {
+    write('nuxt.config.ts')
+    installNuxt()
+
+    prompt.answer = false
+    await expect(preflight({ cwd: createSubdirectory(), interactive: true })).rejects.toThrow(/cd \.\. && nuxt dev/)
+  })
+
+  it.skipIf(process.getuid?.() === 0 || process.platform === 'win32')('should explain a read-only build directory', async () => {
+    write('nuxt.config.ts')
+    installNuxt()
+    const buildDir = join(tempDir, '.nuxt')
+    mkdirSync(buildDir)
+    chmodSync(buildDir, 0o555)
+
+    try {
+      await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/Nuxt cannot write to[\s\S]*chmod u\+w \.nuxt/)
+    }
+    finally {
+      chmodSync(buildDir, 0o755)
+    }
+  })
+
+  it('should explain that nuxt is not a dependency', async () => {
+    write('nuxt.config.ts')
+    write('package.json', JSON.stringify({ dependencies: { vue: '^3' } }))
+    write('pnpm-lock.yaml')
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/pnpm add nuxt/)
+  })
+
+  it('should name the package manager from `packageManager` without a lockfile', async () => {
+    write('nuxt.config.ts')
+    write('package.json', JSON.stringify({ packageManager: 'yarn@4.5.0', dependencies: { vue: '^3' } }))
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/yarn add nuxt/)
+  })
+
+  it('should ask for an install when dependencies are missing', async () => {
+    write('nuxt.config.ts')
+    write('package.json', JSON.stringify({ dependencies: { nuxt: '^4' } }))
+    write('pnpm-lock.yaml')
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).rejects.toThrow(/pnpm install/)
+  })
+
+  it('should pass a project that is ready to start', async () => {
+    write('nuxt.config.ts')
+    write('package.json', JSON.stringify({ dependencies: { nuxt: '^4' } }))
+    write('pnpm-lock.yaml')
+    installNuxt()
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).resolves.toBe(tempDir)
+  })
+
+  it('should never block the dev server on an unexpected failure', async () => {
+    write('nuxt.config.ts')
+    resolvedNuxt.error = new Error('resolution blew up')
+
+    await expect(preflight({ cwd: tempDir, interactive: false })).resolves.toBe(tempDir)
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/args.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/args.spec.ts
@@ -1,6 +1,7 @@
+import { resolve } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
-import { normaliseCwdArg } from '../../../src/utils/args'
+import { normaliseCwdArg, replaceCwdArg } from '../../../src/utils/args'
 
 function normalise(rawArgs: string[]): string[] {
   normaliseCwdArg(rawArgs)
@@ -34,5 +35,30 @@ describe('normaliseCwdArg', () => {
   it('should keep --cwd ahead of a -- separator', () => {
     expect(normalise(['--cwd', 'apps/web', 'test', '--', '--watch'])).toEqual(['test', '--cwd=apps/web', '--', '--watch'])
     expect(normalise(['test', '--cwd=apps/web', '--', '--watch'])).toEqual(['test', '--cwd=apps/web', '--', '--watch'])
+  })
+})
+
+describe('replaceCwdArg', () => {
+  const previous = resolve('apps/web')
+
+  function replace(rawArgs: string[]): string[] {
+    replaceCwdArg(rawArgs, '/projects/site', previous)
+    return rawArgs
+  }
+
+  it('should replace an existing --cwd', () => {
+    expect(replace(['dev', '--cwd=apps/web'])).toEqual(['dev', '--cwd=/projects/site'])
+  })
+
+  it('should drop a ROOTDIR positional naming the previous directory', () => {
+    expect(replace(['dev', 'apps/web', '--port=3000'])).toEqual(['dev', '--port=3000', '--cwd=/projects/site'])
+  })
+
+  it('should keep positionals that name something else', () => {
+    expect(replace(['dev', 'apps/docs'])).toEqual(['dev', 'apps/docs', '--cwd=/projects/site'])
+  })
+
+  it('should leave arguments after a -- separator alone', () => {
+    expect(replace(['dev', '--', 'apps/web'])).toEqual(['dev', '--cwd=/projects/site', '--', 'apps/web'])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

running `nuxt dev` one directory too deep, or before installing, currently fails somewhere deep inside `@nuxt/kit` with a stack trace and advice to install `nuxt` (which is already installed, one directory up).

this adds a preflight stage in `dev/preflight.ts` that runs before any Nuxt code loads, asking:
1. is this a Nuxt project
2. is the build directory writable
3. is `nuxt` resolvable

each problem is either offered a fix or reported as an `ActionableError`, whose message carries the command to run and whose stack is suppressed so the terminal shows advice rather than frames inside `dist`.

when `nuxt dev` was launched in a subdirectory of the actual nuxt project, then rather than just failing, as we did before, we offer the project above:

```
▲  /project/app/sub is not a Nuxt project, but /project is.
◆  Run there instead? (Y/n)
```