### PR TITLE
chore: keep generated templates when the starter repo is unreachable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,16 @@ jobs:
 
       # The repo's `postinstall` runs `scripts/generate-data.ts` to write
       # `packages/nuxt-cli/src/data/*.ts` that the build then bundles. uppt's
-      # default install path uses `--ignore-scripts`, which would skip it
-      # and produce a stale or broken nuxi tarball, so we install ourselves
-      # and pass `install: false` to uppt/pack.
+      # default install path never runs it, which would produce a stale or
+      # broken nuxi tarball, so we install and build ourselves and pass
+      # `install: false` to uppt/pack.
       - name: 📦 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: 🔨 Generate data and build
+        run: pnpm run postinstall
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - id: pack
         uses: danielroe/uppt/pack@7bcfb5397c37202ef882363f755423130419d28a # v0.5.5

--- a/scripts/generate-data.ts
+++ b/scripts/generate-data.ts
@@ -1,10 +1,12 @@
 /** generate completion data from nitropack and Nuxt starter repo */
 
+import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 import { resolveModulePath } from 'exsolve'
+import { isCI } from 'std-env'
 
 import { fetchTemplates } from '../packages/nuxt-cli/src/utils/starter-templates.ts'
 
@@ -14,10 +16,12 @@ interface PresetMeta {
 
 const dataDir = new URL('../packages/nuxt-cli/src/data/', import.meta.url)
 
+const templatesFile = new URL('templates.ts', dataDir)
+
 export async function generateCompletionData() {
   const [nitroPresets, templates] = await Promise.all([
     getNitroPresets(),
-    fetchTemplates(),
+    fetchTemplates().catch(keepExistingTemplates),
   ])
 
   await mkdir(dataDir, { recursive: true })
@@ -25,10 +29,19 @@ export async function generateCompletionData() {
     new URL('nitro-presets.ts', dataDir),
     `export const nitroPresets = ${JSON.stringify(nitroPresets, null, 2)} as const`,
   )
-  await writeFile(
-    new URL('templates.ts', dataDir),
-    `export const templates = ${JSON.stringify(templates, null, 2)} as const`,
-  )
+  if (templates) {
+    await writeFile(
+      templatesFile,
+      `export const templates = ${JSON.stringify(templates, null, 2)} as const`,
+    )
+  }
+}
+
+function keepExistingTemplates(error: unknown): undefined {
+  if (isCI || !existsSync(templatesFile)) {
+    throw error
+  }
+  console.warn(`Could not fetch starter templates, keeping the ones already generated: ${error}`)
 }
 
 async function getNitroPresets() {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

small chore - avoids failures when running `pnpm install` locally and hitting a github rate limit