### PR TITLE
fix(typecheck): warn about multiple Vue versions

### DIFF
--- a/packages/nuxt-cli/src/commands/typecheck.ts
+++ b/packages/nuxt-cli/src/commands/typecheck.ts
@@ -1,6 +1,6 @@
 import type { TSConfig } from 'pkg-types'
 import { existsSync, readFileSync } from 'node:fs'
-import { writeFile } from 'node:fs/promises'
+import { readdir, readFile, realpath, writeFile } from 'node:fs/promises'
 import process from 'node:process'
 
 import { styleText } from 'node:util'
@@ -167,6 +167,10 @@ export default defineCommand({
       }
       return
     }
+    const vueVersions = await findVueVersions(cwd)
+    if (vueVersions.length > 1) {
+      logger.warn(`Multiple versions of ${styleText('cyan', 'vue')} are installed (${vueVersions.join(', ')}). This can break template type augmentations. Dedupe your dependencies or pin a single Vue version before investigating type errors.`)
+    }
 
     if (hasTTY) {
       logger.error(`Type check failed in ${styleText('cyan', duration)}.`)
@@ -174,6 +178,70 @@ export default defineCommand({
     process.exitCode = result.exitCode ?? 1
   },
 })
+
+async function findVueVersions(cwd: string): Promise<string[]> {
+  const versions = new Set<string>()
+  const pending: string[] = []
+  const visited = new Set<string>()
+
+  for (let directory = cwd; ; directory = dirname(directory)) {
+    pending.push(resolve(directory, 'node_modules'))
+    const parent = dirname(directory)
+    if (parent === directory) {
+      break
+    }
+  }
+  pending.reverse()
+
+  while (pending.length > 0 && versions.size < 2) {
+    const nodeModules = pending.pop()!
+    const resolvedNodeModules = await realpath(nodeModules).catch(() => undefined)
+    if (!resolvedNodeModules || visited.has(resolvedNodeModules)) {
+      continue
+    }
+    visited.add(resolvedNodeModules)
+
+    const resolvedVuePath = await realpath(resolve(resolvedNodeModules, 'vue')).catch(() => undefined)
+    if (resolvedVuePath) {
+      try {
+        const manifest = JSON.parse(await readFile(resolve(resolvedVuePath, 'package.json'), 'utf8')) as { version?: unknown }
+        if (typeof manifest.version === 'string') {
+          versions.add(manifest.version)
+        }
+      }
+      catch {
+        // Ignore incomplete package installations.
+      }
+    }
+
+    const entries = await readdir(resolvedNodeModules, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries) {
+      if (entry.name === '.bin' || entry.name === 'vue') {
+        continue
+      }
+      const packagePath = resolve(resolvedNodeModules, entry.name)
+      if (entry.name.startsWith('@')) {
+        const scopedPackages = await readdir(packagePath).catch(() => [])
+        for (const packageName of scopedPackages) {
+          pending.push(resolve(packagePath, packageName, 'node_modules'))
+        }
+      }
+      else if (entry.name === '.pnpm') {
+        const packages = await readdir(packagePath).catch(() => [])
+        for (const packageName of packages) {
+          if (packageName.startsWith('vue@')) {
+            pending.push(resolve(packagePath, packageName, 'node_modules'))
+          }
+        }
+      }
+      else {
+        pending.push(resolve(packagePath, 'node_modules'))
+      }
+    }
+  }
+
+  return [...versions].sort()
+}
 
 const NUXT_PROJECT_REFERENCE_RE = /(?:^|[/\\])tsconfig\.(?:app|server|shared|node)\.json$/
 

--- a/packages/nuxt-cli/test/unit/commands/typecheck.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/typecheck.spec.ts
@@ -1,6 +1,9 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { runCommand } from '../../../src/run'
 import { logger } from '../../../src/utils/logger'
@@ -31,6 +34,21 @@ function fixture(name: string) {
   return fileURLToPath(new URL(`../../fixtures/typecheck/${name}`, import.meta.url))
 }
 
+const tempDirs: string[] = []
+
+async function vueProject(...versions: string[]) {
+  const cwd = await mkdtemp(join(tmpdir(), 'nuxt-typecheck-'))
+  tempDirs.push(cwd)
+  for (const [index, version] of versions.entries()) {
+    const vueDir = index === 0
+      ? join(cwd, 'node_modules/vue')
+      : join(cwd, `node_modules/dependency-${index}/node_modules/vue`)
+    await mkdir(vueDir, { recursive: true })
+    await writeFile(join(vueDir, 'package.json'), JSON.stringify({ name: 'vue', version }))
+  }
+  return cwd
+}
+
 async function run(cwd: string, ...args: string[]) {
   await runCommand('typecheck', ['--cwd', cwd, ...args])
   return x.mock.calls[0]?.[1]
@@ -42,6 +60,10 @@ describe('nuxt typecheck command', () => {
     process.exitCode = undefined
     resolveModulePath.mockImplementation((id: string) => id.includes('vue-tsc') ? '/node_modules/vue-tsc/bin/vue-tsc.js' : '/node_modules/typescript/index.js')
     x.mockResolvedValue({ exitCode: 0 })
+  })
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map(directory => rm(directory, { recursive: true, force: true })))
   })
 
   it('should use build mode for Nuxt project references', async () => {
@@ -64,6 +86,26 @@ describe('nuxt typecheck command', () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
     await run(fixture('incomplete-references'))
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('"files": []'))
+    warn.mockRestore()
+  })
+
+  it('should warn when multiple Vue versions are installed', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    x.mockResolvedValueOnce({ exitCode: 2 })
+
+    await run(await vueProject('3.5.40', '3.5.41'))
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('3.5.40, 3.5.41'))
+    warn.mockRestore()
+  })
+
+  it('should not warn for duplicate copies of the same Vue version', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    x.mockResolvedValueOnce({ exitCode: 2 })
+
+    await run(await vueProject('3.5.41', '3.5.41'))
+
+    expect(warn).not.toHaveBeenCalled()
     warn.mockRestore()
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1448

### 📚 Description

A failed type check now warns when the installed dependency tree contains multiple Vue versions. The usual `TS2339` flood gives no clue that module augmentation landed on another Vue copy, so the warning points to deduping or pinning Vue before chasing hundreds of template errors.