### PR TITLE
fix(dev,info): print nitro version nuxt depends on

### DIFF
--- a/packages/nuxt-cli/src/commands/info.ts
+++ b/packages/nuxt-cli/src/commands/info.ts
@@ -19,11 +19,12 @@ import { resolveCatalogEntry } from '../utils/catalog'
 import { formatInfoBox } from '../utils/formatting'
 import { tryResolveNuxt } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { findNitroPkgName, NITRO_PKGS, NITRO_SERVER_PKG, NUXT_PKGS } from '../utils/nitro'
+import { NITRO_PKGS, resolveNuxtNitroDependency } from '../utils/nitro'
 import { getNuxtConfig } from '../utils/nuxt-config'
 import { readDependencyPackageJson } from '../utils/package-json'
 import { getPackageManagerVersion } from '../utils/packageManagers'
 import { resolveRootDir } from '../utils/paths'
+import { getPkgJSON } from '../utils/pkg'
 import { rootDirArgs } from './_shared'
 
 const LEADING_SLASH_RE = /^\//
@@ -68,7 +69,7 @@ export default defineCommand({
     const [modules, nuxtVersion = '-', nitroVersion] = await Promise.all([
       modulesPromise,
       getDepVersion('nuxt').then(version => version || getDepVersion('nuxt-nightly')),
-      resolveNitroVersion([nuxtPath, cwd], getDepVersion),
+      resolveNitroVersion(cwd, getDepVersion),
     ])
     const builder = nuxtConfig.builder || 'vite'
     const packageManager = detectedPackageManager
@@ -138,12 +139,12 @@ export default defineCommand({
 })
 
 async function resolveNitroVersion(
-  roots: Array<string | null>,
+  cwd: string,
   getDepVersion: (name: string) => Promise<string | undefined>,
 ): Promise<string | undefined> {
-  const name = await resolveNitroPkgName(roots)
-  if (name) {
-    return getDepVersion(name)
+  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via }))
+  if (dep) {
+    return getDepVersion(dep.name)
   }
   // The owning manifest may be unreadable (`exports` withholding `package.json`,
   // or nitro installed without nuxt), so fall back to whatever is resolvable.
@@ -151,31 +152,6 @@ async function resolveNitroVersion(
     const version = await getDepVersion(pkg)
     if (version) {
       return version
-    }
-  }
-}
-
-/**
- * The Nitro package the installed Nuxt declares (directly or via
- * `@nuxt/nitro-server`), or `undefined` when no owning manifest can be read.
- */
-async function resolveNitroPkgName(roots: Array<string | null>): Promise<string | undefined> {
-  for (const owner of NUXT_PKGS) {
-    for (const root of roots) {
-      const manifest = root && await readDependencyPackageJson(owner, root)
-      if (!root || !manifest) {
-        continue
-      }
-      const name = findNitroPkgName(manifest)
-      if (name) {
-        return name
-      }
-      if (manifest.dependencies?.[NITRO_SERVER_PKG]) {
-        const serverName = findNitroPkgName(await readDependencyPackageJson(NITRO_SERVER_PKG, root))
-        if (serverName) {
-          return serverName
-        }
-      }
     }
   }
 }

--- a/packages/nuxt-cli/src/commands/info.ts
+++ b/packages/nuxt-cli/src/commands/info.ts
@@ -19,7 +19,7 @@ import { resolveCatalogEntry } from '../utils/catalog'
 import { formatInfoBox } from '../utils/formatting'
 import { tryResolveNuxt } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { findNitroPkgName, NITRO_OWNERS } from '../utils/nitro'
+import { findNitroPkgName, NITRO_PKGS, NITRO_SERVER_PKG, NUXT_PKGS } from '../utils/nitro'
 import { getNuxtConfig } from '../utils/nuxt-config'
 import { readDependencyPackageJson } from '../utils/package-json'
 import { getPackageManagerVersion } from '../utils/packageManagers'
@@ -68,7 +68,7 @@ export default defineCommand({
     const [modules, nuxtVersion = '-', nitroVersion] = await Promise.all([
       modulesPromise,
       getDepVersion('nuxt').then(version => version || getDepVersion('nuxt-nightly')),
-      resolveNitroPkgName([nuxtPath, cwd]).then(name => name && getDepVersion(name)),
+      resolveNitroVersion([nuxtPath, cwd], getDepVersion),
     ])
     const builder = nuxtConfig.builder || 'vite'
     const packageManager = detectedPackageManager
@@ -137,16 +137,44 @@ export default defineCommand({
   },
 })
 
+async function resolveNitroVersion(
+  roots: Array<string | null>,
+  getDepVersion: (name: string) => Promise<string | undefined>,
+): Promise<string | undefined> {
+  const name = await resolveNitroPkgName(roots)
+  if (name) {
+    return getDepVersion(name)
+  }
+  // The owning manifest may be unreadable (`exports` withholding `package.json`,
+  // or nitro installed without nuxt), so fall back to whatever is resolvable.
+  for (const pkg of NITRO_PKGS) {
+    const version = await getDepVersion(pkg)
+    if (version) {
+      return version
+    }
+  }
+}
+
 /**
- * The Nitro package the installed Nuxt declares, or `undefined` when no owning
- * manifest can be read.
+ * The Nitro package the installed Nuxt declares (directly or via
+ * `@nuxt/nitro-server`), or `undefined` when no owning manifest can be read.
  */
 async function resolveNitroPkgName(roots: Array<string | null>): Promise<string | undefined> {
-  for (const owner of NITRO_OWNERS) {
+  for (const owner of NUXT_PKGS) {
     for (const root of roots) {
-      const name = root && findNitroPkgName(await readDependencyPackageJson(owner, root))
+      const manifest = root && await readDependencyPackageJson(owner, root)
+      if (!root || !manifest) {
+        continue
+      }
+      const name = findNitroPkgName(manifest)
       if (name) {
         return name
+      }
+      if (manifest.dependencies?.[NITRO_SERVER_PKG]) {
+        const serverName = findNitroPkgName(await readDependencyPackageJson(NITRO_SERVER_PKG, root))
+        if (serverName) {
+          return serverName
+        }
       }
     }
   }

--- a/packages/nuxt-cli/src/commands/info.ts
+++ b/packages/nuxt-cli/src/commands/info.ts
@@ -19,6 +19,7 @@ import { resolveCatalogEntry } from '../utils/catalog'
 import { formatInfoBox } from '../utils/formatting'
 import { tryResolveNuxt } from '../utils/kit'
 import { logger } from '../utils/logger'
+import { findNitroPkgName, NITRO_OWNERS } from '../utils/nitro'
 import { getNuxtConfig } from '../utils/nuxt-config'
 import { readDependencyPackageJson } from '../utils/package-json'
 import { getPackageManagerVersion } from '../utils/packageManagers'
@@ -67,7 +68,7 @@ export default defineCommand({
     const [modules, nuxtVersion = '-', nitroVersion] = await Promise.all([
       modulesPromise,
       getDepVersion('nuxt').then(version => version || getDepVersion('nuxt-nightly')),
-      getDepVersion('nitropack').then(version => version || getDepVersion('nitro')),
+      resolveNitroPkgName([nuxtPath, cwd]).then(name => name && getDepVersion(name)),
     ])
     const builder = nuxtConfig.builder || 'vite'
     const packageManager = detectedPackageManager
@@ -135,6 +136,21 @@ export default defineCommand({
     })
   },
 })
+
+/**
+ * The Nitro package the installed Nuxt declares, or `undefined` when no owning
+ * manifest can be read.
+ */
+async function resolveNitroPkgName(roots: Array<string | null>): Promise<string | undefined> {
+  for (const owner of NITRO_OWNERS) {
+    for (const root of roots) {
+      const name = root && findNitroPkgName(await readDependencyPackageJson(owner, root))
+      if (name) {
+        return name
+      }
+    }
+  }
+}
 
 async function resolveDependencyVersion(
   name: string,

--- a/packages/nuxt-cli/src/commands/info.ts
+++ b/packages/nuxt-cli/src/commands/info.ts
@@ -19,12 +19,11 @@ import { resolveCatalogEntry } from '../utils/catalog'
 import { formatInfoBox } from '../utils/formatting'
 import { tryResolveNuxt } from '../utils/kit'
 import { logger } from '../utils/logger'
-import { NITRO_PKGS, resolveNuxtNitroDependency } from '../utils/nitro'
+import { resolveNitroVersion } from '../utils/nitro'
 import { getNuxtConfig } from '../utils/nuxt-config'
 import { readDependencyPackageJson } from '../utils/package-json'
 import { getPackageManagerVersion } from '../utils/packageManagers'
 import { resolveRootDir } from '../utils/paths'
-import { getPkgJSON } from '../utils/pkg'
 import { rootDirArgs } from './_shared'
 
 const LEADING_SLASH_RE = /^\//
@@ -137,24 +136,6 @@ export default defineCommand({
     })
   },
 })
-
-async function resolveNitroVersion(
-  cwd: string,
-  getDepVersion: (name: string) => Promise<string | undefined>,
-): Promise<string | undefined> {
-  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via }))
-  if (dep) {
-    return getDepVersion(dep.name)
-  }
-  // The owning manifest may be unreadable (`exports` withholding `package.json`,
-  // or nitro installed without nuxt), so fall back to whatever is resolvable.
-  for (const pkg of NITRO_PKGS) {
-    const version = await getDepVersion(pkg)
-    if (version) {
-      return version
-    }
-  }
-}
 
 async function resolveDependencyVersion(
   name: string,

--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -3,7 +3,7 @@ import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { styleText } from 'node:util'
 
 import { logger } from './logger'
-import { findNitroPkgName, NITRO_OWNERS, NITRO_PKGS } from './nitro'
+import { findNitroPkgName, NITRO_PKGS, NITRO_SERVER_PKG, NUXT_PKGS } from './nitro'
 import { getPkgJSON, getPkgVersion } from './pkg'
 
 export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string, provider?: { name: string, version: string } } {
@@ -29,15 +29,18 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
   }
 }
 
-/** The dependency path from the project to a package known to depend on Nitro. */
-function nitroOwnerVia(owner: string) {
-  return owner === '@nuxt/nitro-server' ? ['nuxt', owner] : [owner]
-}
-
 function getNitroVersion(cwd: string) {
-  for (const owner of NITRO_OWNERS) {
-    const via = nitroOwnerVia(owner)
-    const name = findNitroPkgName(getPkgJSON(cwd, owner, { via: via.slice(0, -1) }))
+  for (const owner of NUXT_PKGS) {
+    const manifest = getPkgJSON(cwd, owner)
+    if (!manifest) {
+      continue
+    }
+    let via = [owner]
+    let name = findNitroPkgName(manifest)
+    if (!name && manifest.dependencies?.[NITRO_SERVER_PKG]) {
+      name = findNitroPkgName(getPkgJSON(cwd, NITRO_SERVER_PKG, { via }))
+      via = [owner, NITRO_SERVER_PKG]
+    }
     if (name) {
       return getPkgVersion(cwd, name, { via })
     }

--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -3,7 +3,7 @@ import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { styleText } from 'node:util'
 
 import { logger } from './logger'
-import { findNitroPkgName, NITRO_PKGS, NITRO_SERVER_PKG, NUXT_PKGS } from './nitro'
+import { NITRO_PKGS, resolveNuxtNitroDependency } from './nitro'
 import { getPkgJSON, getPkgVersion } from './pkg'
 
 export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string, provider?: { name: string, version: string } } {
@@ -30,20 +30,9 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
 }
 
 function getNitroVersion(cwd: string) {
-  for (const owner of NUXT_PKGS) {
-    const manifest = getPkgJSON(cwd, owner)
-    if (!manifest) {
-      continue
-    }
-    let via = [owner]
-    let name = findNitroPkgName(manifest)
-    if (!name && manifest.dependencies?.[NITRO_SERVER_PKG]) {
-      name = findNitroPkgName(getPkgJSON(cwd, NITRO_SERVER_PKG, { via }))
-      via = [owner, NITRO_SERVER_PKG]
-    }
-    if (name) {
-      return getPkgVersion(cwd, name, { via })
-    }
+  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via }))
+  if (dep) {
+    return getPkgVersion(cwd, dep.name, { via: dep.via })
   }
   // The owning manifest may be unreadable (`exports` withholding `package.json`,
   // or nitro installed without nuxt), so fall back to whatever is resolvable.

--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -3,7 +3,7 @@ import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { styleText } from 'node:util'
 
 import { logger } from './logger'
-import { NITRO_PKGS, resolveNuxtNitroDependency } from './nitro'
+import { getNitroVersion } from './nitro'
 import { getPkgJSON, getPkgVersion } from './pkg'
 
 export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string, provider?: { name: string, version: string } } {
@@ -29,22 +29,6 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
   }
 }
 
-function getNitroVersion(cwd: string) {
-  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via }))
-  if (dep) {
-    return getPkgVersion(cwd, dep.name, { via: dep.via })
-  }
-  // The owning manifest may be unreadable (`exports` withholding `package.json`,
-  // or nitro installed without nuxt), so fall back to whatever is resolvable.
-  for (const name of NITRO_PKGS) {
-    const version = getPkgVersion(cwd, name)
-    if (version) {
-      return version
-    }
-  }
-  return ''
-}
-
 export function showBanner(nuxt: Nuxt) {
   const cwd = nuxt.options.rootDir
 
@@ -64,7 +48,7 @@ export function showBanner(nuxt: Nuxt) {
 
   const detail = parts.length > 1
     ? `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}`
-    : parts.join('')
+    : parts[0]
 
   logger.info(
     styleText('green', `Nuxt ${styleText('bold', nuxtVersion)}`)

--- a/packages/nuxt-cli/src/utils/banner.ts
+++ b/packages/nuxt-cli/src/utils/banner.ts
@@ -3,6 +3,7 @@ import type { Nuxt, NuxtBuilder, NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { styleText } from 'node:util'
 
 import { logger } from './logger'
+import { findNitroPkgName, NITRO_OWNERS, NITRO_PKGS } from './nitro'
 import { getPkgJSON, getPkgVersion } from './pkg'
 
 export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] | NuxtConfig['builder'], NuxtBuilder>): { name: string, version: string, provider?: { name: string, version: string } } {
@@ -28,23 +29,53 @@ export function getBuilder(cwd: string, builder: Exclude<NuxtOptions['builder'] 
   }
 }
 
+/** The dependency path from the project to a package known to depend on Nitro. */
+function nitroOwnerVia(owner: string) {
+  return owner === '@nuxt/nitro-server' ? ['nuxt', owner] : [owner]
+}
+
+function getNitroVersion(cwd: string) {
+  for (const owner of NITRO_OWNERS) {
+    const via = nitroOwnerVia(owner)
+    const name = findNitroPkgName(getPkgJSON(cwd, owner, { via: via.slice(0, -1) }))
+    if (name) {
+      return getPkgVersion(cwd, name, { via })
+    }
+  }
+  // The owning manifest may be unreadable (`exports` withholding `package.json`,
+  // or nitro installed without nuxt), so fall back to whatever is resolvable.
+  for (const name of NITRO_PKGS) {
+    const version = getPkgVersion(cwd, name)
+    if (version) {
+      return version
+    }
+  }
+  return ''
+}
+
 export function showBanner(nuxt: Nuxt) {
   const cwd = nuxt.options.rootDir
 
   const nuxtVersion = nuxt._version || getPkgVersion(cwd, 'nuxt') || getPkgVersion(cwd, 'nuxt-nightly')
 
-  const nitroVia = { via: ['nuxt', '@nuxt/nitro-server'] }
-  const nitroVersion = getPkgVersion(cwd, 'nitropack', nitroVia) || getPkgVersion(cwd, 'nitro', nitroVia) || getPkgVersion(cwd, 'nitropack-nightly') || getPkgVersion(cwd, 'nitropack-edge')
+  const nitroVersion = getNitroVersion(cwd)
   const builder = getBuilder(cwd, nuxt.options.builder)
   const vueVersion = getPkgVersion(cwd, 'vue', { via: ['nuxt'] }) || null
 
+  const builderPart = `${builder.name} ${styleText('bold', builder.version)}${builder.provider ? ` via ${builder.provider.name} ${styleText('bold', builder.provider.version)}` : ''}`
+
+  const parts = [
+    nitroVersion ? `Nitro ${styleText('bold', nitroVersion)}` : null,
+    builderPart,
+    vueVersion ? `Vue ${styleText('bold', vueVersion)}` : null,
+  ].filter((part): part is string => !!part)
+
+  const detail = parts.length > 1
+    ? `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}`
+    : parts.join('')
+
   logger.info(
     styleText('green', `Nuxt ${styleText('bold', nuxtVersion)}`)
-    + styleText('gray', ' (with ')
-    + (nitroVersion ? styleText('gray', `Nitro ${styleText('bold', nitroVersion)}`) : '')
-    + styleText('gray', `, ${builder.name} ${styleText('bold', builder.version)}`)
-    + (builder.provider ? styleText('gray', ` via ${builder.provider.name} ${styleText('bold', builder.provider.version)}`) : '')
-    + (vueVersion ? styleText('gray', ` and Vue ${styleText('bold', vueVersion)}`) : '')
-    + styleText('gray', ')'),
+    + styleText('gray', ` (with ${detail})`),
   )
 }

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -1,5 +1,7 @@
 import type { PackageJson } from 'pkg-types'
 
+import { getPkgJSON, getPkgVersion } from './pkg'
+
 /**
  * Dependency names Nitro is declared under, newest naming first, so a manifest
  * that declares more than one resolves to the current name.
@@ -13,7 +15,7 @@ const NITRO_DEP_NAMES = ['nitro', 'nitropack']
  * Names Nitro is resolvable under when it cannot be found through Nuxt,
  * including the aliased releases in case one is installed directly.
  */
-export const NITRO_PKGS = [...NITRO_DEP_NAMES, 'nitro-nightly', 'nitropack-nightly', 'nitropack-edge']
+const NITRO_PKGS = [...NITRO_DEP_NAMES, 'nitro-nightly', 'nitropack-nightly', 'nitropack-edge']
 
 /**
  * The package that declares Nitro in Nuxt versions where `nuxt` itself does
@@ -59,6 +61,48 @@ export function resolveNuxtNitroDependency(
       if (serverName) {
         return { name: serverName, via: [owner, NITRO_SERVER_PKG] }
       }
+    }
+  }
+}
+
+/**
+ * The version of Nitro the installed Nuxt depends on.
+ *
+ * Falls back to any resolvable Nitro package when the owning manifest cannot be
+ * read (`exports` withholding `package.json`, or Nitro installed without Nuxt).
+ */
+export function getNitroVersion(cwd: string): string {
+  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via, strict: true }))
+  const declared = dep && getPkgVersion(cwd, dep.name, { via: dep.via, strict: true })
+  if (declared) {
+    return declared
+  }
+  for (const name of NITRO_PKGS) {
+    const version = getPkgVersion(cwd, name)
+    if (version) {
+      return version
+    }
+  }
+  return ''
+}
+
+/**
+ * The version of Nitro the installed Nuxt depends on, falling back to the
+ * version `getDepVersion` reports when no Nitro package can be resolved from
+ * the project (for example when it is only declared in a catalog).
+ */
+export async function resolveNitroVersion(
+  cwd: string,
+  getDepVersion: (name: string) => Promise<string | undefined>,
+): Promise<string | undefined> {
+  const version = getNitroVersion(cwd)
+  if (version) {
+    return version
+  }
+  for (const name of NITRO_PKGS) {
+    const declared = await getDepVersion(name)
+    if (declared) {
+      return declared
     }
   }
 }

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -59,29 +59,36 @@ export function resolveNuxtNitroDependency(
   }
 }
 
+/** A Nitro package to look for, optionally through a dependency path. */
+type NitroCandidate = Pick<NitroDependency, 'name'> & Partial<NitroDependency>
+
 /**
- * The version of Nitro the installed Nuxt depends on.
+ * The Nitro packages to look for, the one the installed Nuxt depends on first.
  *
- * Falls back to any resolvable Nitro package when the owning manifest cannot be
- * read (`exports` withholding `package.json`, or Nitro installed without Nuxt).
+ * The plain names are kept as later candidates so Nitro is still found when no
+ * owning manifest can be read (`exports` withholding `package.json`, or Nitro
+ * installed without Nuxt).
  */
-export function getNitroVersion(cwd: string): string {
-  return resolveInstalledNitro(cwd).version
+function getNitroCandidates(cwd: string): NitroCandidate[] {
+  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via, strict: true }))
+  const candidates: NitroCandidate[] = NITRO_PKGS.map(name => ({ name }))
+  return dep ? [dep, ...candidates] : candidates
 }
 
-function resolveInstalledNitro(cwd: string): { name?: string, version: string } {
-  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via, strict: true }))
-  const declared = dep && getPkgVersion(cwd, dep.name, { via: dep.via, strict: true })
-  if (declared) {
-    return { name: dep.name, version: declared }
-  }
-  for (const name of NITRO_PKGS) {
-    const version = getPkgVersion(cwd, name)
+/** The version of the first candidate installed in the project. */
+function getInstalledVersion(cwd: string, candidates: NitroCandidate[]): string {
+  for (const { name, via } of candidates) {
+    const version = getPkgVersion(cwd, name, via && { via, strict: true })
     if (version) {
-      return { name, version }
+      return version
     }
   }
-  return { name: dep?.name, version: '' }
+  return ''
+}
+
+/** The version of Nitro the installed Nuxt depends on. */
+export function getNitroVersion(cwd: string): string {
+  return getInstalledVersion(cwd, getNitroCandidates(cwd))
 }
 
 /**
@@ -93,14 +100,12 @@ export async function resolveNitroVersion(
   cwd: string,
   getDepVersion: (name: string) => Promise<string | undefined>,
 ): Promise<string | undefined> {
-  const { name: owned, version } = resolveInstalledNitro(cwd)
+  const candidates = getNitroCandidates(cwd)
+  const version = getInstalledVersion(cwd, candidates)
   if (version) {
     return version
   }
-  // Nuxt's own dependency is asked for first, so a stale declaration of the
-  // other name cannot win when neither package is resolvable.
-  const names = owned ? [owned, ...NITRO_PKGS.filter(name => name !== owned)] : NITRO_PKGS
-  for (const name of names) {
+  for (const { name } of candidates) {
     const declared = await getDepVersion(name)
     if (declared) {
       return declared

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -21,7 +21,7 @@ export const NITRO_PKGS = [...NITRO_DEP_NAMES, 'nitro-nightly', 'nitropack-night
  * a copy installed outside the Nuxt dependency chain cannot shadow the Nitro
  * version Nuxt actually uses.
  */
-export const NITRO_SERVER_PKG = '@nuxt/nitro-server'
+const NITRO_SERVER_PKG = '@nuxt/nitro-server'
 
 /**
  * Packages whose declared Nitro dependency is authoritative.
@@ -29,7 +29,39 @@ export const NITRO_SERVER_PKG = '@nuxt/nitro-server'
  * Nightly releases are usually aliased onto `nuxt`, so `nuxt-nightly` only
  * covers an install under its own name.
  */
-export const NUXT_PKGS = ['nuxt', 'nuxt-nightly']
+const NUXT_PKGS = ['nuxt', 'nuxt-nightly']
+
+export interface NitroDependency {
+  /** The Nitro package name the installed Nuxt declares. */
+  name: string
+  /** The dependency path from the project to the package declaring it. */
+  via: string[]
+}
+
+/**
+ * The Nitro package the installed Nuxt depends on, directly or through
+ * `@nuxt/nitro-server`, or `undefined` when no owning manifest can be read.
+ */
+export function resolveNuxtNitroDependency(
+  readManifest: (name: string, via?: string[]) => PackageJson | null | undefined,
+): NitroDependency | undefined {
+  for (const owner of NUXT_PKGS) {
+    const manifest = readManifest(owner)
+    if (!manifest) {
+      continue
+    }
+    const name = findNitroPkgName(manifest)
+    if (name) {
+      return { name, via: [owner] }
+    }
+    if (manifest.dependencies?.[NITRO_SERVER_PKG]) {
+      const serverName = findNitroPkgName(readManifest(NITRO_SERVER_PKG, [owner]))
+      if (serverName) {
+        return { name: serverName, via: [owner, NITRO_SERVER_PKG] }
+      }
+    }
+  }
+}
 
 /** The name of the Nitro package a manifest depends on. */
 export function findNitroPkgName(manifest: PackageJson | null | undefined): string | undefined {

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -27,20 +27,33 @@ const NITRO_SERVER_PKG = '@nuxt/nitro-server'
  */
 const NUXT_PKGS = ['nuxt', 'nuxt-nightly']
 
-export interface NitroDependency {
-  /** The Nitro package name the installed Nuxt declares. */
+interface NitroCandidate {
+  /** The name Nitro is installed under. */
   name: string
-  /** The dependency path from the project to the package declaring it. */
-  via: string[]
+  /** The dependency path to resolve it through, when Nuxt declares it. */
+  via?: string[]
+}
+
+/**
+ * The Nitro packages to look for, the one the installed Nuxt depends on first.
+ *
+ * The plain names are kept as later candidates so Nitro is still found when no
+ * owning manifest can be read (`exports` withholding `package.json`, or Nitro
+ * installed without Nuxt).
+ */
+function getNitroCandidates(cwd: string): NitroCandidate[] {
+  const candidates: NitroCandidate[] = NITRO_PKGS.map(name => ({ name }))
+  const declared = getNuxtNitroDependency(cwd)
+  return declared ? [declared, ...candidates] : candidates
 }
 
 /**
  * The Nitro package the installed Nuxt depends on, directly or through
  * `@nuxt/nitro-server`, or `undefined` when no owning manifest can be read.
  */
-export function resolveNuxtNitroDependency(
-  readManifest: (name: string, via?: string[]) => PackageJson | null | undefined,
-): NitroDependency | undefined {
+function getNuxtNitroDependency(cwd: string): NitroCandidate | undefined {
+  const readManifest = (name: string, via?: string[]) => getPkgJSON(cwd, name, { via, strict: true })
+
   for (const owner of NUXT_PKGS) {
     const manifest = readManifest(owner)
     if (!manifest) {
@@ -51,28 +64,18 @@ export function resolveNuxtNitroDependency(
       return { name, via: [owner] }
     }
     if (manifest.dependencies?.[NITRO_SERVER_PKG]) {
-      const serverName = findNitroPkgName(readManifest(NITRO_SERVER_PKG, [owner]))
-      if (serverName) {
-        return { name: serverName, via: [owner, NITRO_SERVER_PKG] }
+      const server = findNitroPkgName(readManifest(NITRO_SERVER_PKG, [owner]))
+      if (server) {
+        return { name: server, via: [owner, NITRO_SERVER_PKG] }
       }
     }
   }
 }
 
-/** A Nitro package to look for, optionally through a dependency path. */
-type NitroCandidate = Pick<NitroDependency, 'name'> & Partial<NitroDependency>
-
-/**
- * The Nitro packages to look for, the one the installed Nuxt depends on first.
- *
- * The plain names are kept as later candidates so Nitro is still found when no
- * owning manifest can be read (`exports` withholding `package.json`, or Nitro
- * installed without Nuxt).
- */
-function getNitroCandidates(cwd: string): NitroCandidate[] {
-  const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via, strict: true }))
-  const candidates: NitroCandidate[] = NITRO_PKGS.map(name => ({ name }))
-  return dep ? [dep, ...candidates] : candidates
+/** The name of the Nitro package a manifest depends on. */
+function findNitroPkgName(manifest: PackageJson | null | undefined): string | undefined {
+  const deps = manifest?.dependencies
+  return deps && NITRO_PKGS.find(name => name in deps)
 }
 
 /** The version of the first candidate installed in the project. */
@@ -111,10 +114,4 @@ export async function resolveNitroVersion(
       return declared
     }
   }
-}
-
-/** The name of the Nitro package a manifest depends on. */
-export function findNitroPkgName(manifest: PackageJson | null | undefined): string | undefined {
-  const deps = manifest?.dependencies
-  return deps && NITRO_PKGS.find(name => name in deps)
 }

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -1,0 +1,31 @@
+import type { PackageJson } from 'pkg-types'
+
+/**
+ * Dependency names Nitro is declared under, newest naming first, so a manifest
+ * that declares more than one resolves to the current name.
+ *
+ * Nightly and edge releases are aliased onto these names (for example
+ * `"nitro": "npm:nitro-nightly@latest"`), so they are not separate keys.
+ */
+const NITRO_DEP_NAMES = ['nitro', 'nitropack']
+
+/**
+ * Names Nitro is resolvable under when it cannot be found through an owner,
+ * including the aliased releases in case one is installed directly.
+ */
+export const NITRO_PKGS = [...NITRO_DEP_NAMES, 'nitro-nightly', 'nitropack-nightly', 'nitropack-edge']
+
+/**
+ * Packages that depend on Nitro, nearest first.
+ *
+ * Nitro is a dependency of `@nuxt/nitro-server` (itself a dependency of `nuxt`),
+ * or of `nuxt` in versions that predate it. Nightly releases are usually aliased
+ * onto `nuxt`, so `nuxt-nightly` only covers an install under its own name.
+ */
+export const NITRO_OWNERS = ['@nuxt/nitro-server', 'nuxt', 'nuxt-nightly']
+
+/** The name of the Nitro package a manifest depends on. */
+export function findNitroPkgName(manifest: PackageJson | null | undefined): string | undefined {
+  const deps = manifest?.dependencies
+  return deps && NITRO_DEP_NAMES.find(name => name in deps)
+}

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -10,19 +10,26 @@ import type { PackageJson } from 'pkg-types'
 const NITRO_DEP_NAMES = ['nitro', 'nitropack']
 
 /**
- * Names Nitro is resolvable under when it cannot be found through an owner,
+ * Names Nitro is resolvable under when it cannot be found through Nuxt,
  * including the aliased releases in case one is installed directly.
  */
 export const NITRO_PKGS = [...NITRO_DEP_NAMES, 'nitro-nightly', 'nitropack-nightly', 'nitropack-edge']
 
 /**
- * Packages that depend on Nitro, nearest first.
- *
- * Nitro is a dependency of `@nuxt/nitro-server` (itself a dependency of `nuxt`),
- * or of `nuxt` in versions that predate it. Nightly releases are usually aliased
- * onto `nuxt`, so `nuxt-nightly` only covers an install under its own name.
+ * The package that declares Nitro in Nuxt versions where `nuxt` itself does
+ * not. Only consulted when the installed Nuxt declares it as a dependency, so
+ * a copy installed outside the Nuxt dependency chain cannot shadow the Nitro
+ * version Nuxt actually uses.
  */
-export const NITRO_OWNERS = ['@nuxt/nitro-server', 'nuxt', 'nuxt-nightly']
+export const NITRO_SERVER_PKG = '@nuxt/nitro-server'
+
+/**
+ * Packages whose declared Nitro dependency is authoritative.
+ *
+ * Nightly releases are usually aliased onto `nuxt`, so `nuxt-nightly` only
+ * covers an install under its own name.
+ */
+export const NUXT_PKGS = ['nuxt', 'nuxt-nightly']
 
 /** The name of the Nitro package a manifest depends on. */
 export function findNitroPkgName(manifest: PackageJson | null | undefined): string | undefined {

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -3,19 +3,13 @@ import type { PackageJson } from 'pkg-types'
 import { getPkgJSON, getPkgVersion } from './pkg'
 
 /**
- * Dependency names Nitro is declared under, newest naming first, so a manifest
- * that declares more than one resolves to the current name.
+ * Names Nitro is installed under, newest naming first, so a manifest that
+ * declares more than one resolves to the current name.
  *
- * Nightly and edge releases are aliased onto these names (for example
- * `"nitro": "npm:nitro-nightly@latest"`), so they are not separate keys.
+ * Nightly releases are aliased onto these names (for example
+ * `"nitropack": "npm:nitropack-nightly@latest"`), so they are not separate keys.
  */
-const NITRO_DEP_NAMES = ['nitro', 'nitropack']
-
-/**
- * Names Nitro is resolvable under when it cannot be found through Nuxt,
- * including the aliased releases in case one is installed directly.
- */
-const NITRO_PKGS = [...NITRO_DEP_NAMES, 'nitro-nightly', 'nitropack-nightly', 'nitropack-edge']
+const NITRO_PKGS = ['nitro', 'nitropack']
 
 /**
  * The package that declares Nitro in Nuxt versions where `nuxt` itself does
@@ -117,5 +111,5 @@ export async function resolveNitroVersion(
 /** The name of the Nitro package a manifest depends on. */
 export function findNitroPkgName(manifest: PackageJson | null | undefined): string | undefined {
   const deps = manifest?.dependencies
-  return deps && NITRO_DEP_NAMES.find(name => name in deps)
+  return deps && NITRO_PKGS.find(name => name in deps)
 }

--- a/packages/nuxt-cli/src/utils/nitro.ts
+++ b/packages/nuxt-cli/src/utils/nitro.ts
@@ -72,18 +72,22 @@ export function resolveNuxtNitroDependency(
  * read (`exports` withholding `package.json`, or Nitro installed without Nuxt).
  */
 export function getNitroVersion(cwd: string): string {
+  return resolveInstalledNitro(cwd).version
+}
+
+function resolveInstalledNitro(cwd: string): { name?: string, version: string } {
   const dep = resolveNuxtNitroDependency((name, via) => getPkgJSON(cwd, name, { via, strict: true }))
   const declared = dep && getPkgVersion(cwd, dep.name, { via: dep.via, strict: true })
   if (declared) {
-    return declared
+    return { name: dep.name, version: declared }
   }
   for (const name of NITRO_PKGS) {
     const version = getPkgVersion(cwd, name)
     if (version) {
-      return version
+      return { name, version }
     }
   }
-  return ''
+  return { name: dep?.name, version: '' }
 }
 
 /**
@@ -95,11 +99,14 @@ export async function resolveNitroVersion(
   cwd: string,
   getDepVersion: (name: string) => Promise<string | undefined>,
 ): Promise<string | undefined> {
-  const version = getNitroVersion(cwd)
+  const { name: owned, version } = resolveInstalledNitro(cwd)
   if (version) {
     return version
   }
-  for (const name of NITRO_PKGS) {
+  // Nuxt's own dependency is asked for first, so a stale declaration of the
+  // other name cannot win when neither package is resolvable.
+  const names = owned ? [owned, ...NITRO_PKGS.filter(name => name !== owned)] : NITRO_PKGS
+  for (const name of names) {
     const declared = await getDepVersion(name)
     if (declared) {
       return declared

--- a/packages/nuxt-cli/src/utils/pkg.ts
+++ b/packages/nuxt-cli/src/utils/pkg.ts
@@ -3,9 +3,16 @@ import { resolveModulePath } from 'exsolve'
 
 import { tryResolveNuxt } from './kit'
 
-export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string[] }) {
+export function getPkgVersion(cwd: string, pkg: string, options?: PkgJSONOptions) {
   const pkgJSON = getPkgJSON(cwd, pkg, options)
   return pkgJSON?.version ?? ''
+}
+
+export interface PkgJSONOptions {
+  /** The dependency path to walk before resolving the package. */
+  via?: string[]
+  /** Resolve only through `via`, without falling back to `cwd` or `nuxt`. */
+  strict?: boolean
 }
 
 /**
@@ -21,9 +28,10 @@ export function getPkgVersion(cwd: string, pkg: string, options?: { via?: string
  *   getPkgJSON(cwd, 'webpack', { via: ['@nuxt/webpack-builder'] })
  *
  * Each entry is resolved from the location of the previous one,
- * starting from cwd. Falls back to direct resolution from cwd/nuxt.
+ * starting from cwd. Falls back to direct resolution from cwd/nuxt,
+ * unless `strict` is set, in which case only the chain is used.
  */
-export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string[] }) {
+export function getPkgJSON(cwd: string, pkg: string, options?: PkgJSONOptions) {
   // Build list of locations to try resolving pkg from.
   // When `via` is provided, walk the chain first; then fall back to cwd/nuxt.
   const roots: string[] = []
@@ -42,10 +50,12 @@ export function getPkgJSON(cwd: string, pkg: string, options?: { via?: string[] 
   }
 
   // Fallback: direct resolution from cwd or nuxt's location
-  roots.push(cwd)
-  const nuxtPath = tryResolveNuxt(cwd)
-  if (nuxtPath) {
-    roots.push(nuxtPath)
+  if (!options?.strict || !options.via?.length) {
+    roots.push(cwd)
+    const nuxtPath = tryResolveNuxt(cwd)
+    if (nuxtPath) {
+      roots.push(nuxtPath)
+    }
   }
 
   for (const root of roots) {

--- a/packages/nuxt-cli/test/unit/utils/banner.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/banner.spec.ts
@@ -9,30 +9,48 @@ const VERSIONS: Record<string, string> = {
   '@rspack/core': '1.3.0',
   'nuxt': '4.4.6',
   'nitropack': '2.13.4',
+  'nitro': '3.0.0',
   'vue': '3.5.39',
 }
 
+const CWD_VERSIONS: Record<string, Record<string, string>> = {
+  '/no-owner': { nitro: '' },
+  '/no-nitro': { nitro: '', nitropack: '' },
+}
+
+const NUXT_WITH_NITROPACK = { name: 'nuxt', version: '4.4.6', dependencies: { nitropack: '^2.13.4' } }
+const NITRO_SERVER = { name: '@nuxt/nitro-server', version: '5.0.0', dependencies: { nitro: '^3.0.0' } }
+
+const MANIFESTS: Record<string, Record<string, unknown>> = {
+  '/any': { nuxt: NUXT_WITH_NITROPACK },
+  '/missing': { nuxt: NUXT_WITH_NITROPACK },
+  '/vite-plus': { nuxt: NUXT_WITH_NITROPACK },
+  '/nitro-v3': { 'nuxt': { ...NUXT_WITH_NITROPACK, version: '5.0.0' }, '@nuxt/nitro-server': NITRO_SERVER },
+  '/no-owner': {},
+  '/no-nitro': {},
+}
+
 vi.mock('../../../src/utils/pkg', () => ({
-  getPkgJSON: vi.fn((_cwd: string, pkg: string, options?: { via?: string[] }) => {
+  getPkgJSON: vi.fn((cwd: string, pkg: string, options?: { via?: string[] }) => {
     if (pkg === 'vite' && options?.via?.includes('@nuxt/vite-builder')) {
-      if (_cwd === '/missing') {
+      if (cwd === '/missing') {
         return null
       }
-      if (_cwd === '/vite-plus') {
+      if (cwd === '/vite-plus') {
         return { name: '@voidzero-dev/vite-plus-core', version: '0.2.6', bundledVersions: { vite: '8.1.5' } }
       }
       return { name: 'vite', version: '7.3.1' }
     }
-    return null
+    return MANIFESTS[cwd]?.[pkg] ?? null
   }),
-  getPkgVersion: vi.fn((_cwd: string, pkg: string, options?: { via?: string[] }) => {
+  getPkgVersion: vi.fn((cwd: string, pkg: string, options?: { via?: string[] }) => {
     if (pkg === 'webpack' && !options?.via?.includes('@nuxt/webpack-builder')) {
       return ''
     }
     if (pkg === '@rspack/core' && !options?.via?.includes('@nuxt/rspack-builder')) {
       return ''
     }
-    return VERSIONS[pkg] || ''
+    return CWD_VERSIONS[cwd]?.[pkg] ?? VERSIONS[pkg] ?? ''
   }),
 }))
 
@@ -72,6 +90,36 @@ describe('showBanner', () => {
     expect(screen(renderer)).toMatchInlineSnapshot(`
       "│
       ●  Nuxt 4.4.6 (with Nitro 2.13.4, Vite 7.3.1 and Vue 3.5.39)"
+    `)
+  })
+
+  it('should prefer the nitro version declared by nuxt', async () => {
+    const renderer = await render(() =>
+      showBanner({ _version: '5.0.0', options: { rootDir: '/nitro-v3', builder: 'vite' } } as unknown as Nuxt))
+
+    expect(screen(renderer)).toMatchInlineSnapshot(`
+      "│
+      ●  Nuxt 5.0.0 (with Nitro 3.0.0, Vite 7.3.1 and Vue 3.5.39)"
+    `)
+  })
+
+  it('should fall back to an installed nitro when no owner declares it', async () => {
+    const renderer = await render(() =>
+      showBanner({ _version: '4.4.6', options: { rootDir: '/no-owner', builder: 'vite' } } as unknown as Nuxt))
+
+    expect(screen(renderer)).toMatchInlineSnapshot(`
+      "│
+      ●  Nuxt 4.4.6 (with Nitro 2.13.4, Vite 7.3.1 and Vue 3.5.39)"
+    `)
+  })
+
+  it('should omit nitro when no version can be resolved', async () => {
+    const renderer = await render(() =>
+      showBanner({ _version: '4.4.6', options: { rootDir: '/no-nitro', builder: 'vite' } } as unknown as Nuxt))
+
+    expect(screen(renderer)).toMatchInlineSnapshot(`
+      "│
+      ●  Nuxt 4.4.6 (with Vite 7.3.1 and Vue 3.5.39)"
     `)
   })
 

--- a/packages/nuxt-cli/test/unit/utils/banner.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/banner.spec.ts
@@ -19,13 +19,15 @@ const CWD_VERSIONS: Record<string, Record<string, string>> = {
 }
 
 const NUXT_WITH_NITROPACK = { name: 'nuxt', version: '4.4.6', dependencies: { nitropack: '^2.13.4' } }
+const NUXT_WITH_NITRO_SERVER = { name: 'nuxt', version: '5.0.0', dependencies: { '@nuxt/nitro-server': '^5.0.0' } }
 const NITRO_SERVER = { name: '@nuxt/nitro-server', version: '5.0.0', dependencies: { nitro: '^3.0.0' } }
 
 const MANIFESTS: Record<string, Record<string, unknown>> = {
   '/any': { nuxt: NUXT_WITH_NITROPACK },
   '/missing': { nuxt: NUXT_WITH_NITROPACK },
   '/vite-plus': { nuxt: NUXT_WITH_NITROPACK },
-  '/nitro-v3': { 'nuxt': { ...NUXT_WITH_NITROPACK, version: '5.0.0' }, '@nuxt/nitro-server': NITRO_SERVER },
+  '/nitro-v3': { 'nuxt': NUXT_WITH_NITRO_SERVER, '@nuxt/nitro-server': NITRO_SERVER },
+  '/direct-server': { 'nuxt': NUXT_WITH_NITROPACK, '@nuxt/nitro-server': NITRO_SERVER },
   '/no-owner': {},
   '/no-nitro': {},
 }
@@ -100,6 +102,16 @@ describe('showBanner', () => {
     expect(screen(renderer)).toMatchInlineSnapshot(`
       "│
       ●  Nuxt 5.0.0 (with Nitro 3.0.0, Vite 7.3.1 and Vue 3.5.39)"
+    `)
+  })
+
+  it('should follow nuxt\'s declared nitropack over a directly installed @nuxt/nitro-server', async () => {
+    const renderer = await render(() =>
+      showBanner({ _version: '4.4.6', options: { rootDir: '/direct-server', builder: 'vite' } } as unknown as Nuxt))
+
+    expect(screen(renderer)).toMatchInlineSnapshot(`
+      "│
+      ●  Nuxt 4.4.6 (with Nitro 2.13.4, Vite 7.3.1 and Vue 3.5.39)"
     `)
   })
 

--- a/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
@@ -2,7 +2,7 @@ import type { PackageJson } from 'pkg-types'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { findNitroPkgName, getNitroVersion, resolveNitroVersion, resolveNuxtNitroDependency } from '../../../src/utils/nitro'
+import { getNitroVersion, resolveNitroVersion } from '../../../src/utils/nitro'
 import { getPkgJSON, getPkgVersion } from '../../../src/utils/pkg'
 
 vi.mock('../../../src/utils/pkg', () => ({
@@ -10,142 +10,125 @@ vi.mock('../../../src/utils/pkg', () => ({
   getPkgVersion: vi.fn(),
 }))
 
-describe('findNitroPkgName', () => {
-  it('should read the declared nitro dependency', () => {
-    expect(findNitroPkgName({ dependencies: { nitro: '^3.0.0' } })).toBe('nitro')
-    expect(findNitroPkgName({ dependencies: { nitropack: '^2.13.0' } })).toBe('nitropack')
-  })
+/** Describe the packages installed in the project by name. */
+function installed(pkgs: Record<string, PackageJson>) {
+  vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => pkgs[pkg] ?? null)
+  vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg) => pkgs[pkg]?.version ?? '')
+}
 
-  it('should read an aliased nightly dependency under its declared name', () => {
-    expect(findNitroPkgName({ dependencies: { nitro: 'npm:nitro-nightly@latest' } })).toBe('nitro')
-    expect(findNitroPkgName({ dependencies: { nitropack: 'npm:nitropack-nightly@2.0.0' } })).toBe('nitropack')
-  })
-
-  it('should prefer the current name when several are declared', () => {
-    expect(findNitroPkgName({ dependencies: { nitro: '^3.0.0', nitropack: '^2.13.0' } })).toBe('nitro')
-  })
-
-  it('should read a dependency declared without a range', () => {
-    expect(findNitroPkgName({ dependencies: { nitro: '' } })).toBe('nitro')
-  })
-
-  it('should return undefined for a manifest without a nitro dependency', () => {
-    expect(findNitroPkgName({ dependencies: { vue: '^3.5.0' } })).toBeUndefined()
-    expect(findNitroPkgName({ dependencies: { 'nitro-nightly': 'latest' } })).toBeUndefined()
-    expect(findNitroPkgName({})).toBeUndefined()
-    expect(findNitroPkgName(null)).toBeUndefined()
-  })
-})
-
-describe('resolveNuxtNitroDependency', () => {
-  const reader = (manifests: Record<string, PackageJson>) =>
-    (name: string) => manifests[name] ?? null
-
-  it('should resolve nitro declared by nuxt directly', () => {
-    const read = reader({ nuxt: { dependencies: { nitropack: '^2.13.4' } } })
-
-    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitropack', via: ['nuxt'] })
-  })
-
-  it('should follow nuxt\'s declared @nuxt/nitro-server', () => {
-    const read = reader({
-      'nuxt': { dependencies: { '@nuxt/nitro-server': '^5.0.0' } },
-      '@nuxt/nitro-server': { dependencies: { nitro: '^3.0.0' } },
-    })
-
-    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitro', via: ['nuxt', '@nuxt/nitro-server'] })
-  })
-
-  it('should ignore @nuxt/nitro-server when nuxt does not declare it', () => {
-    const read = reader({
-      'nuxt': { dependencies: { nitropack: '^2.13.4' } },
-      '@nuxt/nitro-server': { dependencies: { nitro: '^3.0.0' } },
-    })
-
-    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitropack', via: ['nuxt'] })
-  })
-
-  it('should resolve nitro declared by nuxt-nightly', () => {
-    const read = reader({ 'nuxt-nightly': { dependencies: { nitropack: '^2.13.4' } } })
-
-    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitropack', via: ['nuxt-nightly'] })
-  })
-
-  it('should return undefined when no manifest is readable', () => {
-    expect(resolveNuxtNitroDependency(() => null)).toBeUndefined()
-    expect(resolveNuxtNitroDependency(reader({ nuxt: { dependencies: { vue: '^3.5.0' } } }))).toBeUndefined()
-  })
+beforeEach(() => {
+  vi.mocked(getPkgJSON).mockReset()
+  vi.mocked(getPkgVersion).mockReset()
 })
 
 describe('getNitroVersion', () => {
-  beforeEach(() => {
-    vi.mocked(getPkgJSON).mockReset()
-    vi.mocked(getPkgVersion).mockReset()
-  })
-
-  it('should resolve the version through the nuxt dependency chain', () => {
-    vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => ({
-      'nuxt': { dependencies: { '@nuxt/nitro-server': '^4.5.2' } },
-      '@nuxt/nitro-server': { dependencies: { nitropack: '^2.13.4' } },
-    }[pkg] ?? null))
-    vi.mocked(getPkgVersion).mockReturnValue('2.13.4')
+  it('should read the version nuxt declares', () => {
+    installed({
+      nuxt: { dependencies: { nitropack: '^2.13.4' } },
+      nitropack: { version: '2.13.4' },
+    })
 
     expect(getNitroVersion('/project')).toBe('2.13.4')
-    expect(getPkgVersion).toHaveBeenCalledWith('/project', 'nitropack', { via: ['nuxt', '@nuxt/nitro-server'], strict: true })
+    expect(getPkgVersion).toHaveBeenCalledWith('/project', 'nitropack', { via: ['nuxt'], strict: true })
   })
 
-  it('should fall back to a directly resolvable nitro package', () => {
-    vi.mocked(getPkgJSON).mockReturnValue(null)
-    vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg) => pkg === 'nitropack' ? '2.13.4' : '')
+  it('should follow nuxt\'s declared @nuxt/nitro-server', () => {
+    installed({
+      'nuxt': { dependencies: { '@nuxt/nitro-server': '^5.0.0' } },
+      '@nuxt/nitro-server': { dependencies: { nitro: '^3.0.0' } },
+      'nitro': { version: '3.0.0' },
+    })
+
+    expect(getNitroVersion('/project')).toBe('3.0.0')
+    expect(getPkgVersion).toHaveBeenCalledWith('/project', 'nitro', { via: ['nuxt', '@nuxt/nitro-server'], strict: true })
+  })
+
+  it('should ignore @nuxt/nitro-server when nuxt does not declare it', () => {
+    installed({
+      'nuxt': { dependencies: { nitropack: '^2.13.4' } },
+      '@nuxt/nitro-server': { dependencies: { nitro: '^3.0.0' } },
+      'nitropack': { version: '2.13.4' },
+      'nitro': { version: '3.0.0' },
+    })
+
+    expect(getNitroVersion('/project')).toBe('2.13.4')
+  })
+
+  it('should read the version nuxt-nightly declares', () => {
+    installed({
+      'nuxt-nightly': { dependencies: { nitropack: '^2.13.4' } },
+      'nitropack': { version: '2.13.4' },
+    })
+
+    expect(getNitroVersion('/project')).toBe('2.13.4')
+  })
+
+  it('should read an aliased nightly dependency under its declared name', () => {
+    installed({
+      nuxt: { dependencies: { nitropack: 'npm:nitropack-nightly@latest' } },
+      nitropack: { version: '2.14.0-nightly' },
+    })
+
+    expect(getNitroVersion('/project')).toBe('2.14.0-nightly')
+  })
+
+  it('should prefer the current name when nuxt declares several', () => {
+    installed({
+      nuxt: { dependencies: { nitro: '^3.0.0', nitropack: '^2.13.4' } },
+      nitro: { version: '3.0.0' },
+      nitropack: { version: '2.13.4' },
+    })
+
+    expect(getNitroVersion('/project')).toBe('3.0.0')
+  })
+
+  it('should fall back to an installed nitro when nuxt declares none', () => {
+    installed({
+      nuxt: { dependencies: { vue: '^3.5.0' } },
+      nitropack: { version: '2.13.4' },
+    })
 
     expect(getNitroVersion('/project')).toBe('2.13.4')
   })
 
   it('should fall back when the declared package cannot be resolved', () => {
-    vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => pkg === 'nuxt' ? { dependencies: { nitro: '^3.0.0' } } : null)
+    installed({ nitropack: { version: '2.13.4' } })
     vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg, options) => pkg === 'nitropack' && !options?.via ? '2.13.4' : '')
 
     expect(getNitroVersion('/project')).toBe('2.13.4')
   })
 
   it('should return an empty string when nitro is not installed', () => {
-    vi.mocked(getPkgJSON).mockReturnValue(null)
-    vi.mocked(getPkgVersion).mockReturnValue('')
+    installed({ nuxt: { dependencies: { nitropack: '^2.13.4' } } })
 
     expect(getNitroVersion('/project')).toBe('')
   })
 })
 
 describe('resolveNitroVersion', () => {
-  beforeEach(() => {
-    vi.mocked(getPkgJSON).mockReset()
-    vi.mocked(getPkgVersion).mockReset()
-  })
-
   it('should prefer the installed version', async () => {
-    vi.mocked(getPkgJSON).mockReturnValue(null)
-    vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg) => pkg === 'nitropack' ? '2.13.4' : '')
+    installed({
+      nuxt: { dependencies: { nitropack: '^2.13.4' } },
+      nitropack: { version: '2.13.4' },
+    })
 
     await expect(resolveNitroVersion('/project', async () => '2.0.0')).resolves.toBe('2.13.4')
   })
 
   it('should prefer the declared version of the package nuxt depends on', async () => {
-    vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => pkg === 'nuxt' ? { dependencies: { nitropack: '^2.13.4' } } : null)
-    vi.mocked(getPkgVersion).mockReturnValue('')
+    installed({ nuxt: { dependencies: { nitropack: '^2.13.4' } } })
 
     await expect(resolveNitroVersion('/project', async name => ({ nitro: '^3.0.0', nitropack: '^2.13.4' }[name]))).resolves.toBe('^2.13.4')
   })
 
   it('should fall back to a declared version when nothing is installed', async () => {
-    vi.mocked(getPkgJSON).mockReturnValue(null)
-    vi.mocked(getPkgVersion).mockReturnValue('')
+    installed({})
 
     await expect(resolveNitroVersion('/project', async name => name === 'nitropack' ? '^2.13.4' : undefined)).resolves.toBe('^2.13.4')
   })
 
   it('should return undefined when no version can be found', async () => {
-    vi.mocked(getPkgJSON).mockReturnValue(null)
-    vi.mocked(getPkgVersion).mockReturnValue('')
+    installed({})
 
     await expect(resolveNitroVersion('/project', async () => undefined)).resolves.toBeUndefined()
   })

--- a/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
@@ -129,6 +129,13 @@ describe('resolveNitroVersion', () => {
     await expect(resolveNitroVersion('/project', async () => '2.0.0')).resolves.toBe('2.13.4')
   })
 
+  it('should prefer the declared version of the package nuxt depends on', async () => {
+    vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => pkg === 'nuxt' ? { dependencies: { nitropack: '^2.13.4' } } : null)
+    vi.mocked(getPkgVersion).mockReturnValue('')
+
+    await expect(resolveNitroVersion('/project', async name => ({ nitro: '^3.0.0', nitropack: '^2.13.4' }[name]))).resolves.toBe('^2.13.4')
+  })
+
   it('should fall back to a declared version when nothing is installed', async () => {
     vi.mocked(getPkgJSON).mockReturnValue(null)
     vi.mocked(getPkgVersion).mockReturnValue('')

--- a/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { findNitroPkgName } from '../../../src/utils/nitro'
+
+describe('findNitroPkgName', () => {
+  it('should read the declared nitro dependency', () => {
+    expect(findNitroPkgName({ dependencies: { nitro: '^3.0.0' } })).toBe('nitro')
+    expect(findNitroPkgName({ dependencies: { nitropack: '^2.13.0' } })).toBe('nitropack')
+  })
+
+  it('should read an aliased nightly dependency under its declared name', () => {
+    expect(findNitroPkgName({ dependencies: { nitro: 'npm:nitro-nightly@latest' } })).toBe('nitro')
+    expect(findNitroPkgName({ dependencies: { nitropack: 'npm:nitropack-nightly@2.0.0' } })).toBe('nitropack')
+  })
+
+  it('should prefer the current name when several are declared', () => {
+    expect(findNitroPkgName({ dependencies: { nitro: '^3.0.0', nitropack: '^2.13.0' } })).toBe('nitro')
+  })
+
+  it('should read a dependency declared without a range', () => {
+    expect(findNitroPkgName({ dependencies: { nitro: '' } })).toBe('nitro')
+  })
+
+  it('should return undefined for a manifest without a nitro dependency', () => {
+    expect(findNitroPkgName({ dependencies: { vue: '^3.5.0' } })).toBeUndefined()
+    expect(findNitroPkgName({ dependencies: { 'nitro-nightly': 'latest' } })).toBeUndefined()
+    expect(findNitroPkgName({})).toBeUndefined()
+    expect(findNitroPkgName(null)).toBeUndefined()
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
@@ -1,8 +1,14 @@
 import type { PackageJson } from 'pkg-types'
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { findNitroPkgName, resolveNuxtNitroDependency } from '../../../src/utils/nitro'
+import { findNitroPkgName, getNitroVersion, resolveNitroVersion, resolveNuxtNitroDependency } from '../../../src/utils/nitro'
+import { getPkgJSON, getPkgVersion } from '../../../src/utils/pkg'
+
+vi.mock('../../../src/utils/pkg', () => ({
+  getPkgJSON: vi.fn(),
+  getPkgVersion: vi.fn(),
+}))
 
 describe('findNitroPkgName', () => {
   it('should read the declared nitro dependency', () => {
@@ -68,5 +74,72 @@ describe('resolveNuxtNitroDependency', () => {
   it('should return undefined when no manifest is readable', () => {
     expect(resolveNuxtNitroDependency(() => null)).toBeUndefined()
     expect(resolveNuxtNitroDependency(reader({ nuxt: { dependencies: { vue: '^3.5.0' } } }))).toBeUndefined()
+  })
+})
+
+describe('getNitroVersion', () => {
+  beforeEach(() => {
+    vi.mocked(getPkgJSON).mockReset()
+    vi.mocked(getPkgVersion).mockReset()
+  })
+
+  it('should resolve the version through the nuxt dependency chain', () => {
+    vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => ({
+      'nuxt': { dependencies: { '@nuxt/nitro-server': '^4.5.2' } },
+      '@nuxt/nitro-server': { dependencies: { nitropack: '^2.13.4' } },
+    }[pkg] ?? null))
+    vi.mocked(getPkgVersion).mockReturnValue('2.13.4')
+
+    expect(getNitroVersion('/project')).toBe('2.13.4')
+    expect(getPkgVersion).toHaveBeenCalledWith('/project', 'nitropack', { via: ['nuxt', '@nuxt/nitro-server'], strict: true })
+  })
+
+  it('should fall back to a directly resolvable nitro package', () => {
+    vi.mocked(getPkgJSON).mockReturnValue(null)
+    vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg) => pkg === 'nitropack' ? '2.13.4' : '')
+
+    expect(getNitroVersion('/project')).toBe('2.13.4')
+  })
+
+  it('should fall back when the declared package cannot be resolved', () => {
+    vi.mocked(getPkgJSON).mockImplementation((_cwd, pkg) => pkg === 'nuxt' ? { dependencies: { nitro: '^3.0.0' } } : null)
+    vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg, options) => pkg === 'nitropack' && !options?.via ? '2.13.4' : '')
+
+    expect(getNitroVersion('/project')).toBe('2.13.4')
+  })
+
+  it('should return an empty string when nitro is not installed', () => {
+    vi.mocked(getPkgJSON).mockReturnValue(null)
+    vi.mocked(getPkgVersion).mockReturnValue('')
+
+    expect(getNitroVersion('/project')).toBe('')
+  })
+})
+
+describe('resolveNitroVersion', () => {
+  beforeEach(() => {
+    vi.mocked(getPkgJSON).mockReset()
+    vi.mocked(getPkgVersion).mockReset()
+  })
+
+  it('should prefer the installed version', async () => {
+    vi.mocked(getPkgJSON).mockReturnValue(null)
+    vi.mocked(getPkgVersion).mockImplementation((_cwd, pkg) => pkg === 'nitropack' ? '2.13.4' : '')
+
+    await expect(resolveNitroVersion('/project', async () => '2.0.0')).resolves.toBe('2.13.4')
+  })
+
+  it('should fall back to a declared version when nothing is installed', async () => {
+    vi.mocked(getPkgJSON).mockReturnValue(null)
+    vi.mocked(getPkgVersion).mockReturnValue('')
+
+    await expect(resolveNitroVersion('/project', async name => name === 'nitropack' ? '^2.13.4' : undefined)).resolves.toBe('^2.13.4')
+  })
+
+  it('should return undefined when no version can be found', async () => {
+    vi.mocked(getPkgJSON).mockReturnValue(null)
+    vi.mocked(getPkgVersion).mockReturnValue('')
+
+    await expect(resolveNitroVersion('/project', async () => undefined)).resolves.toBeUndefined()
   })
 })

--- a/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/nitro.spec.ts
@@ -1,6 +1,8 @@
+import type { PackageJson } from 'pkg-types'
+
 import { describe, expect, it } from 'vitest'
 
-import { findNitroPkgName } from '../../../src/utils/nitro'
+import { findNitroPkgName, resolveNuxtNitroDependency } from '../../../src/utils/nitro'
 
 describe('findNitroPkgName', () => {
   it('should read the declared nitro dependency', () => {
@@ -26,5 +28,45 @@ describe('findNitroPkgName', () => {
     expect(findNitroPkgName({ dependencies: { 'nitro-nightly': 'latest' } })).toBeUndefined()
     expect(findNitroPkgName({})).toBeUndefined()
     expect(findNitroPkgName(null)).toBeUndefined()
+  })
+})
+
+describe('resolveNuxtNitroDependency', () => {
+  const reader = (manifests: Record<string, PackageJson>) =>
+    (name: string) => manifests[name] ?? null
+
+  it('should resolve nitro declared by nuxt directly', () => {
+    const read = reader({ nuxt: { dependencies: { nitropack: '^2.13.4' } } })
+
+    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitropack', via: ['nuxt'] })
+  })
+
+  it('should follow nuxt\'s declared @nuxt/nitro-server', () => {
+    const read = reader({
+      'nuxt': { dependencies: { '@nuxt/nitro-server': '^5.0.0' } },
+      '@nuxt/nitro-server': { dependencies: { nitro: '^3.0.0' } },
+    })
+
+    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitro', via: ['nuxt', '@nuxt/nitro-server'] })
+  })
+
+  it('should ignore @nuxt/nitro-server when nuxt does not declare it', () => {
+    const read = reader({
+      'nuxt': { dependencies: { nitropack: '^2.13.4' } },
+      '@nuxt/nitro-server': { dependencies: { nitro: '^3.0.0' } },
+    })
+
+    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitropack', via: ['nuxt'] })
+  })
+
+  it('should resolve nitro declared by nuxt-nightly', () => {
+    const read = reader({ 'nuxt-nightly': { dependencies: { nitropack: '^2.13.4' } } })
+
+    expect(resolveNuxtNitroDependency(read)).toEqual({ name: 'nitropack', via: ['nuxt-nightly'] })
+  })
+
+  it('should return undefined when no manifest is readable', () => {
+    expect(resolveNuxtNitroDependency(() => null)).toBeUndefined()
+    expect(resolveNuxtNitroDependency(reader({ nuxt: { dependencies: { vue: '^3.5.0' } } }))).toBeUndefined()
   })
 })

--- a/packages/nuxt-cli/test/unit/utils/pkg.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/pkg.spec.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { getPkgJSON } from '../../../src/utils/pkg'
+
+/** This package's own directory, where its dependencies resolve from. */
+const packageDir = fileURLToPath(new URL('../../../', import.meta.url))
+
+describe('getPkgJSON', () => {
+  it('should resolve a package through a dependency chain', () => {
+    const pkg = getPkgJSON(packageDir, 'nitropack', { via: ['nuxt', '@nuxt/nitro-server'] })
+
+    expect(pkg?.name).toBe('nitropack')
+  })
+
+  it('should fall back to direct resolution when the chain breaks', () => {
+    const pkg = getPkgJSON(packageDir, 'nuxt', { via: ['not-a-real-package-xyz'] })
+
+    expect(pkg?.name).toBe('nuxt')
+  })
+
+  it('should not fall back to direct resolution when strict', () => {
+    expect(getPkgJSON(packageDir, 'nuxt', { via: ['not-a-real-package-xyz'], strict: true })).toBeNull()
+  })
+
+  it('should resolve from the project when strict without a chain', () => {
+    expect(getPkgJSON(packageDir, 'nuxt', { strict: true })?.name).toBe('nuxt')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

for a project that might have both nitro/nitropack installed, we should follow nuxt's dependency rather than simply resolving the first one we can find