### PR TITLE
fix(dev): use a strict port when `_PORT` is provided to `_dev`

### DIFF
--- a/packages/nuxt-cli/src/commands/dev-child.ts
+++ b/packages/nuxt-cli/src/commands/dev-child.ts
@@ -24,7 +24,7 @@ export default defineCommand({
   async run(ctx) {
     const cwd = resolveRootDir(ctx.args)
     const listenOverrides = process.env._PORT
-      ? { port: process.env._PORT, hostname: '127.0.0.1', showURL: false } as const
+      ? { port: process.env._PORT, hostname: '127.0.0.1', showURL: false, strictPort: true } as const
       : undefined
 
     const { initialize } = await import('../dev')

--- a/packages/nuxt-cli/test/unit/commands/dev-child.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/dev-child.spec.ts
@@ -36,7 +36,22 @@ describe('nuxt _dev command', () => {
           port: '4321',
           hostname: '127.0.0.1',
           showURL: false,
+          strictPort: true,
         },
+      }),
+    )
+  })
+
+  it('should still allow a random port with `_PORT=0`', async () => {
+    vi.stubEnv('_PORT', '0')
+    const { runCommand } = await import('../../../src/run')
+
+    await runCommand('_dev', [])
+
+    expect(initialize).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        listenOverrides: expect.objectContaining({ port: '0', strictPort: true }),
       }),
     )
   })

--- a/packages/nuxt-cli/test/unit/listen.spec.ts
+++ b/packages/nuxt-cli/test/unit/listen.spec.ts
@@ -259,6 +259,11 @@ describe('listen', () => {
     const listener = await start({ port, strictPort: true })
     expect(listener.address.port).toBe(port)
   })
+
+  it('should still assign a random port with `strictPort` and port `0`', async () => {
+    const listener = await start({ port: 0, strictPort: true })
+    expect(listener.address.port).toBeGreaterThan(0)
+  })
 })
 
 describe('listener.close', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

when `nuxi _dev` is called, it's because test-utils wants to directly communicate with a port - we should error if we can't bind to it, rather than silently picking another one