### PR TITLE
fix(dev): disable timestamps on the project's consola instance

### DIFF
--- a/packages/nuxt-cli/src/dev/index.ts
+++ b/packages/nuxt-cli/src/dev/index.ts
@@ -6,6 +6,7 @@ import type { NuxtDevContext, NuxtDevIPCMessage, NuxtParentIPCMessage } from './
 import process from 'node:process'
 import defu from 'defu'
 import { resolveDotenvFileNames } from '../utils/args'
+import { configureProjectConsola } from '../utils/console'
 import { overrideEnv } from '../utils/env.ts'
 import { isRemotePeerError } from '../utils/errors'
 import { debug } from '../utils/logger'
@@ -130,6 +131,8 @@ interface InitializeReturn {
 
 export async function initialize(devContext: NuxtDevContext, ctx: InitializeOptions = {}): Promise<InitializeReturn> {
   overrideEnv('development')
+
+  await configureProjectConsola(devContext.cwd)
 
   const profileArg = devContext.args.profile
   const profiling = profileArg !== undefined

--- a/packages/nuxt-cli/src/utils/console.ts
+++ b/packages/nuxt-cli/src/utils/console.ts
@@ -1,10 +1,13 @@
 import type { ConsolaReporter } from 'consola'
 
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 import { consola } from 'consola'
+import { resolveModulePath } from 'exsolve'
 
 import { isRemotePeerError } from './errors'
+import { tryResolveNuxt } from './kit'
 import { debug } from './logger'
 import { trackOutputSpacing } from './stdout'
 
@@ -26,6 +29,23 @@ function wrapReporter(reporter: ConsolaReporter) {
       return reporter.log(logObj, ctx)
     },
   }) satisfies ConsolaReporter
+}
+
+export async function configureProjectConsola(rootDir: string): Promise<void> {
+  try {
+    const path = resolveModulePath('consola', { from: tryResolveNuxt(rootDir) || rootDir, try: true })
+    if (!path) {
+      return
+    }
+    const mod = await import(pathToFileURL(path).href) as { consola?: typeof consola, default?: typeof consola }
+    const projectConsola = mod.consola ?? mod.default
+    if (projectConsola) {
+      projectConsola.options.formatOptions.date = false
+    }
+  }
+  catch (error) {
+    debug('Could not configure the project consola:', error)
+  }
 }
 
 export function setupGlobalConsole(opts: { dev?: boolean } = {}) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in the event that the project's `consola` instance is different from the cli's `consola` instance, we need to set this in both places