### PR TITLE
feat(dev): suggest using `nuxt curl` when running non-interactively

### DIFF
--- a/packages/nuxt-cli/src/dev/shortcuts.ts
+++ b/packages/nuxt-cli/src/dev/shortcuts.ts
@@ -125,7 +125,7 @@ function availableShortcuts(context: ShortcutContext): Shortcut[] {
  */
 export function setupShortcuts(context: ShortcutContext): void {
   if (!process.stdin.isTTY || isCI || isTest) {
-    if (!isTest) {
+    if (!isCI && !isTest) {
       context.onReady(() => printRequestHint())
     }
     return

--- a/packages/nuxt-cli/src/dev/shortcuts.ts
+++ b/packages/nuxt-cli/src/dev/shortcuts.ts
@@ -103,6 +103,16 @@ function printHelp(context: ActionContext): void {
   console.log(`\n${lines.join('\n')}\n`)
 }
 
+/**
+ * Without a TTY there are no shortcuts to offer, so point at the way to talk to
+ * the server instead: non-interactive callers (scripts, agents) otherwise have
+ * no indication that one exists.
+ */
+function printRequestHint(): void {
+  // eslint-disable-next-line no-console
+  console.log(`\n  ${styleText('dim', 'run')} ${styleText('bold', 'nuxt curl /api/hello')} ${styleText('dim', 'to send a request to this server')}\n`)
+}
+
 function availableShortcuts(context: ShortcutContext): Shortcut[] {
   return shortcuts.filter(shortcut => shortcut.isAvailable?.(context) !== false)
 }
@@ -115,6 +125,9 @@ function availableShortcuts(context: ShortcutContext): Shortcut[] {
  */
 export function setupShortcuts(context: ShortcutContext): void {
   if (!process.stdin.isTTY || isCI || isTest) {
+    if (!isTest) {
+      context.onReady(() => printRequestHint())
+    }
     return
   }
 

--- a/packages/nuxt-cli/test/unit/dev-startup-log.spec.ts
+++ b/packages/nuxt-cli/test/unit/dev-startup-log.spec.ts
@@ -35,7 +35,14 @@ describe('startup reporter', () => {
 
   afterEach(() => {
     reporters.splice(0).forEach(reporter => reporter.stop())
+    vi.restoreAllMocks()
   })
+
+  /** The transient line renders elapsed time from the wall clock, which would otherwise tick between the update and the assertion. */
+  function freezeClock(): void {
+    const now = Date.now()
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+  }
 
   function reporter(animated: boolean): StartupReporter {
     const instance = createStartupReporter({ animated })
@@ -44,6 +51,7 @@ describe('startup reporter', () => {
   }
 
   it('should keep the progress line in place while loading', async () => {
+    freezeClock()
     const renderer = await render(() => {
       const startup = reporter(true)
       startup.update(snapshot())
@@ -149,6 +157,7 @@ describe('startup reporter', () => {
   }
 
   it('should keep the progress line in place under the dev console wrapper', async () => {
+    freezeClock()
     const renderer = await render(async () => {
       const restore = wrapStdoutAsConsolaDoes()
       try {

--- a/packages/nuxt-cli/test/unit/shortcuts.spec.ts
+++ b/packages/nuxt-cli/test/unit/shortcuts.spec.ts
@@ -46,7 +46,7 @@ describe('setupShortcuts', () => {
     Object.defineProperty(process, 'stdin', { value: stdin, configurable: true })
     restores.push(() => Object.defineProperty(process, 'stdin', { value: original, configurable: true }))
 
-    vi.spyOn(console, 'log').mockImplementation(() => {})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     const listener = {
       url: 'http://localhost:3000/',
@@ -66,6 +66,7 @@ describe('setupShortcuts', () => {
     return {
       context: resolved,
       listener,
+      log,
       stdin,
       press: async (input: string) => {
         stdin.write(`${input}\n`)
@@ -89,15 +90,22 @@ describe('setupShortcuts', () => {
   })
 
   it('should suggest `nuxt curl` when there is no TTY', () => {
-    setup({}, { isTTY: false })
+    const { log } = setup({}, { isTTY: false })
 
-    expect(vi.mocked(console.log).mock.calls.join('\n')).toContain('nuxt curl /api/hello')
+    expect(log.mock.calls.join('\n')).toContain('nuxt curl /api/hello')
+  })
+
+  it('should stay silent in CI', () => {
+    environment.isCI = true
+    const { log } = setup({}, { isTTY: false })
+
+    expect(log.mock.calls.join('\n')).not.toContain('nuxt curl')
   })
 
   it('should not suggest `nuxt curl` when shortcuts are available', () => {
-    setup()
+    const { log } = setup()
 
-    expect(vi.mocked(console.log).mock.calls.join('\n')).not.toContain('nuxt curl')
+    expect(log.mock.calls.join('\n')).not.toContain('nuxt curl')
   })
 
   it('should take stdin out of raw mode', async () => {

--- a/packages/nuxt-cli/test/unit/shortcuts.spec.ts
+++ b/packages/nuxt-cli/test/unit/shortcuts.spec.ts
@@ -88,6 +88,18 @@ describe('setupShortcuts', () => {
     expect(setup().stdin.listenerCount('data')).toBe(0)
   })
 
+  it('should suggest `nuxt curl` when there is no TTY', () => {
+    setup({}, { isTTY: false })
+
+    expect(vi.mocked(console.log).mock.calls.join('\n')).toContain('nuxt curl /api/hello')
+  })
+
+  it('should not suggest `nuxt curl` when shortcuts are available', () => {
+    setup()
+
+    expect(vi.mocked(console.log).mock.calls.join('\n')).not.toContain('nuxt curl')
+  })
+
   it('should take stdin out of raw mode', async () => {
     const { stdin, listener, press } = setup({}, { isRaw: true })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this should help with discoverability of `nuxt curl`, particularly if using with agents