### PR TITLE
docs: move cli documentation into repository

### DIFF
--- a/docs/.navigation.yml
+++ b/docs/.navigation.yml
@@ -1,0 +1,3 @@
+title: Commands
+titleTemplate: '%s · Nuxt Commands'
+icon: i-lucide-square-terminal

--- a/docs/add.md
+++ b/docs/add.md
@@ -1,0 +1,112 @@
+---
+title: "nuxt add"
+description: "Scaffold an entity into your Nuxt application."
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/add-template.ts
+    size: xs
+---
+
+<!--add-cmd-->
+```bash [Terminal]
+npx nuxt add <TEMPLATE> <NAME> [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--force]
+```
+<!--/add-cmd-->
+
+## Arguments
+
+<!--add-args-->
+| Argument   | Description                                                                                                                                                                                                      |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `TEMPLATE` | Specify which template to generate (options: <api\|app\|app-config\|component\|composable\|error\|layer\|layout\|middleware\|module\|page\|plugin\|server-middleware\|server-plugin\|server-route\|server-util>) |
+| `NAME`     | Specify name of the generated file                                                                                                                                                                               |
+<!--/add-args-->
+
+## Options
+
+<!--add-opts-->
+| Option                               | Default | Description                              |
+|--------------------------------------|---------|------------------------------------------|
+| `--cwd=<directory>`                  | `.`     | Specify the working directory            |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level             |
+| `--force`                            | `false` | Force override file if it already exists |
+<!--/add-opts-->
+
+**Modifiers:**
+
+Some templates support additional modifier flags to add a suffix (like `.client` or `.get`) to their name.
+
+```bash [Terminal]
+# Generates `/plugins/sockets.client.ts`
+npx nuxt add plugin sockets --client
+```
+
+## `nuxt add component`
+
+* Modifier flags: `--mode client|server` or `--client` or `--server`
+
+```bash [Terminal]
+# Generates `app/components/TheHeader.vue`
+npx nuxt add component TheHeader
+```
+
+## `nuxt add composable`
+
+```bash [Terminal]
+# Generates `app/composables/foo.ts`
+npx nuxt add composable foo
+```
+
+## `nuxt add layout`
+
+```bash [Terminal]
+# Generates `app/layouts/custom.vue`
+npx nuxt add layout custom
+```
+
+## `nuxt add plugin`
+
+* Modifier flags: `--mode client|server` or `--client`or `--server`
+
+```bash [Terminal]
+# Generates `app/plugins/analytics.ts`
+npx nuxt add plugin analytics
+```
+
+## `nuxt add page`
+
+```bash [Terminal]
+# Generates `app/pages/about.vue`
+npx nuxt add page about
+```
+
+```bash [Terminal]
+# Generates `app/pages/category/[id].vue`
+npx nuxt add page "category/[id]"
+```
+
+## `nuxt add middleware`
+
+* Modifier flags: `--global`
+
+```bash [Terminal]
+# Generates `app/middleware/auth.ts`
+npx nuxt add middleware auth
+```
+
+## `nuxt add api`
+
+* Modifier flags: `--method` (can accept `connect`, `delete`, `get`, `head`, `options`, `patch`, `post`, `put` or `trace`) or alternatively you can directly use `--get`, `--post`, etc.
+
+```bash [Terminal]
+# Generates `server/api/hello.ts`
+npx nuxt add api hello
+```
+
+## `nuxt add layer`
+
+```bash [Terminal]
+# Generates `layers/subscribe/nuxt.config.ts`
+npx nuxt add layer subscribe
+```

--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -1,0 +1,42 @@
+---
+title: "nuxt analyze"
+description: "Analyze the production bundle or your Nuxt application."
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/analyze.ts
+    size: xs
+---
+
+<!--analyze-cmd-->
+```bash [Terminal]
+npx nuxt analyze [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dotenv] [-e, --extends=<layer-name>] [--name=<name>] [--no-serve]
+```
+<!--/analyze-cmd-->
+
+The `analyze` command builds Nuxt and analyzes the production bundle (experimental).
+
+## Arguments
+
+<!--analyze-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/analyze-args-->
+
+## Options
+
+<!--analyze-opts-->
+| Option                               | Default   | Description                                                                      |
+|--------------------------------------|-----------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |           | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+| `--logLevel=<silent\|info\|verbose>` |           | Specify build-time log level                                                     |
+| `--dotenv`                           |           | Path to `.env` file to load, relative to the root directory                      |
+| `-e, --extends=<layer-name>`         |           | Extend from a Nuxt layer                                                         |
+| `--name=<name>`                      | `default` | Name of the analysis                                                             |
+| `--no-serve`                         |           | Skip serving the analysis results                                                |
+<!--/analyze-opts-->
+
+::note
+This command sets `process.env.NODE_ENV` to `production`.
+::

--- a/docs/build-module.md
+++ b/docs/build-module.md
@@ -1,0 +1,42 @@
+---
+title: 'nuxt build-module'
+description: 'Nuxt command to build your Nuxt module before publishing.'
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/module-builder/blob/main/src/cli.ts
+    size: xs
+---
+
+<!--build-module-cmd-->
+```bash [Terminal]
+npx nuxt build-module [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--build] [--stub] [--sourcemap] [--prepare]
+```
+<!--/build-module-cmd-->
+
+The `build-module` command runs `@nuxt/module-builder` to generate `dist` directory within your `rootDir` that contains the full build for your **nuxt-module**.
+
+## Arguments
+
+<!--build-module-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/build-module-args-->
+
+## Options
+
+<!--build-module-opts-->
+| Option                               | Default | Description                                                                      |
+|--------------------------------------|---------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                     |
+| `--build`                            | `false` | Build module for distribution                                                    |
+| `--stub`                             | `false` | Stub dist instead of actually building it for development                        |
+| `--sourcemap`                        | `false` | Generate sourcemaps                                                              |
+| `--prepare`                          | `false` | Prepare module for local development                                             |
+<!--/build-module-opts-->
+
+::read-more{to="https://github.com/nuxt/module-builder" icon="i-simple-icons-github" target="\_blank"}
+Read more about `@nuxt/module-builder`.
+::

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,48 @@
+---
+title: "nuxt build"
+description: "Build your Nuxt application."
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/build.ts
+    size: xs
+---
+
+<!--build-cmd-->
+```bash [Terminal]
+npx nuxt build [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--prerender] [--preset] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--profile[=verbose]]
+```
+<!--/build-cmd-->
+
+The `build` command creates a `.output` directory with all your application, server and dependencies ready for production.
+
+## Arguments
+
+<!--build-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/build-args-->
+
+## Options
+
+<!--build-opts-->
+| Option                               | Default | Description                                                                                                                                          |
+|--------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`)                                                                     |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
+| `--prerender`                        |         | Build Nuxt and prerender static routes                                                                                                               |
+| `--preset=<preset>`                  |         | Specify Nitro server preset. Available presets depend on Nitro (e.g. `node-server`, `vercel`, `netlify`, `static`)                                  |
+| `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
+| `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
+| `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+| `--profile` :badge[v4.4]{color="info" size="xs" class="align-middle"} |         | Profile performance. Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                             |
+<!--/build-opts-->
+
+::note
+This command sets `process.env.NODE_ENV` to `production`.
+::
+
+::note
+`--prerender` will always set the `preset` to `static`
+::

--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -1,0 +1,38 @@
+---
+title: 'nuxt cleanup'
+description: 'Remove common generated Nuxt files and caches.'
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/cleanup.ts
+    size: xs
+---
+
+<!--cleanup-cmd-->
+```bash [Terminal]
+npx nuxt cleanup [ROOTDIR] [--cwd=<directory>]
+```
+<!--/cleanup-cmd-->
+
+The `cleanup` command removes common generated Nuxt files and caches, including:
+
+- `.nuxt`
+- `.output`
+- `node_modules/.vite`
+- `node_modules/.cache`
+
+## Arguments
+
+<!--cleanup-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/cleanup-args-->
+
+## Options
+
+<!--cleanup-opts-->
+| Option              | Default | Description                                                                      |
+|---------------------|---------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>` |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+<!--/cleanup-opts-->

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,0 +1,61 @@
+---
+title: 'nuxt dev'
+description: The dev command starts a development server with hot module replacement at http://localhost:3000
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/dev.ts
+    size: xs
+---
+
+<!--dev-cmd-->
+```bash [Terminal]
+npx nuxt dev [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--clear] [--no-f, --no-fork] [-p, --port] [-h, --host] [--clipboard] [-o, --open] [--https] [--publicURL] [--qr] [--public] [--tunnel] [--profile[=verbose]] [--sslCert] [--sslKey]
+```
+<!--/dev-cmd-->
+
+The `dev` command starts a development server with hot module replacement at [http://localhost:3000](https://localhost:3000)
+
+## Arguments
+
+<!--dev-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/dev-args-->
+
+## Options
+
+<!--dev-opts-->
+| Option                               | Default | Description                                                                                                                                          |
+|--------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`)                                                                     |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
+| `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
+| `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
+| `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+| `--clear`                            | `false` | Clear console on restart                                                                                                                             |
+| `--no-f, --no-fork`                  |         | Disable forked mode                                                                                                                                  |
+| `-p, --port`                         |         | Port to listen on (default: `NUXT_PORT \|\| NITRO_PORT \|\| PORT \|\| nuxtOptions.devServer.port`)                                                   |
+| `-h, --host`                         |         | Host to listen on (default: `NUXT_HOST \|\| NITRO_HOST \|\| HOST \|\| nuxtOptions.devServer?.host`)                                                  |
+| `--clipboard`                        | `false` | Copy the URL to the clipboard                                                                                                                        |
+| `-o, --open`                         | `false` | Open the URL in the browser                                                                                                                          |
+| `--https`                            |         | Enable HTTPS                                                                                                                                         |
+| `--publicURL`                        |         | Displayed public URL (used for QR code)                                                                                                              |
+| `--qr`                               |         | Display The QR code of public URL when available                                                                                                     |
+| `--public`                           |         | Listen to all network interfaces                                                                                                                     |
+| `--tunnel`                           |         | Open a tunnel using https://github.com/unjs/untun                                                                                                    |
+| `--profile` :badge[v4.4]{color="info" size="xs" class="align-middle"} |         | Profile performance. Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                             |
+| `--sslCert`                          |         | (DEPRECATED) Use `--https.cert` instead.                                                                                                             |
+| `--sslKey`                           |         | (DEPRECATED) Use `--https.key` instead.                                                                                                              |
+<!--/dev-opts-->
+
+The port and host can also be set via NUXT_PORT, PORT, NUXT_HOST or HOST environment variables.
+
+Additionally to the above options, `@nuxt/cli` can pass options through to `listhen`, e.g. `--no-qr` to turn off the dev server QR code. You can find the list of `listhen` options in the [unjs/listhen](https://github.com/unjs/listhen) docs.
+
+This command sets `process.env.NODE_ENV` to `development`.
+
+::note
+If you are using a self-signed certificate in development, you will need to set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your environment.
+::

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -1,0 +1,38 @@
+---
+title: "nuxt devtools"
+description: The devtools command allows you to enable or disable Nuxt DevTools on a per-project basis.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/devtools.ts
+    size: xs
+---
+
+<!--devtools-cmd-->
+```bash [Terminal]
+npx nuxt devtools <COMMAND> [ROOTDIR] [--cwd=<directory>]
+```
+<!--/devtools-cmd-->
+
+Running `nuxt devtools enable` will install the Nuxt DevTools globally, and also enable it within the particular project you are using. It is saved as a preference in your user-level `.nuxtrc`. If you want to remove devtools support for a particular project, you can run `nuxt devtools disable`.
+
+## Arguments
+
+<!--devtools-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `COMMAND`     | Command to run (options: <enable\|disable>)    |
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/devtools-args-->
+
+## Options
+
+<!--devtools-opts-->
+| Option              | Default | Description                                                                      |
+|---------------------|---------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>` |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+<!--/devtools-opts-->
+
+::read-more{icon="i-simple-icons-nuxtdotjs" to="https://devtools.nuxt.com" target="\_blank"}
+Read more about the **Nuxt DevTools**.
+::

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -1,0 +1,43 @@
+---
+title: "nuxt generate"
+description: Pre-renders every route of the application and stores the result in plain HTML files.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/generate.ts
+    size: xs
+---
+
+<!--generate-cmd-->
+```bash [Terminal]
+npx nuxt generate [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--preset] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--profile[=verbose]]
+```
+<!--/generate-cmd-->
+
+The `generate` command pre-renders every route of your application and stores the result in plain HTML files that you can deploy on any static hosting services. The command triggers the `nuxt build` command with the `prerender` argument set to `true`
+
+## Arguments
+
+<!--generate-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/generate-args-->
+
+## Options
+
+<!--generate-opts-->
+| Option                               | Default | Description                                                                                                                                          |
+|--------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`)                                                                     |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
+| `--preset`                           |         | Nitro server preset                                                                                                                                  |
+| `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
+| `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
+| `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+| `--profile` :badge[v4.4]{color="info" size="xs" class="align-middle"} |         | Profile performance. Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                             |
+<!--/generate-opts-->
+
+::read-more{to="/docs/getting-started/deployment#static-hosting"}
+Read more about pre-rendering and static hosting.
+::

--- a/docs/info.md
+++ b/docs/info.md
@@ -1,0 +1,33 @@
+---
+title: "nuxt info"
+description: The info command logs information about the current or specified Nuxt project.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/info.ts
+    size: xs
+---
+
+<!--info-cmd-->
+```bash [Terminal]
+npx nuxt info [ROOTDIR] [--cwd=<directory>]
+```
+<!--/info-cmd-->
+
+The `info` command logs information about the current or specified Nuxt project.
+
+## Arguments
+
+<!--info-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/info-args-->
+
+## Options
+
+<!--info-opts-->
+| Option              | Default | Description                                                                      |
+|---------------------|---------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>` |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+<!--/info-opts-->

--- a/docs/init.md
+++ b/docs/init.md
@@ -1,0 +1,50 @@
+---
+title: "create nuxt"
+description: The init command initializes a fresh Nuxt project.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/init.ts
+    size: xs
+---
+
+<!--init-cmd-->
+```bash [Terminal]
+npm create nuxt@latest [DIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [-t, --template] [-f, --force] [--offline] [--preferOffline] [--no-install] [--gitInit] [--shell] [--packageManager] [-M, --modules] [--no-modules] [--nightly]
+```
+<!--/init-cmd-->
+
+The `create-nuxt` command initializes a fresh Nuxt project using [unjs/giget](https://github.com/unjs/giget).
+
+## Arguments
+
+<!--init-args-->
+| Argument | Description       |
+|----------|-------------------|
+| `DIR=""` | Project directory |
+<!--/init-args-->
+
+## Options
+
+<!--init-opts-->
+| Option                               | Default | Description                                              |
+|--------------------------------------|---------|----------------------------------------------------------|
+| `--cwd=<directory>`                  | `.`     | Specify the working directory                            |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                             |
+| `-t, --template`                     |         | Template name                                            |
+| `-f, --force`                        |         | Override existing directory                              |
+| `--offline`                          |         | Force offline mode                                       |
+| `--preferOffline`                    |         | Prefer offline mode                                      |
+| `--no-install`                       |         | Skip installing dependencies                             |
+| `--gitInit`                          |         | Initialize git repository                                |
+| `--shell`                            |         | Start shell after installation in project directory      |
+| `--packageManager`                   |         | Package manager choice (npm, pnpm, yarn, bun)            |
+| `-M, --modules`                      |         | Nuxt modules to install (comma separated without spaces) |
+| `--no-modules`                       |         | Skip module installation prompt                          |
+| `--nightly`                          |         | Use Nuxt nightly release channel (3x or latest)          |
+<!--/init-opts-->
+
+## Environment Variables
+
+- `NUXI_INIT_REGISTRY`: Set to a custom template registry. ([learn more](https://github.com/unjs/giget#custom-registry)).
+  - Default registry is loaded from [nuxt/starter/templates](https://github.com/nuxt/starter/tree/templates/templates)

--- a/docs/module.md
+++ b/docs/module.md
@@ -1,0 +1,84 @@
+---
+title: "nuxt module"
+description: "Search and add modules to your Nuxt application with the command line."
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/tree/main/packages/nuxi/src/commands/module
+    size: xs
+---
+
+Nuxt provides a few utilities to work with [Nuxt modules](/modules) seamlessly.
+
+## `nuxt module add`
+
+<!--module-add-cmd-->
+```bash [Terminal]
+npx nuxt module add <MODULENAME> [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--skipInstall] [--skipConfig] [--dev]
+```
+<!--/module-add-cmd-->
+
+<!--module-add-args-->
+| Argument     | Description                                                         |
+|--------------|---------------------------------------------------------------------|
+| `MODULENAME` | Specify one or more modules to install by name, separated by spaces |
+<!--/module-add-args-->
+
+<!--module-add-opts-->
+| Option                               | Default | Description                         |
+|--------------------------------------|---------|-------------------------------------|
+| `--cwd=<directory>`                  | `.`     | Specify the working directory       |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level        |
+| `--skipInstall`                      |         | Skip npm install                    |
+| `--skipConfig`                       |         | Skip nuxt.config.ts update          |
+| `--dev`                              |         | Install modules as dev dependencies |
+<!--/module-add-opts-->
+
+The command lets you install [Nuxt modules](/modules) in your application with no manual work.
+
+When running the command, it will:
+
+- install the module as a dependency using your package manager
+- add it to your [package.json](/docs/directory-structure/package) file
+- update your [`nuxt.config`](/docs/directory-structure/nuxt-config) file
+
+**Example:**
+
+Installing the [`Pinia`](/modules/pinia) module
+
+```bash [Terminal]
+npx nuxt module add pinia
+```
+
+## `nuxt module search`
+
+<!--module-search-cmd-->
+```bash [Terminal]
+npx nuxt module search <QUERY> [--cwd=<directory>] [--nuxtVersion=<2|3>]
+```
+<!--/module-search-cmd-->
+
+### Arguments
+
+<!--module-search-args-->
+| Argument | Description            |
+|----------|------------------------|
+| `QUERY`  | keywords to search for |
+<!--/module-search-args-->
+
+### Options
+
+<!--module-search-opts-->
+| Option                 | Default | Description                                                                        |
+|------------------------|---------|------------------------------------------------------------------------------------|
+| `--cwd=<directory>`    | `.`     | Specify the working directory                                                      |
+| `--nuxtVersion=<2\|3>` |         | Filter by Nuxt version and list compatible modules only (auto detected by default) |
+<!--/module-search-opts-->
+
+The command searches for Nuxt modules matching your query that are compatible with your Nuxt version.
+
+**Example:**
+
+```bash [Terminal]
+npx nuxt module search pinia
+```

--- a/docs/prepare.md
+++ b/docs/prepare.md
@@ -1,0 +1,41 @@
+---
+title: 'nuxt prepare'
+description: The prepare command creates a .nuxt directory in your application and generates types.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/prepare.ts
+    size: xs
+---
+
+<!--prepare-cmd-->
+```bash [Terminal]
+npx nuxt prepare [ROOTDIR] [--dotenv] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--envName] [-e, --extends=<layer-name>]
+```
+<!--/prepare-cmd-->
+
+The `prepare` command creates a [`.nuxt`](/docs/directory-structure/nuxt) directory in your application and generates types. This can be useful in a CI environment or as a `postinstall` command in your [`package.json`](/docs/directory-structure/package).
+
+## Arguments
+
+<!--prepare-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/prepare-args-->
+
+## Options
+
+<!--prepare-opts-->
+| Option                               | Default | Description                                                                                                                                          |
+|--------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`)                                                                     |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
+| `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
+| `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+<!--/prepare-opts-->
+
+::note
+This command sets `process.env.NODE_ENV` to `production`.
+::

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -1,0 +1,44 @@
+---
+title: "nuxt preview"
+description: The preview command starts a server to preview your application after the build command.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/preview.ts
+    size: xs
+---
+
+<!--preview-cmd-->
+```bash [Terminal]
+npx nuxt preview [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--envName] [-e, --extends=<layer-name>] [-p, --port] [--dotenv]
+```
+<!--/preview-cmd-->
+
+The `preview` command starts a server to preview your Nuxt application after running the `build` command. The `start` command is an alias for `preview`. When running your application in production refer to the [Deployment section](/docs/getting-started/deployment).
+
+## Arguments
+
+<!--preview-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/preview-args-->
+
+## Options
+
+<!--preview-opts-->
+| Option                               | Default | Description                                                                                                                                          |
+|--------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`)                                                                     |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
+| `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
+| `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+| `-p, --port`                         |         | Port to listen on (use `PORT` environment variable to override)                                                                                      |
+| `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
+<!--/preview-opts-->
+
+This command sets `process.env.NODE_ENV` to `production`. To override, define `NODE_ENV` in a `.env` file or as command-line argument.
+
+::note
+For convenience, in preview mode, your [`.env`](/docs/directory-structure/env) file will be loaded into `process.env`. (However, in production you will need to ensure your environment variables are set yourself. For example, with Node.js 20+ you could do this by running `NODE_ENV=production node --env-file .env .output/server/index.mjs` to start your server.)
+::

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,0 +1,40 @@
+---
+title: "nuxt test"
+description: The test command runs tests using @nuxt/test-utils.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/test.ts
+    size: xs
+---
+
+<!--test-cmd-->
+```bash [Terminal]
+npx nuxt test [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dev] [--watch]
+```
+<!--/test-cmd-->
+
+The `test` command runs tests using [`@nuxt/test-utils`](/docs/getting-started/testing). This command sets `process.env.NODE_ENV` to `test` if not already set.
+
+## Arguments
+
+<!--test-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/test-args-->
+
+## Options
+
+<!--test-opts-->
+| Option                               | Default | Description                                                                      |
+|--------------------------------------|---------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                     |
+| `--dev`                              |         | Run in dev mode                                                                  |
+| `--watch`                            |         | Watch mode                                                                       |
+<!--/test-opts-->
+
+::note
+This command sets `process.env.NODE_ENV` to `test`.
+::

--- a/docs/typecheck.md
+++ b/docs/typecheck.md
@@ -1,0 +1,44 @@
+---
+title: "nuxt typecheck"
+description: The typecheck command runs vue-tsc to check types throughout your app.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/typecheck.ts
+    size: xs
+---
+
+<!--typecheck-cmd-->
+```bash [Terminal]
+npx nuxt typecheck [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dotenv] [-e, --extends=<layer-name>]
+```
+<!--/typecheck-cmd-->
+
+The `typecheck` command runs [`vue-tsc`](https://github.com/vuejs/language-tools/tree/master/packages/tsc) to check types throughout your app.
+
+## Arguments
+
+<!--typecheck-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/typecheck-args-->
+
+## Options
+
+<!--typecheck-opts-->
+| Option                               | Default | Description                                                                      |
+|--------------------------------------|---------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>`                  |         | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+| `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                     |
+| `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                      |
+| `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                         |
+<!--/typecheck-opts-->
+
+::note
+This command sets `process.env.NODE_ENV` to `production`. To override, define `NODE_ENV` in a [`.env`](/docs/directory-structure/env) file or as a command-line argument.
+::
+
+::read-more{to="/docs/guide/concepts/typescript#type-checking"}
+Read more on how to enable type-checking at build or development time.
+::

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,37 @@
+---
+title: "nuxt upgrade"
+description: The upgrade command upgrades Nuxt to the latest version.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/upgrade.ts
+    size: xs
+---
+
+<!--upgrade-cmd-->
+```bash [Terminal]
+npx nuxt upgrade [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dedupe] [-f, --force] [-ch, --channel=<stable|nightly|v3|v4|v4-nightly|v3-nightly>]
+```
+<!--/upgrade-cmd-->
+
+The `upgrade` command upgrades Nuxt to the latest version.
+
+## Arguments
+
+<!--upgrade-args-->
+| Argument      | Description                                    |
+|---------------|------------------------------------------------|
+| `ROOTDIR="."` | Specifies the working directory (default: `.`) |
+<!--/upgrade-args-->
+
+## Options
+
+<!--upgrade-opts-->
+| Option                                                             | Default  | Description                                                                      |
+|--------------------------------------------------------------------|----------|----------------------------------------------------------------------------------|
+| `--cwd=<directory>`                                                |          | Specify the working directory, this takes precedence over ROOTDIR (default: `.`) |
+| `--logLevel=<silent\|info\|verbose>`                               |          | Specify build-time log level                                                     |
+| `--dedupe`                                                         |          | Dedupe dependencies after upgrading                                              |
+| `-f, --force`                                                      |          | Force upgrade to recreate lockfile and node_modules                              |
+| `-ch, --channel=<stable\|nightly\|v3\|v4\|v4-nightly\|v3-nightly>` | `stable` | Specify a channel to install from (default: stable)                              |
+<!--/upgrade-opts-->


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this relocates nuxt documentation for the cli into the cli repo directly.

currently this is v3 documentation; I'll follow up with a PR
1. migrating to v4 alpha
2. with some infra to auto-regenerate command output, cli flags, etc. and _maybe_ add screenshots

that PR won't merge until the alpha does ...