### PR TITLE
fix(dev): stop racing the first render

### DIFF
--- a/packages/nuxt-cli/src/dev/loading-client.ts
+++ b/packages/nuxt-cli/src/dev/loading-client.ts
@@ -17,7 +17,7 @@ export interface ProgressClientOptions {
   progressProperty: string
   /** How far the load had got when this page was served. */
   elapsed: number
-  /** How long to wait before the first request for the app once the server says it is ready. */
+  /** Wait after the first request for the app, from which later waits back off. */
   pollInterval: number
   /** Ceiling the wait between those requests backs off to. */
   maxPollInterval: number

--- a/packages/nuxt-cli/src/dev/loading-client.ts
+++ b/packages/nuxt-cli/src/dev/loading-client.ts
@@ -17,8 +17,10 @@ export interface ProgressClientOptions {
   progressProperty: string
   /** How far the load had got when this page was served. */
   elapsed: number
-  /** How often to ask for the app once the server says it is ready. */
+  /** How long to wait before the first request for the app once the server says it is ready. */
   pollInterval: number
+  /** Ceiling the wait between those requests backs off to. */
+  maxPollInterval: number
 }
 
 export function progressClient(options: ProgressClientOptions): void {
@@ -75,6 +77,7 @@ export function progressClient(options: ProgressClientOptions): void {
   source.addEventListener('nuxt:ready', (event) => {
     source.close()
     phase = 'starting the app'
+    document.title = 'Starting the app'
     document.documentElement.style.setProperty(options.progressProperty, '100%')
     paint()
 
@@ -84,25 +87,36 @@ export function progressClient(options: ProgressClientOptions): void {
       return
     }
 
-    // `nuxt:ready` means the request handler exists, not that it can render
-    // quickly: on a cold start the first response still contends with the
-    // warmup the server is finishing, and asking for it at once measured 2-3x
-    // slower than asking a few hundred milliseconds later. So this page stays,
-    // still reporting progress, and asks until the app answers. Doing that here
-    // rather than leaving it to the template means every page the dev server
-    // serves updates itself, so none of them needs a `Refresh` header whose
-    // hard reload would throw the progress away every few seconds.
-    const poll = setInterval(() => {
-      void fetch(location.href, { headers: { accept: 'text/html' } })
-        .then(response => response.text())
-        .then((body) => {
-          if (!body.includes(options.captionId)) {
-            clearInterval(poll)
-            location.reload()
-          }
-        })
-        .catch(() => {})
-    }, options.pollInterval)
+    // `nuxt:ready` means the request handler exists, not that it can answer
+    // yet: the first document still has to be compiled. So this page stays,
+    // still reporting progress, and asks until the app answers, which keeps
+    // every page the dev server serves updating itself rather than needing a
+    // `Refresh` header whose hard reload would throw the progress away.
+    //
+    // One request at a time, backing off towards a ceiling. The dev server
+    // serialises the first render, so asking more often would only queue.
+    const controller = new AbortController()
+    let wait = options.pollInterval
+
+    const attempt = async (): Promise<void> => {
+      try {
+        const response = await fetch(location.href, { headers: { accept: 'text/html' }, signal: controller.signal })
+        const body = await response.text()
+        if (!body.includes(options.captionId)) {
+          controller.abort()
+          location.reload()
+          return
+        }
+      }
+      catch {}
+      if (controller.signal.aborted) {
+        return
+      }
+      setTimeout(attempt, wait)
+      wait = Math.min(Math.round(wait * 1.5), options.maxPollInterval)
+    }
+
+    void attempt()
   })
 }
 
@@ -113,7 +127,12 @@ export interface RecoveryClientOptions {
 /** Reloads the error page as soon as the next load starts or succeeds. */
 export function recoveryClient(options: RecoveryClientOptions): void {
   const source = new EventSource(options.progressPath)
+  let reloading = false
   const reload = (): void => {
+    if (reloading) {
+      return
+    }
+    reloading = true
     source.close()
     location.reload()
   }

--- a/packages/nuxt-cli/src/dev/loading-page.ts
+++ b/packages/nuxt-cli/src/dev/loading-page.ts
@@ -6,6 +6,7 @@ import { PROGRESS_PATH } from './progress'
 const CAPTION_ID = 'nuxt-dev-phase'
 const PROGRESS_PROPERTY = '--nuxt-progress'
 const POLL_INTERVAL_MS = 200
+const MAX_POLL_INTERVAL_MS = 1000
 
 /**
  * Turns the static bar Nuxt's own loading page draws into a determinate one, and
@@ -22,6 +23,7 @@ function progressTags(snapshot: DevProgressSnapshot): string {
     progressProperty: PROGRESS_PROPERTY,
     elapsed: snapshot.elapsed,
     pollInterval: POLL_INTERVAL_MS,
+    maxPollInterval: MAX_POLL_INTERVAL_MS,
   })}`
 }
 

--- a/packages/nuxt-cli/src/dev/tui/index.ts
+++ b/packages/nuxt-cli/src/dev/tui/index.ts
@@ -368,17 +368,18 @@ export function setupDevUI(context: ShortcutContext, options: DevUIOptions = {})
         return
       }
       requests.push(batch.map(request => ({ time: Date.now(), ...request })))
-      const failed = batch.filter(request => request.status >= 500)
+      // The bundler's own probes 503 while a restart is in flight
+      const app = batch.filter(request => !request.internal)
+      const failed = app.filter(request => request.status >= 500)
       // Nuxt answers a failed render with its error page rather than logging it,
       // so the response status is the only signal that something is wrong.
-      const failing = (batch.at(-1)?.status ?? 0) >= 500
+      const failing = (app.at(-1)?.status ?? 0) >= 500
+      const recovered = app.length > 0 && !failing && state.status === 'error' && !state.errors
       update({
         active: true,
         failures: (state.failures ?? 0) + failed.length,
-        status: failing
-          ? 'error'
-          : state.status === 'error' && !state.errors ? 'ready' : state.status,
-        note: failing ? 'a request failed · press n to trace it' : state.note,
+        status: failing ? 'error' : recovered ? 'ready' : state.status,
+        note: failing ? 'a request failed · press n to trace it' : recovered ? undefined : state.note,
       })
       repaintTicker()
       clearTimeout(activityTimer)

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -41,6 +41,7 @@ import { resolvePortlessURLs } from './portless'
 import { DevProgress } from './progress'
 import { formatChangedKeys, formatRestartReason, formatSkippedReload, mergeRestartReasons, withConfigKeys } from './reason'
 import { encodeRequest, REQUEST_HEADER, runWithRequest } from './serving-state'
+import { WarmupGate } from './warmup-gate'
 
 /**
  * Nitro plugin that attributes the app's logs to the request that caused them,
@@ -344,6 +345,20 @@ export function isBundlerRequest(url: string, fetchDest?: string): boolean {
   return fetchDest === 'script' || fetchDest === 'style' || BUNDLER_URL_RE.test(url)
 }
 
+/**
+ * Whether a request is one the app renders a page for, rather than the bundler
+ * fetching a module or a client asking for data.
+ */
+export function isDocumentRequest(req: IncomingMessage): boolean {
+  if ((req.method || 'GET') !== 'GET') {
+    return false
+  }
+  if (!String(req.headers.accept || '').includes('text/html')) {
+    return false
+  }
+  return !isBundlerRequest(req.url || '/', String(req.headers['sec-fetch-dest'] || '') || undefined)
+}
+
 interface DevServerEventMap {
   'loading:error': [error: Error]
   'loading': [loadingMessage: string]
@@ -378,6 +393,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
   #bound?: BoundServer
   #openedEagerly = false
   #progress = new DevProgress()
+  #warmup = new WarmupGate()
 
   loadDebounced: () => void
   handler: RequestListener
@@ -465,6 +481,12 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     res.once('close', () => {
       this.#inflightResponses.delete(res)
     })
+    if (!this.#warmup.warmed && isDocumentRequest(req)) {
+      await this.#warmup.admit(res)
+      if (res.destroyed || res.writableEnded) {
+        return
+      }
+    }
     this.#handler(req, res)
   }
 
@@ -1068,6 +1090,10 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
 
       this.scheduleReload({ type: 'dist-removed' })
     })
+
+    // A fresh instance compiles from cold again, so the first page render after
+    // a reload is worth serialising just as much as the first one after startup.
+    this.#warmup.rearm()
 
     if ('handler' in this.#currentNuxt.server) {
       this.#handler = this.#currentNuxt.server.handler as RequestListener

--- a/packages/nuxt-cli/src/dev/warmup-gate.ts
+++ b/packages/nuxt-cli/src/dev/warmup-gate.ts
@@ -1,0 +1,97 @@
+import type { ServerResponse } from 'node:http'
+
+/**
+ * A safety valve rather than a tuning knob: longer than any first render
+ * measured on a large project, so a leader that never answers cannot hold a
+ * page open indefinitely.
+ */
+const DEFAULT_TIMEOUT_MS = 30_000
+
+/**
+ * Serialises the first page render, so a cold start pays for it once.
+ *
+ * The first render of any route compiles the module graph the whole app shares.
+ * Two at once compile it twice and contend, so two tabs on a cold start are
+ * slower than one; a second render afterwards costs tens of milliseconds.
+ *
+ * Not a cache: every request is still served by the app, so anything
+ * per-request behaves as it would without the gate. Global rather than
+ * per-URL, because what is being warmed is the graph and not the route.
+ */
+export class WarmupGate {
+  #warmed = false
+  #leader?: Promise<void>
+  #timeout: number
+
+  constructor(options: { timeout?: number } = {}) {
+    this.#timeout = options.timeout ?? DEFAULT_TIMEOUT_MS
+  }
+
+  /** Whether a page has been rendered, after which the gate does nothing. */
+  get warmed(): boolean {
+    return this.#warmed
+  }
+
+  /** Gate the next load again, because it will compile from cold once more. */
+  rearm(): void {
+    this.#warmed = false
+  }
+
+  /**
+   * Resolves when this request may be handed to the app: at once while nothing
+   * is rendering, otherwise as soon as the render ahead of it has finished,
+   * given up, or run out of time. Only page renders should be handed here.
+   */
+  async admit(res: ServerResponse): Promise<void> {
+    if (this.#warmed) {
+      return
+    }
+
+    const deadline = Date.now() + this.#timeout
+    while (!this.#warmed && this.#leader) {
+      const remaining = deadline - Date.now()
+      if (remaining <= 0) {
+        return
+      }
+      let timer: NodeJS.Timeout | undefined
+      await Promise.race([
+        this.#leader,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, remaining)
+          timer.unref?.()
+        }),
+      ])
+      clearTimeout(timer)
+      // A client that has gone away must not take the lead, or the next real
+      // request would wait on a render nobody is receiving.
+      if (res.destroyed || res.writableEnded) {
+        return
+      }
+    }
+    if (this.#warmed) {
+      return
+    }
+
+    let release = (): void => {}
+    this.#leader = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let settled = false
+    let expiry: NodeJS.Timeout | undefined
+    const finish = (warmed: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(expiry)
+      // A failed render warmed nothing, so the request behind it gets its own
+      // chance rather than inheriting the failure.
+      this.#warmed = warmed
+      this.#leader = undefined
+      release()
+    }
+    expiry = setTimeout(finish, this.#timeout, false)
+    expiry.unref?.()
+    res.once('close', () => finish(res.writableEnded && res.statusCode < 500))
+  }
+}

--- a/packages/nuxt-cli/test/e2e/dev-warmup.spec.ts
+++ b/packages/nuxt-cli/test/e2e/dev-warmup.spec.ts
@@ -1,0 +1,87 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { getPort } from 'get-port-please'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { initialize } from '../../src/dev'
+import { createDevFixture } from '../utils'
+
+const fixtureDir = await createDevFixture('dev-warmup')
+
+/**
+ * Records every page render the app runs, from inside the handler the gate is
+ * protecting: how many were already in flight when this one started, and long
+ * enough that a second request would overlap it if nothing held it back.
+ */
+const MIDDLEWARE = `import { defineEventHandler, getRequestHeader } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  if (!getRequestHeader(event, 'accept')?.includes('text/html')) {
+    return
+  }
+  const state = (globalThis.__renders ??= { active: 0, entries: [] })
+  state.active++
+  state.entries.push(state.active)
+  await new Promise(resolve => setTimeout(resolve, 300))
+  state.active--
+})
+`
+
+const ENDPOINT = `import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => ({ entries: globalThis.__renders?.entries ?? [] }))
+`
+
+/** How many renders were in flight as each one started, oldest first. */
+async function renders(base: string): Promise<number[]> {
+  const { entries } = await fetch(`${base}/api/renders`, { headers: { accept: 'application/json' } })
+    .then(response => response.json()) as { entries: number[] }
+  return entries
+}
+
+function documents(base: string, count: number): Promise<Response[]> {
+  return Promise.all(Array.from({ length: count }, () => fetch(base, { headers: { accept: 'text/html' } })))
+}
+
+const host = '127.0.0.1'
+let base: string
+let close: () => Promise<void>
+
+describe('the warmup gate', () => {
+  beforeAll(async () => {
+    await mkdir(join(fixtureDir, 'server/middleware'), { recursive: true })
+    await writeFile(join(fixtureDir, 'server/middleware/renders.ts'), MIDDLEWARE)
+    await writeFile(join(fixtureDir, 'server/api/renders.ts'), ENDPOINT)
+
+    const port = await getPort({ host, port: 3089 })
+    base = `http://${host}:${port}`
+    const server = await initialize({ cwd: fixtureDir, args: {} }, {
+      listenOverrides: { hostname: host, port },
+      showBanner: false,
+    })
+    close = server.close
+  }, 120_000)
+
+  afterAll(async () => {
+    await close?.()
+  })
+
+  it('should render the first page on its own', { timeout: 120_000 }, async () => {
+    const responses = await documents(base, 2)
+    expect(responses.every(response => response.ok)).toBe(true)
+
+    // Two requests, neither overlapping: the second waits for the compile the
+    // first is paying for.
+    expect(await renders(base)).toEqual([1, 1])
+  })
+
+  it('should stop gating once the app is warm', { timeout: 120_000 }, async () => {
+    const before = await renders(base)
+    await documents(base, 20)
+    const entries = await renders(base)
+
+    expect(entries.length).toBe(before.length + 20)
+    // A warm render costs tens of milliseconds, so there is nothing left to
+    // protect and the gate is out of the way entirely.
+    expect(Math.max(...entries.slice(before.length))).toBeGreaterThan(1)
+  })
+})

--- a/packages/nuxt-cli/test/unit/dev-tui.spec.ts
+++ b/packages/nuxt-cli/test/unit/dev-tui.spec.ts
@@ -2081,3 +2081,93 @@ describe('dev ui fallback', () => {
     expect(setupDevUI(context as never, { enabled: false }).interactive).toBe(false)
   })
 })
+
+/** Long enough for the panel's trailing repaint to land. */
+const TICKER_SETTLE_MS = 400
+
+describe('request failures on the panel', () => {
+  const context = {
+    listener: { url: 'http://localhost:3000/', getURLs: () => [], showURLs: () => {} },
+    close: async () => {},
+    onReady: () => {},
+  }
+
+  async function withPanel(run: (ui: ReturnType<typeof setupDevUI>, settle: () => Promise<string>) => Promise<void>): Promise<void> {
+    const chunks: string[] = []
+    const saved = (['isTTY', 'columns', 'rows'] as const).map(key => [key, Object.getOwnPropertyDescriptor(process.stdout, key)] as const)
+    const stdin = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+    const setRawMode = Object.getOwnPropertyDescriptor(process.stdin, 'setRawMode')
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true })
+    Object.defineProperty(process.stdout, 'columns', { value: 100, configurable: true })
+    Object.defineProperty(process.stdout, 'rows', { value: 30, configurable: true })
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true })
+    Object.defineProperty(process.stdin, 'setRawMode', { value: () => process.stdin, configurable: true })
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      chunks.push(String(chunk))
+      return true
+    })
+    const session = beginDevUI({ ci: false, test: false, version: '4.5.2' })!
+    const ui = setupDevUI(context as never, { ci: false, test: false, version: '4.5.2' })
+    try {
+      await run(ui, async () => {
+        // The panel repaints on a trailing timer, so nothing is on screen yet.
+        await new Promise(resolve => setTimeout(resolve, TICKER_SETTLE_MS))
+        return strip(chunks.join(''))
+      })
+    }
+    finally {
+      session.teardown()
+      write.mockRestore()
+      for (const [key, descriptor] of saved) {
+        if (descriptor) {
+          Object.defineProperty(process.stdout, key, descriptor)
+        }
+      }
+      if (stdin) {
+        Object.defineProperty(process.stdin, 'isTTY', stdin)
+      }
+      if (setRawMode) {
+        Object.defineProperty(process.stdin, 'setRawMode', setRawMode)
+      }
+      else {
+        Reflect.deleteProperty(process.stdin, 'setRawMode')
+      }
+    }
+  }
+
+  it('should not report the bundler\'s own failed probes as failed requests', async () => {
+    await withPanel(async (ui, settle) => {
+      ui.setStatus('building')
+      ui.pushRequests([{ method: 'GET', url: '/__skip_vite', status: 503, duration: 1, internal: true }])
+      const frames = await settle()
+
+      expect(frames).not.toContain('failed request')
+      expect(frames).not.toContain('a request failed')
+    })
+  })
+
+  it('should report a failed app request', async () => {
+    await withPanel(async (ui, settle) => {
+      ui.setStatus('ready')
+      ui.pushRequests([{ method: 'GET', url: '/', status: 500, duration: 1 }])
+      const frames = await settle()
+
+      expect(frames).toContain('1 failed request')
+      expect(frames).toContain('a request failed')
+    })
+  })
+
+  it('should not let an internal request clear a failure the app reported', async () => {
+    await withPanel(async (ui, settle) => {
+      ui.setStatus('ready')
+      ui.pushRequests([{ method: 'GET', url: '/', status: 500, duration: 1 }])
+      await settle()
+      ui.pushRequests([{ method: 'GET', url: '/__skip_vite', status: 200, duration: 1, internal: true }])
+      const frames = await settle()
+
+      const last = frames.slice(frames.lastIndexOf('Nuxt 4.5.2'))
+      expect(last).toContain('ERROR')
+      expect(last).toContain('a request failed')
+    })
+  })
+})

--- a/packages/nuxt-cli/test/unit/dev-tui.spec.ts
+++ b/packages/nuxt-cli/test/unit/dev-tui.spec.ts
@@ -2122,9 +2122,15 @@ describe('request failures on the panel', () => {
         if (descriptor) {
           Object.defineProperty(process.stdout, key, descriptor)
         }
+        else {
+          Reflect.deleteProperty(process.stdout, key)
+        }
       }
       if (stdin) {
         Object.defineProperty(process.stdin, 'isTTY', stdin)
+      }
+      else {
+        Reflect.deleteProperty(process.stdin, 'isTTY')
       }
       if (setRawMode) {
         Object.defineProperty(process.stdin, 'setRawMode', setRawMode)

--- a/packages/nuxt-cli/test/unit/loading-client.spec.ts
+++ b/packages/nuxt-cli/test/unit/loading-client.spec.ts
@@ -11,6 +11,7 @@ const OPTIONS: ProgressClientOptions = {
   progressProperty: '--nuxt-progress',
   elapsed: 0,
   pollInterval: 200,
+  maxPollInterval: 1000,
 }
 
 function snapshot(overrides: Partial<DevProgressSnapshot> = {}): DevProgressSnapshot {
@@ -41,7 +42,7 @@ interface FakeElement {
  * scope of its own. A reference to anything the bundler renamed would throw
  * here rather than in someone's browser.
  */
-function run(options: Partial<ProgressClientOptions> = {}) {
+function run(options: Partial<ProgressClientOptions> = {}, fetchImpl?: typeof fetch) {
   const listeners = new Map<string, (event: { data: string }) => void>()
   const elements: FakeElement[] = []
   const classes = new Set<string>()
@@ -56,15 +57,21 @@ function run(options: Partial<ProgressClientOptions> = {}) {
     body: { append: (element: FakeElement) => void elements.push(element), classList },
     createElement: (): FakeElement => ({ id: '', title: '', textContent: '', removeAttribute: () => {} }),
   })
+  const sources: { readyState: number }[] = []
   vi.stubGlobal('EventSource', class {
-    constructor(readonly url: string) {}
+    readyState = 0
+    constructor(readonly url: string) {
+      sources.push(this)
+    }
+
     close = close
     addEventListener(type: string, listener: (event: { data: string }) => void) {
       listeners.set(type, listener)
     }
   })
   vi.stubGlobal('location', { href: 'http://localhost:3000/', reload })
-  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ text: () => Promise.resolve('') })))
+  const request = vi.fn(fetchImpl ?? (() => Promise.resolve({ text: () => Promise.resolve('') } as Response)))
+  vi.stubGlobal('fetch', request)
 
   const script = inlineScript(progressClient, { ...OPTIONS, ...options })
   // eslint-disable-next-line no-new-func
@@ -76,6 +83,7 @@ function run(options: Partial<ProgressClientOptions> = {}) {
     properties,
     reload,
     close,
+    request,
     emit: (type: string, data: unknown) => listeners.get(type)?.({ data: JSON.stringify(data) }),
     listens: (type: string) => listeners.has(type),
   }
@@ -129,6 +137,69 @@ describe('the injected progress client', () => {
     expect(client.elements[0]!.textContent).toMatch(/^starting the app · /)
 
     await vi.waitFor(() => expect(client.reload).toHaveBeenCalled())
-    expect(fetch).toHaveBeenCalledWith('http://localhost:3000/', { headers: { accept: 'text/html' } })
+    expect(client.request).toHaveBeenCalledWith('http://localhost:3000/', expect.objectContaining({ headers: { accept: 'text/html' } }))
+  })
+
+  it('should say it is starting the app in the tab title as well as the caption', () => {
+    const client = run()
+    client.emit('nuxt:loading', snapshot())
+    client.emit('nuxt:ready', snapshot({ status: 'ready', progress: 1 }))
+
+    expect(document.title).toBe('Starting the app')
+    expect(client.elements[0]!.textContent).toMatch(/^starting the app · /)
+  })
+
+  it('should never have more than one request for the app in flight', async () => {
+    vi.useFakeTimers()
+    let pending = 0
+    let peak = 0
+    const client = run({}, () => {
+      peak = Math.max(peak, ++pending)
+      return new Promise(resolve => setTimeout(() => {
+        pending--
+        resolve({ text: () => Promise.resolve('<div id="nuxt-dev-phase"></div>') } as Response)
+      }, 5000))
+    })
+
+    client.emit('nuxt:ready', snapshot({ status: 'ready', progress: 1 }))
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(peak).toBe(1)
+    expect(client.request.mock.calls.length).toBeLessThan(12)
+    expect(client.reload).not.toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+
+  it('should back off towards the ceiling between attempts', async () => {
+    vi.useFakeTimers()
+    const at: number[] = []
+    const started = Date.now()
+    const client = run({}, () => {
+      at.push(Date.now() - started)
+      return Promise.resolve({ text: () => Promise.resolve('<div id="nuxt-dev-phase"></div>') } as Response)
+    })
+
+    client.emit('nuxt:ready', snapshot({ status: 'ready', progress: 1 }))
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(at.slice(0, 6)).toEqual([0, 200, 500, 950, 1625, 2625])
+    vi.useRealTimers()
+  })
+
+  it('should stop polling and reload once, aborting whatever is in flight', async () => {
+    vi.useFakeTimers()
+    const signals: (AbortSignal | undefined)[] = []
+    const client = run({}, (_input, init) => {
+      signals.push(init?.signal ?? undefined)
+      return Promise.resolve({ text: () => Promise.resolve('<html>the app</html>') } as Response)
+    })
+
+    client.emit('nuxt:ready', snapshot({ status: 'ready', progress: 1 }))
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(client.reload).toHaveBeenCalledTimes(1)
+    expect(client.request).toHaveBeenCalledTimes(1)
+    expect(signals[0]!.aborted).toBe(true)
+    vi.useRealTimers()
   })
 })

--- a/packages/nuxt-cli/test/unit/warmup-gate.spec.ts
+++ b/packages/nuxt-cli/test/unit/warmup-gate.spec.ts
@@ -1,0 +1,202 @@
+import type { IncomingMessage } from 'node:http'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { isDocumentRequest } from '../../src/dev/utils'
+import { WarmupGate } from '../../src/dev/warmup-gate'
+
+/** Just enough of a response for the gate: it only ever waits for `close`. */
+function response() {
+  const listeners: Array<() => void> = []
+  const res = {
+    statusCode: 200,
+    writableEnded: false,
+    destroyed: false,
+    once(_event: string, listener: () => void) {
+      listeners.push(listener)
+      return res
+    },
+    /** Finish the response as the app would, then close the socket. */
+    end(status = 200) {
+      res.statusCode = status
+      res.writableEnded = true
+      for (const listener of listeners.splice(0)) {
+        listener()
+      }
+    },
+    /** The client went away before anything was written. */
+    abort() {
+      res.destroyed = true
+      for (const listener of listeners.splice(0)) {
+        listener()
+      }
+    },
+  }
+  return res
+}
+
+function request(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+  return { method: 'GET', url: '/', headers: { accept: 'text/html' }, ...overrides } as IncomingMessage
+}
+
+/**
+ * Admit `count` requests at once, as separate tabs would, and report which of
+ * them the gate has let through so far.
+ */
+function admitAll(gate: WarmupGate, count: number) {
+  const responses = Array.from({ length: count }, response)
+  const admitted = new Set<number>()
+  const settled = responses.map((res, index) => gate.admit(res as never).then(() => void admitted.add(index)))
+  return { responses, admitted, settled: Promise.all(settled) }
+}
+
+describe('which requests the warmup gate applies to', () => {
+  it('should queue page renders', () => {
+    expect(isDocumentRequest(request())).toBe(true)
+    expect(isDocumentRequest(request({ headers: { accept: 'text/html,application/xhtml+xml' } }))).toBe(true)
+  })
+
+  it('should ignore everything that does not pay for the module graph', () => {
+    expect(isDocumentRequest(request({ method: 'POST' }))).toBe(false)
+    expect(isDocumentRequest(request({ headers: { accept: 'application/json' } }))).toBe(false)
+    expect(isDocumentRequest(request({ headers: {} }))).toBe(false)
+    expect(isDocumentRequest(request({ url: '/_nuxt/@vite/client' }))).toBe(false)
+    expect(isDocumentRequest(request({ url: '/__nuxt_dev__/progress' }))).toBe(false)
+    expect(isDocumentRequest(request({ headers: { 'accept': 'text/html', 'sec-fetch-dest': 'script' } }))).toBe(false)
+  })
+})
+
+describe('the warmup gate', () => {
+  it('should let two tabs render one at a time, then let the rest straight through', async () => {
+    const gate = new WarmupGate()
+    const { responses, admitted, settled } = admitAll(gate, 2)
+
+    await Promise.resolve()
+    expect([...admitted]).toEqual([0])
+
+    responses[0]!.end()
+    await settled
+    expect([...admitted]).toEqual([0, 1])
+    expect(gate.warmed).toBe(true)
+  })
+
+  it('should admit exactly one of twenty simultaneous requests until the first render lands', async () => {
+    const gate = new WarmupGate()
+    const { responses, admitted, settled } = admitAll(gate, 20)
+
+    await vi.waitFor(() => expect(admitted.size).toBe(1))
+    responses[0]!.end()
+    await settled
+
+    expect(admitted.size).toBe(20)
+  })
+
+  it('should be inert once a page has rendered', async () => {
+    const gate = new WarmupGate()
+    const leader = response()
+    await gate.admit(leader as never)
+    leader.end()
+
+    const later = admitAll(gate, 5)
+    await later.settled
+
+    expect(later.admitted.size).toBe(5)
+    // Nothing was waiting on anything, so nothing had to be closed to proceed.
+    expect(later.responses.every(res => !res.writableEnded)).toBe(true)
+  })
+
+  it('should gate again after a reload, which compiles from cold once more', async () => {
+    const gate = new WarmupGate()
+    const first = response()
+    await gate.admit(first as never)
+    first.end()
+    gate.rearm()
+
+    const { responses, admitted } = admitAll(gate, 2)
+    await Promise.resolve()
+
+    expect([...admitted]).toEqual([0])
+    responses[0]!.end()
+  })
+
+  it('should not let a failed render hold back or fail the request behind it', async () => {
+    const gate = new WarmupGate()
+    const { responses, admitted, settled } = admitAll(gate, 2)
+
+    await Promise.resolve()
+    responses[0]!.end(500)
+    await vi.waitFor(() => expect(admitted.size).toBe(2))
+
+    // The failure warmed nothing, so the next request renders under the gate too.
+    expect(gate.warmed).toBe(false)
+    responses[1]!.end()
+    await settled
+    expect(gate.warmed).toBe(true)
+  })
+
+  it('should hand the lead on when the leader disconnects mid-render', async () => {
+    const gate = new WarmupGate()
+    const { responses, admitted, settled } = admitAll(gate, 2)
+
+    await Promise.resolve()
+    responses[0]!.abort()
+    await vi.waitFor(() => expect(admitted.size).toBe(2))
+
+    expect(gate.warmed).toBe(false)
+    responses[1]!.end()
+    await settled
+    expect(gate.warmed).toBe(true)
+  })
+
+  it('should not give the lead to a queued client that has gone away', async () => {
+    const gate = new WarmupGate()
+    const { responses, settled } = admitAll(gate, 3)
+
+    await Promise.resolve()
+    responses[1]!.abort()
+    responses[0]!.end(500)
+    await settled
+
+    // The abandoned request took nothing with it: the live one still renders.
+    expect(gate.warmed).toBe(false)
+    responses[2]!.end()
+    expect(gate.warmed).toBe(true)
+  })
+
+  it('should never hold a request longer than the wait it was given', async () => {
+    vi.useFakeTimers()
+    try {
+      const gate = new WarmupGate({ timeout: 1000 })
+      const { admitted } = admitAll(gate, 2)
+
+      await vi.advanceTimersByTimeAsync(999)
+      expect(admitted.size).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(2)
+      expect(admitted.size).toBe(2)
+      expect(gate.warmed).toBe(false)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('should release the queue when a leader never answers', async () => {
+    vi.useFakeTimers()
+    try {
+      const gate = new WarmupGate({ timeout: 1000 })
+      const leader = response()
+      await gate.admit(leader as never)
+
+      const follower = response()
+      const admitted = gate.admit(follower as never)
+      await vi.advanceTimersByTimeAsync(1001)
+      await admitted
+
+      expect(gate.warmed).toBe(false)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

at the moment, we poll the loading page until the app is ready, but this could potential leave lots of concurrent renders of the same expensive first render

so we now gates that first render to just one document request at a time