### PR TITLE
fix: only report unknown flags that look like a typo

### DIFF
--- a/packages/nuxt-cli/src/main.ts
+++ b/packages/nuxt-cli/src/main.ts
@@ -95,9 +95,13 @@ const _main = defineCommand({
 })
 
 /**
- * Report long flags the resolved command does not declare. Unknown flags are
- * otherwise parsed and silently ignored, so a misspelling looks like the flag
- * simply had no effect.
+ * Report long flags the resolved command does not declare *and* that look like
+ * a misspelling of one it does, so a typo does not look like a flag that simply
+ * had no effect.
+ *
+ * A flag with no close match is passed through in silence: projects read their
+ * own flags out of `process.argv` in `nuxt.config`, and there is no way to tell
+ * one of those from a typo nothing resembles.
  */
 async function warnUnknownFlags(command: string, rawArgs: string[]): Promise<void> {
   let def: CommandDef<any>
@@ -120,11 +124,21 @@ async function warnUnknownFlags(command: string, rawArgs: string[]): Promise<voi
     return
   }
 
-  const suggestions = await suggestFlags(unknown)
+  const suggestions = (await suggestFlags(unknown)).filter((entry): entry is { flag: string, suggestion: string } => {
+    if (entry.suggestion) {
+      return true
+    }
+    debug(`Passing through unknown option ${entry.flag}.`)
+    return false
+  })
+  if (suggestions.length === 0) {
+    return
+  }
+
   const { isInteractive } = await import('./utils/stdout')
   if (!isInteractive()) {
     for (const { flag, suggestion } of suggestions) {
-      logger.warn(`Unknown option ${styleText('cyan', flag)}.${suggestion ? ` Did you mean ${styleText('cyan', suggestion)}?` : ''}`)
+      logger.warn(`Unknown option ${styleText('cyan', flag)}. Did you mean ${styleText('cyan', suggestion)}?`)
     }
     return
   }
@@ -132,10 +146,6 @@ async function warnUnknownFlags(command: string, rawArgs: string[]): Promise<voi
   const { cancel, confirm, isCancel } = await import('@clack/prompts')
   const { restoreRawMode, withDirectStdout } = await import('./utils/console')
   for (const { flag, suggestion } of suggestions) {
-    if (!suggestion) {
-      logger.warn(`Unknown option ${styleText('cyan', flag)}.`)
-      continue
-    }
     // A negated unknown flag is matched against its bare name, so the offered
     // replacement has to restore the negation the user asked for.
     const replacement = flag.startsWith('--no-') && !suggestion.startsWith('--no-')

--- a/packages/nuxt-cli/test/e2e/unknown-flags.spec.ts
+++ b/packages/nuxt-cli/test/e2e/unknown-flags.spec.ts
@@ -1,0 +1,29 @@
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { x } from 'tinyexec'
+import { describe, expect, it } from 'vitest'
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/dev', import.meta.url))
+const nuxi = fileURLToPath(new URL('../../bin/nuxi.mjs', import.meta.url))
+
+function run(args: string[]) {
+  return x('node', [nuxi, ...args], {
+    nodeOptions: { cwd: fixtureDir, env: { ...process.env, NO_COLOR: '1' } },
+  })
+}
+
+describe('unknown flags', () => {
+  it('should suggest the declared flag a misspelling is closest to', { timeout: 60_000 }, async () => {
+    const res = await run(['prepare', '--loglevel=info'])
+    const output = res.stdout + res.stderr
+
+    expect(output).toContain('Unknown option --loglevel. Did you mean --logLevel?')
+  })
+
+  it('should pass through a flag nothing is close to', { timeout: 60_000 }, async () => {
+    const res = await run(['prepare', '--ui-only'])
+    const output = res.stdout + res.stderr
+
+    expect(output).not.toContain('Unknown option')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this avoids warning for flags that may be defined by projects, e.g. nuxt.com has `--ui-only`.

instead we only warn if a flag is _similar_ to one that's built-in