### PR TITLE
feat(analyze,build,dev,preview): support builds without a server runtime

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -10,7 +10,7 @@ links:
 
 <!--build-cmd-->
 ```bash [Terminal]
-npx nuxt build [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--prerender] [--preset=<nitro-preset>] [--dotenv=<path>...] [--envName=<environment>] [-e, --extends=<layer-name>...] [--profile=<verbose>]
+npx nuxt build [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--prerender] [--target=<target>] [--dotenv=<path>...] [--envName=<environment>] [-e, --extends=<layer-name>...] [--profile=<verbose>]
 ```
 <!--/build-cmd-->
 
@@ -32,7 +32,7 @@ The `build` command creates a `.output` directory with all your application, ser
 | `--cwd=<directory>`                  |         | Specify the root directory of your Nuxt project                                                                                                      |
 | `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
 | `--prerender`                        |         | Build Nuxt and prerender static routes                                                                                                               |
-| `--preset=<nitro-preset>`            |         | Nitro server preset (e.g. `node-server`, `vercel`, `netlify`)                                                                                        |
+| `--target=<target>`                  |         | Deploy target for the configured server builder (e.g. `node-server`, `vercel`, `netlify`)                                                            |
 | `--dotenv=<path>...`                 |         | Path to `.env` file to load, relative to the root directory. Can be repeated, with later files taking precedence.                                    |
 | `--envName=<environment>`            |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
 | `-e, --extends=<layer-name>...`      |         | Extend from a Nuxt layer                                                                                                                             |
@@ -44,9 +44,9 @@ This command sets `process.env.NODE_ENV` to `production`.
 ::
 
 ::note
-`--prerender` will always set the `preset` to `static`
+`--prerender` will always set the target to `static`
 ::
 
-When `--preset` is not passed, the `NITRO_PRESET` and `SERVER_PRESET` environment variables are used, in that order.
+`--preset` is still accepted as another name for `--target`. When neither is passed, the `NITRO_PRESET` and `SERVER_PRESET` environment variables are used, in that order.
 
 `--profile` writes a V8 CPU profile to `nuxt-build.cpuprofile` in your project. The build timings it reports, along with `perf-report.json` and `perf-trace.json` in your build directory, come from Nuxt's own build profiling and need Nuxt v4.4 or later.

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -10,7 +10,7 @@ links:
 
 <!--generate-cmd-->
 ```bash [Terminal]
-npx nuxt generate [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--preset=<nitro-preset>] [--dotenv=<path>...] [--envName=<environment>] [-e, --extends=<layer-name>...] [--profile=<verbose>]
+npx nuxt generate [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--target=<target>] [--dotenv=<path>...] [--envName=<environment>] [-e, --extends=<layer-name>...] [--profile=<verbose>]
 ```
 <!--/generate-cmd-->
 
@@ -31,7 +31,7 @@ The `generate` command pre-renders every route of your application and stores th
 |--------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--cwd=<directory>`                  |         | Specify the root directory of your Nuxt project                                                                                                      |
 | `--logLevel=<silent\|info\|verbose>` |         | Specify build-time log level                                                                                                                         |
-| `--preset=<nitro-preset>`            |         | Nitro server preset (e.g. `node-server`, `vercel`, `netlify`)                                                                                        |
+| `--target=<target>`                  |         | Deploy target for the configured server builder (e.g. `node-server`, `vercel`, `netlify`)                                                            |
 | `--dotenv=<path>...`                 |         | Path to `.env` file to load, relative to the root directory. Can be repeated, with later files taking precedence.                                    |
 | `--envName=<environment>`            |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
 | `-e, --extends=<layer-name>...`      |         | Extend from a Nuxt layer                                                                                                                             |

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -16,6 +16,8 @@ npx nuxt preview [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>
 
 The `preview` command starts a server to preview your Nuxt application after running the `build` command. `nuxt start` is the same command under another name. When running your application in production refer to the [Deployment section](/docs/getting-started/deployment).
 
+When the configured `server.builder` produces no server at all (a client-only build, for example), there is nothing to run: the static output is served directly instead, with unmatched paths falling back to the client entry so client-side routing works.
+
 Some Nitro presets do not produce a server that can be run locally. For those, the preset's own preview command is run instead, and the command tells you what it is running.
 
 ## Arguments

--- a/packages/nuxt-cli/src/commands/_shared.ts
+++ b/packages/nuxt-cli/src/commands/_shared.ts
@@ -60,6 +60,28 @@ export const extendsArgs = {
   },
 } as const satisfies Record<string, ArgDef>
 
+/**
+ * The deploy target within the configured server builder.
+ *
+ * `--preset` names the same thing for Nitro, the only builder with a target axis
+ * today, and keeps working for the many deployment guides that use it. It is a
+ * hidden option rather than an alias because citty renders a multi-character
+ * alias as `-preset` in help output.
+ */
+export const targetArgs = {
+  target: {
+    type: 'string',
+    description: 'Deploy target for the configured server builder (e.g. `node-server`, `vercel`, `netlify`)',
+    valueHint: 'target',
+  },
+  preset: {
+    type: 'string',
+    description: 'Alias for `--target`',
+    valueHint: 'target',
+    hidden: true,
+  },
+} as const satisfies Record<string, ArgDef>
+
 export const profileArgs = {
   profile: {
     type: 'string',

--- a/packages/nuxt-cli/src/commands/analyze.ts
+++ b/packages/nuxt-cli/src/commands/analyze.ts
@@ -135,7 +135,10 @@ export default defineCommand({
 
     const analyzeDir = nuxt.options.analyzeDir
     const buildDir = nuxt.options.buildDir
-    const outDir = resolveServerBuild(kit, nuxt).dir
+    const serverBuild = resolveServerBuild(kit, nuxt)
+    // The lock has to be taken before the build, so it claims the output
+    // directory as resolved now; `meta.json` records where the build landed.
+    const outDir = serverBuild.dir
 
     nuxt.options.build.analyze = defu(nuxt.options.build.analyze, {
       filename: join(analyzeDir, 'client.html'),
@@ -177,7 +180,7 @@ export default defineCommand({
         endTime: Date.now(),
         analyzeDir,
         buildDir,
-        outDir,
+        outDir: serverBuild.dir,
       }
 
       await nuxt.callHook('build:analyze:done', meta)

--- a/packages/nuxt-cli/src/commands/analyze.ts
+++ b/packages/nuxt-cli/src/commands/analyze.ts
@@ -7,7 +7,7 @@ import { styleText } from 'node:util'
 import { note, taskLog } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { defu } from 'defu'
-import { join, relative, resolve } from 'pathe'
+import { join, relative } from 'pathe'
 import { serve } from 'srvx'
 
 import { resolveDotenvFileNames } from '../utils/args'
@@ -18,6 +18,7 @@ import { loadKit } from '../utils/kit'
 import { acquireLock, acquireOutputLock, formatLockError } from '../utils/lockfile'
 import { intro, logger, outro } from '../utils/logger'
 import { relativeToProcess, resolveRootDir } from '../utils/paths'
+import { resolveServerBuild } from '../utils/server-build'
 import { dotEnvArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
 
 const NON_WORD_RE = /[^\w-]/g
@@ -80,7 +81,8 @@ export default defineCommand({
 
     const startTime = Date.now()
 
-    const { loadNuxt, buildNuxt } = await loadKit(cwd)
+    const kit = await loadKit(cwd)
+    const { loadNuxt, buildNuxt } = kit
 
     const nuxt = await loadNuxt({
       cwd,
@@ -133,7 +135,7 @@ export default defineCommand({
 
     const analyzeDir = nuxt.options.analyzeDir
     const buildDir = nuxt.options.buildDir
-    const outDir = resolve(nuxt.options.rootDir, nuxt.options.nitro.output?.dir || '.output')
+    const outDir = resolveServerBuild(kit, nuxt).dir
 
     nuxt.options.build.analyze = defu(nuxt.options.build.analyze, {
       filename: join(analyzeDir, 'client.html'),

--- a/packages/nuxt-cli/src/commands/build.ts
+++ b/packages/nuxt-cli/src/commands/build.ts
@@ -19,7 +19,7 @@ import { resolveRootDir } from '../utils/paths'
 import { createPhaseReporter, formatPhaseBreakdown } from '../utils/phase-reporter'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile'
 import { resolveServerBuild } from '../utils/server-build'
-import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs, targetArgs } from './_shared'
 
 /** How often a phase repeats itself where there is no animated line. */
 const HEARTBEAT_INTERVAL = 5000
@@ -36,11 +36,7 @@ export default defineCommand({
       type: 'boolean',
       description: 'Build Nuxt and prerender static routes',
     },
-    preset: {
-      type: 'string',
-      description: 'Nitro server preset (e.g. `node-server`, `vercel`, `netlify`)',
-      valueHint: 'nitro-preset',
-    },
+    ...targetArgs,
     ...dotEnvArgs,
     ...envNameArgs,
     ...extendsArgs,
@@ -96,7 +92,7 @@ export default defineCommand({
           _generate: ctx.args.prerender,
           nitro: {
             static: ctx.args.prerender,
-            preset: ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET,
+            preset: ctx.args.target || ctx.args.preset || process.env.NITRO_PRESET || process.env.SERVER_PRESET,
           },
           ...(ctx.args.extends.length > 0 && { extends: ctx.args.extends }),
           ...ctx.data?.overrides,
@@ -124,8 +120,9 @@ export default defineCommand({
       releaseLocks.push(lock.release)
 
       const serverBuild = resolveServerBuild(kit, nuxt)
-      if (serverBuild.target) {
-        logger.info(`${serverBuild.name === 'nitro' ? 'Nitro' : serverBuild.name} preset: ${styleText('cyan', serverBuild.target)}`)
+      const target = serverBuild.target
+      if (target) {
+        logger.info(`${serverBuild.label} ${serverBuild.targetLabel}: ${styleText('cyan', target)}`)
       }
 
       const outputDir = serverBuild.dir

--- a/packages/nuxt-cli/src/commands/build.ts
+++ b/packages/nuxt-cli/src/commands/build.ts
@@ -18,6 +18,7 @@ import { intro, logger, outro } from '../utils/logger'
 import { resolveRootDir } from '../utils/paths'
 import { createPhaseReporter, formatPhaseBreakdown } from '../utils/phase-reporter'
 import { startCpuProfile, stopCpuProfile } from '../utils/profile'
+import { resolveServerBuild } from '../utils/server-build'
 import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
 
 /** How often a phase repeats itself where there is no animated line. */
@@ -122,15 +123,18 @@ export default defineCommand({
       }
       releaseLocks.push(lock.release)
 
-      const nitro = kit.useNitro()
-      logger.info(`Nitro preset: ${styleText('cyan', nitro.options.preset)}`)
+      const serverBuild = resolveServerBuild(kit, nuxt)
+      if (serverBuild.target) {
+        logger.info(`${serverBuild.name === 'nitro' ? 'Nitro' : serverBuild.name} preset: ${styleText('cyan', serverBuild.target)}`)
+      }
 
-      const outputLock = acquireOutputLock(nuxt.options.rootDir, nitro.options.output.dir, {
+      const outputDir = serverBuild.dir
+      const outputLock = acquireOutputLock(nuxt.options.rootDir, outputDir, {
         command: 'build',
         cwd,
       })
       if (outputLock.existing) {
-        throw new ActionableError(formatLockError(outputLock.existing, { outputDir: relative(process.cwd(), nitro.options.output.dir) }))
+        throw new ActionableError(formatLockError(outputLock.existing, { outputDir: relative(process.cwd(), outputDir) }))
       }
       releaseLocks.push(outputLock.release)
 
@@ -153,7 +157,7 @@ export default defineCommand({
           logger.warn(`HTML content not prerendered because ${styleText('cyan', 'ssr: false')} was set.`)
           logger.info(`You can read more in ${styleText('cyan', 'https://nuxt.com/docs/getting-started/deployment#static-hosting')}.`)
         }
-        const dir = nitro.options.output.publicDir
+        const dir = serverBuild.publicDir
         const publicDir = dir ? relative(process.cwd(), dir) : '.output/public'
         outro(`✨ You can now deploy ${styleText('cyan', publicDir)} to any static hosting! ${styleText('gray', `(${formatDuration(Date.now() - start)})`)}`)
       }

--- a/packages/nuxt-cli/src/commands/generate.ts
+++ b/packages/nuxt-cli/src/commands/generate.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty'
 
-import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs } from './_shared'
+import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, profileArgs, rootDirArgs, targetArgs } from './_shared'
 import buildCommand from './build'
 
 export default defineCommand({
@@ -11,11 +11,7 @@ export default defineCommand({
   args: {
     ...rootDirArgs,
     ...logLevelArgs,
-    preset: {
-      type: 'string',
-      description: 'Nitro server preset (e.g. `node-server`, `vercel`, `netlify`)',
-      valueHint: 'nitro-preset',
-    },
+    ...targetArgs,
     ...dotEnvArgs,
     ...envNameArgs,
     ...extendsArgs,

--- a/packages/nuxt-cli/src/commands/preview.ts
+++ b/packages/nuxt-cli/src/commands/preview.ts
@@ -14,7 +14,11 @@ import { loadKit } from '../utils/kit'
 import { logger, outro } from '../utils/logger'
 import { withPrependedPath } from '../utils/path-env'
 import { relativeToProcess, resolveRootDir } from '../utils/paths'
+import { getServerBuilderName } from '../utils/server-build'
+import { findStaticEntry, previewStaticOutput } from '../utils/static-preview'
 import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
+
+const TRAILING_SLASH_RE = /\/$/
 
 const command = defineCommand({
   meta: {
@@ -47,6 +51,8 @@ const command = defineCommand({
 
     let envLoaded = false
     let resolvedOutputDir: string | undefined
+    let resolvedPublicDir: string | undefined
+    let builderName: string | undefined
 
     try {
       const { loadNuxt } = await loadKit(cwd)
@@ -70,6 +76,14 @@ const command = defineCommand({
           ],
         },
       })
+      builderName = getServerBuilderName(nuxt)
+      // `nuxt.serverOutput` is only present in newer Nuxt; the `nitro:init` hook
+      // above covers older versions, which only ever built with Nitro.
+      const serverOutput = (nuxt as { serverOutput?: { dir: () => string, publicDir: () => string } }).serverOutput
+      if (serverOutput) {
+        resolvedOutputDir = resolve(serverOutput.dir(), 'nitro.json')
+        resolvedPublicDir = serverOutput.publicDir()
+      }
       await nuxt.close()
     }
     catch {}
@@ -79,9 +93,35 @@ const command = defineCommand({
       resolve(cwd, '.output', 'nitro.json'),
     ].filter((path): path is string => !!path))]
     const nitroJSONPath = nitroJSONPaths.find(p => existsSync(p))
+
+    const port = ctx.args.port
+      || process.env.NUXT_PORT
+      || process.env.NITRO_PORT
+      || process.env.PORT
+    const host = ctx.args.host
+      || process.env.NUXT_HOST
+      || process.env.NITRO_HOST
+      || process.env.HOST
+
     if (!nitroJSONPath) {
+      // A build with no server runtime leaves only static files, which the CLI
+      // can serve itself rather than reporting a missing server entry.
+      const publicDirs = [...new Set([
+        resolvedPublicDir,
+        resolve(cwd, '.output', 'public'),
+      ].filter((path): path is string => !!path))]
+      for (const dir of publicDirs) {
+        const entry = findStaticEntry(dir)
+        if (entry) {
+          logger.info(`This build has no server, so ${styleText('cyan', relativeToProcess(dir))} is being served statically.`)
+          const server = await previewStaticOutput({ dir, entry, port, hostname: host })
+          outro(`Previewing ${styleText('cyan', relativeToProcess(dir))} at ${styleText('cyan', server.url?.replace(TRAILING_SLASH_RE, '') || '')}`)
+          return
+        }
+      }
+
       logger.error(
-        `Cannot find ${styleText('cyan', 'nitro.json')}. Did you run ${styleText('cyan', 'nuxt build')} first? Search path:\n${nitroJSONPaths.join('\n')}`,
+        `Cannot find a build to preview${builderName ? ` for the ${styleText('cyan', builderName)} server builder` : ''}. Did you run ${styleText('cyan', 'nuxt build')} first? Search path:\n${[...nitroJSONPaths, ...publicDirs].join('\n')}`,
       )
       process.exit(1)
     }
@@ -144,15 +184,6 @@ const command = defineCommand({
     if (ctx.args.dotenv.length > 0 && missing.length > 0) {
       logger.error(`Cannot find ${missing.map(fileName => styleText('cyan', fileName)).join(', ')}.`)
     }
-
-    const port = ctx.args.port
-      || process.env.NUXT_PORT
-      || process.env.NITRO_PORT
-      || process.env.PORT
-    const host = ctx.args.host
-      || process.env.NUXT_HOST
-      || process.env.NITRO_HOST
-      || process.env.HOST
 
     outro(`Running ${styleText('cyan', previewCommand)} in ${styleText('cyan', relativeToProcess(outputPath))}`)
 

--- a/packages/nuxt-cli/src/commands/preview.ts
+++ b/packages/nuxt-cli/src/commands/preview.ts
@@ -14,11 +14,9 @@ import { loadKit } from '../utils/kit'
 import { logger, outro } from '../utils/logger'
 import { withPrependedPath } from '../utils/path-env'
 import { relativeToProcess, resolveRootDir } from '../utils/paths'
-import { getServerBuilderName } from '../utils/server-build'
-import { findStaticEntry, previewStaticOutput } from '../utils/static-preview'
+import { resolveServerBuild } from '../utils/server-build'
+import { findStaticEntry, formatServerURL, previewStaticOutput } from '../utils/static-preview'
 import { dotEnvArgs, envNameArgs, extendsArgs, logLevelArgs, rootDirArgs } from './_shared'
-
-const TRAILING_SLASH_RE = /\/$/
 
 const command = defineCommand({
   meta: {
@@ -50,13 +48,21 @@ const command = defineCommand({
     const cwd = resolveRootDir(ctx.args)
 
     let envLoaded = false
-    let resolvedOutputDir: string | undefined
-    let resolvedPublicDir: string | undefined
-    let builderName: string | undefined
+    /** `nitro.json` location, for Nuxt versions with no build descriptor. */
+    let legacyNitroJSON: string | undefined
+    /** What Nuxt says about the build it would produce, when it says anything. */
+    let declared: {
+      label: string
+      target: string | undefined
+      targetLabel: string
+      dir: string
+      previewCommand: string | undefined
+      staticDir: string | undefined
+    } | undefined
 
     try {
-      const { loadNuxt } = await loadKit(cwd)
-      const nuxt = await loadNuxt({
+      const kit = await loadKit(cwd)
+      const nuxt = await kit.loadNuxt({
         cwd,
         dotenv: {
           cwd,
@@ -70,29 +76,26 @@ const command = defineCommand({
             function (_, nuxt) {
               envLoaded = true
               nuxt.hook('nitro:init', (nitro) => {
-                resolvedOutputDir = resolve(nuxt.options.srcDir || cwd, nitro.options.output.dir || '.output', 'nitro.json')
+                legacyNitroJSON = resolve(nuxt.options.srcDir || cwd, nitro.options.output.dir || '.output', 'nitro.json')
               })
             },
           ],
         },
       })
-      builderName = getServerBuilderName(nuxt)
-      // `nuxt.serverOutput` is only present in newer Nuxt; the `nitro:init` hook
-      // above covers older versions, which only ever built with Nitro.
-      const serverOutput = (nuxt as { serverOutput?: { dir: () => string, publicDir: () => string } }).serverOutput
-      if (serverOutput) {
-        resolvedOutputDir = resolve(serverOutput.dir(), 'nitro.json')
-        resolvedPublicDir = serverOutput.publicDir()
+      const build = resolveServerBuild(kit, nuxt)
+      if (build.declared) {
+        declared = {
+          label: build.label,
+          target: build.target,
+          targetLabel: build.targetLabel,
+          dir: build.dir,
+          previewCommand: build.previewCommand,
+          staticDir: build.previewStaticDir,
+        }
       }
       await nuxt.close()
     }
     catch {}
-
-    const nitroJSONPaths = [...new Set([
-      resolvedOutputDir,
-      resolve(cwd, '.output', 'nitro.json'),
-    ].filter((path): path is string => !!path))]
-    const nitroJSONPath = nitroJSONPaths.find(p => existsSync(p))
 
     const port = ctx.args.port
       || process.env.NUXT_PORT
@@ -103,41 +106,77 @@ const command = defineCommand({
       || process.env.NITRO_HOST
       || process.env.HOST
 
-    if (!nitroJSONPath) {
+    let previewCommand: string | undefined
+    let outputPath: string | undefined
+    let target: readonly [label: string, value: string] | undefined
+    const searchPaths: string[] = []
+    const staticDirs: string[] = []
+
+    if (declared) {
+      searchPaths.push(declared.dir)
+      if (existsSync(declared.dir)) {
+        previewCommand = declared.previewCommand
+        outputPath = declared.dir
+        if (declared.target) {
+          target = [`${declared.label} ${declared.targetLabel}:`, declared.target]
+        }
+      }
+      if (declared.staticDir) {
+        staticDirs.push(declared.staticDir)
+      }
+    }
+    else {
+      // Without a descriptor, `nitro.json` is both the build marker and the
+      // source of the command to run.
+      const nitroJSONPaths = [...new Set([
+        legacyNitroJSON,
+        resolve(cwd, '.output', 'nitro.json'),
+      ].filter((path): path is string => !!path))]
+      searchPaths.push(...nitroJSONPaths)
+
+      const nitroJSONPath = nitroJSONPaths.find(path => existsSync(path))
+      if (nitroJSONPath) {
+        const nitroJSON = JSON.parse(await fsp.readFile(nitroJSONPath, 'utf-8'))
+        previewCommand = nitroJSON.commands?.preview
+        outputPath = dirname(nitroJSONPath)
+        if (nitroJSON.preset) {
+          target = ['Nitro preset:', nitroJSON.preset]
+        }
+      }
+      staticDirs.push(resolve(cwd, '.output', 'public'))
+    }
+
+    if (typeof previewCommand !== 'string' || !previewCommand.trim()) {
       // A build with no server runtime leaves only static files, which the CLI
       // can serve itself rather than reporting a missing server entry.
-      const publicDirs = [...new Set([
-        resolvedPublicDir,
-        resolve(cwd, '.output', 'public'),
-      ].filter((path): path is string => !!path))]
-      for (const dir of publicDirs) {
+      for (const dir of staticDirs) {
         const entry = findStaticEntry(dir)
         if (entry) {
           logger.info(`This build has no server, so ${styleText('cyan', relativeToProcess(dir))} is being served statically.`)
           const server = await previewStaticOutput({ dir, entry, port, hostname: host })
-          outro(`Previewing ${styleText('cyan', relativeToProcess(dir))} at ${styleText('cyan', server.url?.replace(TRAILING_SLASH_RE, '') || '')}`)
+          outro(`Previewing ${styleText('cyan', relativeToProcess(dir))} at ${styleText('cyan', formatServerURL(server.url))}`)
           return
         }
       }
 
-      logger.error(
-        `Cannot find a build to preview${builderName ? ` for the ${styleText('cyan', builderName)} server builder` : ''}. Did you run ${styleText('cyan', 'nuxt build')} first? Search path:\n${[...nitroJSONPaths, ...publicDirs].join('\n')}`,
-      )
+      if (outputPath) {
+        logger.error('Preview is not supported for this build.')
+      }
+      else {
+        logger.error(
+          `Cannot find a build to preview${declared ? ` for the ${styleText('cyan', declared.label)} server builder` : ''}. Did you run ${styleText('cyan', 'nuxt build')} first? Search path:\n${[...new Set([...searchPaths, ...staticDirs])].join('\n')}`,
+        )
+      }
       process.exit(1)
     }
-    const outputPath = dirname(nitroJSONPath)
-    const nitroJSON = JSON.parse(await fsp.readFile(nitroJSONPath, 'utf-8'))
 
-    const previewCommand = nitroJSON.commands?.preview
-    if (typeof previewCommand !== 'string' || !previewCommand.trim()) {
-      logger.error('Preview is not supported for this build.')
-      process.exit(1)
-    }
+    // `outputPath` is set whenever a preview command was found.
+    const previewDir = outputPath!
 
     const info = [
       ['Node.js:', `v${process.versions.node}`],
-      ['Nitro preset:', nitroJSON.preset],
-      ['Working directory:', relativeToProcess(outputPath)],
+      ...(target ? [target] : []),
+      ['Working directory:', relativeToProcess(previewDir)],
     ] as const
     const _infoKeyLen = Math.max(...info.map(([label]) => label.length))
 
@@ -185,17 +224,17 @@ const command = defineCommand({
       logger.error(`Cannot find ${missing.map(fileName => styleText('cyan', fileName)).join(', ')}.`)
     }
 
-    outro(`Running ${styleText('cyan', previewCommand)} in ${styleText('cyan', relativeToProcess(outputPath))}`)
+    outro(`Running ${styleText('cyan', previewCommand)} in ${styleText('cyan', relativeToProcess(previewDir))}`)
 
     const [command, ...commandArgs] = tokenizeArgs(previewCommand) as [string, ...string[]]
     await x(command, commandArgs, {
       throwOnError: true,
       nodeOptions: {
         stdio: 'inherit',
-        cwd: outputPath,
+        cwd: previewDir,
         env: {
           ...withPrependedPath(process.env, [
-            resolve(outputPath, 'node_modules/.bin'),
+            resolve(previewDir, 'node_modules/.bin'),
             resolve(cwd, 'node_modules/.bin'),
           ]),
           NUXT_PORT: port,

--- a/packages/nuxt-cli/src/completions.ts
+++ b/packages/nuxt-cli/src/completions.ts
@@ -28,11 +28,13 @@ export async function initCompletions<T extends ArgsDef = ArgsDef>(command: Comm
 
   const buildCommand = completion.commands.get('build')
   if (buildCommand) {
-    const presetOption = buildCommand.options.get('preset')
-    if (presetOption) {
-      presetOption.handler = (complete) => {
-        for (const preset of nitroPresets) {
-          complete(preset, '')
+    for (const name of ['target', 'preset']) {
+      const option = buildCommand.options.get(name)
+      if (option) {
+        option.handler = (complete) => {
+          for (const preset of nitroPresets) {
+            complete(preset, '')
+          }
         }
       }
     }

--- a/packages/nuxt-cli/src/completions.ts
+++ b/packages/nuxt-cli/src/completions.ts
@@ -26,10 +26,9 @@ export async function initCompletions<T extends ArgsDef = ArgsDef>(command: Comm
     }
   }
 
-  const buildCommand = completion.commands.get('build')
-  if (buildCommand) {
+  for (const command of ['build', 'generate']) {
     for (const name of ['target', 'preset']) {
-      const option = buildCommand.options.get(name)
+      const option = completion.commands.get(command)?.options.get(name)
       if (option) {
         option.handler = (complete) => {
           for (const preset of nitroPresets) {

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -34,6 +34,7 @@ import { loadKit } from '../utils/kit'
 import { acquireLock, formatLockError, getTakeoverPid, updateLock } from '../utils/lockfile'
 import { debug, logger, writeNotice } from '../utils/logger'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
+import { getServerBuilderName } from '../utils/server-build'
 import { renderError, renderErrorAnsi } from './error-lazy'
 import { isAllowedHost } from './host-check'
 import { bindListener, createListener, matchesBoundTarget, openBrowser, resolveOpenURL } from './listen'
@@ -1156,7 +1157,10 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     await Promise.all([typesPromise, kit.buildNuxt(this.#currentNuxt)])
 
     if (!this.#currentNuxt.server) {
-      throw new Error('Nitro server has not been initialized.')
+      throw new ActionableError(
+        `The ${styleText('cyan', getServerBuilderName(this.#currentNuxt))} server builder did not provide a dev server.\n`
+        + `       A ${styleText('cyan', 'server.builder')} must expose a \`handler\`, \`fetch\` or \`app\` on \`nuxt.server\` to be served by ${styleText('cyan', 'nuxt dev')}.`,
+      )
     }
 
     const distDir = join(this.#currentNuxt.options.buildDir, 'dist')

--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -34,7 +34,7 @@ import { loadKit } from '../utils/kit'
 import { acquireLock, formatLockError, getTakeoverPid, updateLock } from '../utils/lockfile'
 import { debug, logger, writeNotice } from '../utils/logger'
 import { loadNuxtManifest, resolveNuxtManifest, writeNuxtManifest } from '../utils/nuxt'
-import { getServerBuilderName } from '../utils/server-build'
+import { resolveServerBuild } from '../utils/server-build'
 import { renderError, renderErrorAnsi } from './error-lazy'
 import { isAllowedHost } from './host-check'
 import { bindListener, createListener, matchesBoundTarget, openBrowser, resolveOpenURL } from './listen'
@@ -150,6 +150,15 @@ function devForkParentPid(): number | undefined {
 // https://regex101.com/r/7HkR5c/1
 const RESTART_RE = /^(?:nuxt\.config\.[a-z0-9]+|\.nuxtignore|\.nuxtrc|\.config\/nuxt(?:\.config)?\.[a-z0-9]+)$/
 const TRAILING_SLASH_RE = /\/$/
+
+/**
+ * `built` distinguishes a builder that declared it has no dev server from one
+ * that built without leaving a server behind.
+ */
+function noDevServerMessage(builder: string, built: boolean): string {
+  return `The ${styleText('cyan', builder)} server builder ${built ? 'did not provide' : 'does not provide'} a dev server.\n`
+    + `       A ${styleText('cyan', 'server.builder')} must expose a \`handler\`, \`fetch\` or \`app\` on \`nuxt.server\` to be served by ${styleText('cyan', 'nuxt dev')}.`
+}
 
 /**
  * Files above this size are tracked by mtime alone.
@@ -1148,6 +1157,13 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     }
 
     const kit = await loadKit(this.options.cwd)
+
+    // Refusing a build-only builder before building beats reporting it after.
+    const serverBuild = resolveServerBuild(kit, this.#currentNuxt)
+    if (!serverBuild.hasDevServer) {
+      throw new ActionableError(noDevServerMessage(serverBuild.label, false))
+    }
+
     this.#progress.setPhase('types')
     // ensure tsconfigs exist before starting the dev server (vite relies on in the initialisation stage)
     const typesPromise = existsSync(join(this.#currentNuxt.options.buildDir, 'tsconfig.json'))
@@ -1157,10 +1173,7 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
     await Promise.all([typesPromise, kit.buildNuxt(this.#currentNuxt)])
 
     if (!this.#currentNuxt.server) {
-      throw new ActionableError(
-        `The ${styleText('cyan', getServerBuilderName(this.#currentNuxt))} server builder did not provide a dev server.\n`
-        + `       A ${styleText('cyan', 'server.builder')} must expose a \`handler\`, \`fetch\` or \`app\` on \`nuxt.server\` to be served by ${styleText('cyan', 'nuxt dev')}.`,
-      )
+      throw new ActionableError(noDevServerMessage(serverBuild.label, true))
     }
 
     const distDir = join(this.#currentNuxt.options.buildDir, 'dist')

--- a/packages/nuxt-cli/src/run.ts
+++ b/packages/nuxt-cli/src/run.ts
@@ -20,7 +20,7 @@ globalThis.__nuxt_cli__ = globalThis.__nuxt_cli__ || {
 }
 
 // Commands that keep serving after their `run` resolves, so an alive process is expected.
-export const LONG_RUNNING_COMMANDS: Set<string> = new Set(['dev', '_dev', 'analyze', 'test'])
+export const LONG_RUNNING_COMMANDS: Set<string> = new Set(['dev', '_dev', 'analyze', 'test', 'preview', 'start'])
 
 let currentCommand: string | undefined
 

--- a/packages/nuxt-cli/src/utils/server-build.ts
+++ b/packages/nuxt-cli/src/utils/server-build.ts
@@ -21,15 +21,15 @@ const DEFAULT_TARGET_LABEL = 'preset'
  */
 export interface ServerBuild {
   /** The configured server builder, e.g. `nitro` or `vite`. */
-  name: string
+  readonly name: string
   /** The builder's display name, e.g. `Nitro` or `Vite SPA`. */
-  label: string
+  readonly label: string
   /** What the builder calls its deploy target axis, e.g. `preset`. */
   targetLabel: string
   /** Whether Nuxt described this build itself, rather than the CLI inferring it. */
   declared: boolean
   /** Whether this build produces a server runtime. */
-  hasServer: boolean
+  readonly hasServer: boolean
   /** Whether this builder can serve `nuxt dev`. */
   hasDevServer: boolean
   /** The deploy target within the builder, e.g. a Nitro preset. */
@@ -154,30 +154,38 @@ function normalizeDir(dir: string): string {
  */
 export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild {
   const declared = (nuxt as MaybeModernNuxt).serverBuild
-  const nitro = declared?.capabilities.server === false ? undefined : tryUseNitro(kit)
+  // Resolved on each read rather than once: a Nitro instance may not exist yet
+  // when the build is first described, and everything it answers can move.
+  const getNitro = () => declared?.capabilities.server === false ? undefined : tryUseNitro(kit)
 
   return {
-    name: declared?.name ?? inferBuilderName(nuxt) ?? (nitro ? 'nitro' : 'unknown'),
-    label: getServerBuilderName(nuxt, !!nitro),
     targetLabel: declared?.targetLabel ?? DEFAULT_TARGET_LABEL,
     declared: !!declared,
-    hasServer: declared?.capabilities.server ?? !!nitro,
     hasDevServer: declared?.capabilities.dev ?? true,
+    get name() {
+      return declared?.name ?? inferBuilderName(nuxt) ?? (getNitro() ? 'nitro' : 'unknown')
+    },
+    get label() {
+      return getServerBuilderName(nuxt, !!getNitro())
+    },
+    get hasServer() {
+      return declared?.capabilities.server ?? !!getNitro()
+    },
     get target() {
-      return declared ? declared.target?.() : nitro?.options.preset
+      return declared ? declared.target?.() : getNitro()?.options.preset
     },
     get dir() {
       return normalizeDir(declared?.output.dir()
-        ?? nitro?.options.output?.dir
+        ?? getNitro()?.options.output?.dir
         ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.dir || DEFAULT_OUTPUT_DIR))
     },
     get publicDir() {
       return normalizeDir(declared?.output.publicDir()
-        ?? nitro?.options.output?.publicDir
+        ?? getNitro()?.options.output?.publicDir
         ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.publicDir || DEFAULT_PUBLIC_DIR))
     },
     get previewCommand() {
-      return declared ? declared.preview?.command?.() : nitro?.options.commands?.preview
+      return declared ? declared.preview?.command?.() : getNitro()?.options.commands?.preview
     },
     get previewStaticDir() {
       const dir = declared?.preview?.staticDir?.()

--- a/packages/nuxt-cli/src/utils/server-build.ts
+++ b/packages/nuxt-cli/src/utils/server-build.ts
@@ -136,6 +136,16 @@ function inferBuilderName(nuxt: Nuxt): string | undefined {
 }
 
 /**
+ * A directory path that compares equal to another naming the same directory.
+ *
+ * `nitro.options.output.*` carries a trailing slash, and these paths are used as
+ * lock keys and printed relative to the cwd.
+ */
+function normalizeDir(dir: string): string {
+  return resolve(dir)
+}
+
+/**
  * Describe a loaded Nuxt instance's build in builder-agnostic terms.
  *
  * `nuxt.serverBuild` answers all of this where it exists; otherwise it is
@@ -157,20 +167,21 @@ export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild
       return declared ? declared.target?.() : nitro?.options.preset
     },
     get dir() {
-      return declared?.output.dir()
+      return normalizeDir(declared?.output.dir()
         ?? nitro?.options.output?.dir
-        ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.dir || DEFAULT_OUTPUT_DIR)
+        ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.dir || DEFAULT_OUTPUT_DIR))
     },
     get publicDir() {
-      return declared?.output.publicDir()
+      return normalizeDir(declared?.output.publicDir()
         ?? nitro?.options.output?.publicDir
-        ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.publicDir || DEFAULT_PUBLIC_DIR)
+        ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.publicDir || DEFAULT_PUBLIC_DIR))
     },
     get previewCommand() {
       return declared ? declared.preview?.command?.() : nitro?.options.commands?.preview
     },
     get previewStaticDir() {
-      return declared ? declared.preview?.staticDir?.() : undefined
+      const dir = declared?.preview?.staticDir?.()
+      return dir ? normalizeDir(dir) : undefined
     },
   }
 }

--- a/packages/nuxt-cli/src/utils/server-build.ts
+++ b/packages/nuxt-cli/src/utils/server-build.ts
@@ -1,0 +1,111 @@
+import type { Nuxt } from '@nuxt/schema'
+
+import { resolve } from 'pathe'
+
+/** Default output locations Nuxt uses when no server builder declares its own. */
+const DEFAULT_OUTPUT_DIR = '.output'
+const DEFAULT_PUBLIC_DIR = '.output/public'
+
+/**
+ * A server builder as the CLI needs to see it: a name to print, an optional
+ * deploy target within that builder, whether a server runtime exists, and where
+ * the build lands.
+ *
+ * `dir` and `publicDir` are getters, not values: a builder may still move its
+ * output after `nuxt.ready()` (Nitro resolves its preset, then `nitro:config`
+ * and `nitro.updateConfig()` can both change `output.dir`), so a snapshot taken
+ * before the build can be wrong by the time it is used.
+ */
+export interface ServerBuild {
+  /** The configured server builder, e.g. `nitro` or `vite`. */
+  name: string
+  /** A deploy target within that builder, e.g. a Nitro preset. */
+  target: string | undefined
+  /** Whether this build produced a server runtime at all. */
+  hasServer: boolean
+  /** Root of the build output. */
+  readonly dir: string
+  /** Static output served from the root of the deployment. */
+  readonly publicDir: string
+}
+
+/**
+ * Nuxt fields the CLI reads optimistically: they exist in recent Nuxt only, and
+ * the CLI supports a range of versions.
+ */
+interface MaybeModernNuxt extends Nuxt {
+  serverOutput?: { dir: () => string, publicDir: () => string }
+  options: Nuxt['options'] & { server?: { builder?: unknown } }
+}
+
+interface MaybeModernKit {
+  tryUseNitro?: () => NitroLike | undefined
+  useNitro: () => NitroLike
+}
+
+interface NitroLike {
+  options: { preset?: string, output?: { dir?: string, publicDir?: string } }
+}
+
+/**
+ * The Nitro instance for this build, or `undefined` when the configured server
+ * builder did not create one.
+ *
+ * `tryUseNitro` is only present in newer `@nuxt/kit`; on older versions
+ * `useNitro` throwing means the same thing.
+ */
+export function tryUseNitro(kit: MaybeModernKit): NitroLike | undefined {
+  if (typeof kit.tryUseNitro === 'function') {
+    return kit.tryUseNitro()
+  }
+  try {
+    return kit.useNitro()
+  }
+  catch {
+    return undefined
+  }
+}
+
+/**
+ * The name of the configured server builder, normalised for display: a module
+ * specifier such as `@nuxt/vite-server` reads as `vite`.
+ */
+export function getServerBuilderName(nuxt: Nuxt, hasServer?: boolean): string {
+  const builder = (nuxt as MaybeModernNuxt).options.server?.builder
+  if (typeof builder === 'string' && builder) {
+    return builder.replace(/^@nuxt\//, '').replace(/-server$/, '')
+  }
+  if (builder) {
+    return 'custom'
+  }
+  // Nuxt versions without `server.builder` only ever built with Nitro.
+  return hasServer === false ? 'unknown' : 'nitro'
+}
+
+/**
+ * Describe a loaded Nuxt instance's build in builder-agnostic terms.
+ *
+ * Output paths come from `nuxt.serverOutput` where available, falling back to
+ * the Nitro instance and then to Nuxt's defaults, so this works against Nuxt
+ * versions that predate either.
+ */
+export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild {
+  const nitro = tryUseNitro(kit)
+  const serverOutput = (nuxt as MaybeModernNuxt).serverOutput
+
+  return {
+    name: getServerBuilderName(nuxt, !!nitro),
+    target: nitro?.options.preset,
+    hasServer: !!nitro,
+    get dir() {
+      return serverOutput?.dir()
+        ?? nitro?.options.output?.dir
+        ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.dir || DEFAULT_OUTPUT_DIR)
+    },
+    get publicDir() {
+      return serverOutput?.publicDir()
+        ?? nitro?.options.output?.publicDir
+        ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.publicDir || DEFAULT_PUBLIC_DIR)
+    },
+  }
+}

--- a/packages/nuxt-cli/src/utils/server-build.ts
+++ b/packages/nuxt-cli/src/utils/server-build.ts
@@ -6,27 +6,56 @@ import { resolve } from 'pathe'
 const DEFAULT_OUTPUT_DIR = '.output'
 const DEFAULT_PUBLIC_DIR = '.output/public'
 
+/** What a deploy target is called when the builder does not say. */
+const DEFAULT_TARGET_LABEL = 'preset'
+
 /**
- * A server builder as the CLI needs to see it: a name to print, an optional
- * deploy target within that builder, whether a server runtime exists, and where
- * the build lands.
+ * A server builder as the CLI needs to see it: what to call it, an optional
+ * deploy target within it, what it can do, where its build lands and how to
+ * preview it.
  *
- * `dir` and `publicDir` are getters, not values: a builder may still move its
- * output after `nuxt.ready()` (Nitro resolves its preset, then `nitro:config`
- * and `nitro.updateConfig()` can both change `output.dir`), so a snapshot taken
+ * Everything a builder can move during its own init is a getter rather than a
+ * value: Nitro resolves its preset and then `nitro:config` and
+ * `nitro.updateConfig()` can each change `output.dir`, so a snapshot taken
  * before the build can be wrong by the time it is used.
  */
 export interface ServerBuild {
   /** The configured server builder, e.g. `nitro` or `vite`. */
   name: string
-  /** A deploy target within that builder, e.g. a Nitro preset. */
-  target: string | undefined
-  /** Whether this build produced a server runtime at all. */
+  /** The builder's display name, e.g. `Nitro` or `Vite SPA`. */
+  label: string
+  /** What the builder calls its deploy target axis, e.g. `preset`. */
+  targetLabel: string
+  /** Whether Nuxt described this build itself, rather than the CLI inferring it. */
+  declared: boolean
+  /** Whether this build produces a server runtime. */
   hasServer: boolean
+  /** Whether this builder can serve `nuxt dev`. */
+  hasDevServer: boolean
+  /** The deploy target within the builder, e.g. a Nitro preset. */
+  readonly target: string | undefined
   /** Root of the build output. */
   readonly dir: string
   /** Static output served from the root of the deployment. */
   readonly publicDir: string
+  /** Command that runs this build locally, when it has a server to run. */
+  readonly previewCommand: string | undefined
+  /** Directory to serve when this build is static only. */
+  readonly previewStaticDir: string | undefined
+}
+
+/** The descriptor recent Nuxt publishes as `nuxt.serverBuild`. */
+interface NuxtServerBuild {
+  name: string
+  label?: string
+  target?: () => string | undefined
+  targetLabel?: string
+  output: { dir: () => string, publicDir: () => string }
+  capabilities: { server: boolean, dev: boolean }
+  preview?: {
+    command?: () => string | undefined
+    staticDir?: () => string
+  }
 }
 
 /**
@@ -34,7 +63,7 @@ export interface ServerBuild {
  * the CLI supports a range of versions.
  */
 interface MaybeModernNuxt extends Nuxt {
-  serverOutput?: { dir: () => string, publicDir: () => string }
+  serverBuild?: NuxtServerBuild
   options: Nuxt['options'] & { server?: { builder?: unknown } }
 }
 
@@ -44,7 +73,11 @@ interface MaybeModernKit {
 }
 
 interface NitroLike {
-  options: { preset?: string, output?: { dir?: string, publicDir?: string } }
+  options: {
+    preset?: string
+    output?: { dir?: string, publicDir?: string }
+    commands?: { preview?: string }
+  }
 }
 
 /**
@@ -67,45 +100,77 @@ export function tryUseNitro(kit: MaybeModernKit): NitroLike | undefined {
 }
 
 /**
- * The name of the configured server builder, normalised for display: a module
- * specifier such as `@nuxt/vite-server` reads as `vite`.
+ * The display name of the configured server builder.
+ *
+ * Nuxt describes it on `nuxt.serverBuild`; older versions are read from the
+ * `server.builder` option, where a module specifier such as `@nuxt/vite-server`
+ * reads as `vite`.
  */
 export function getServerBuilderName(nuxt: Nuxt, hasServer?: boolean): string {
+  const declared = (nuxt as MaybeModernNuxt).serverBuild
+  if (declared) {
+    return declared.label || declared.name
+  }
+
+  const name = inferBuilderName(nuxt)
+  if (name === 'nitro') {
+    return 'Nitro'
+  }
+  if (name) {
+    return name
+  }
+  // Nuxt versions without `server.builder` only ever built with Nitro.
+  return hasServer === false ? 'unknown' : 'Nitro'
+}
+
+/**
+ * The server builder named by the `server.builder` option, for Nuxt versions
+ * that do not describe the build themselves.
+ */
+function inferBuilderName(nuxt: Nuxt): string | undefined {
   const builder = (nuxt as MaybeModernNuxt).options.server?.builder
   if (typeof builder === 'string' && builder) {
     return builder.replace(/^@nuxt\//, '').replace(/-server$/, '')
   }
-  if (builder) {
-    return 'custom'
-  }
-  // Nuxt versions without `server.builder` only ever built with Nitro.
-  return hasServer === false ? 'unknown' : 'nitro'
+  return builder ? 'custom' : undefined
 }
 
 /**
  * Describe a loaded Nuxt instance's build in builder-agnostic terms.
  *
- * Output paths come from `nuxt.serverOutput` where available, falling back to
- * the Nitro instance and then to Nuxt's defaults, so this works against Nuxt
- * versions that predate either.
+ * `nuxt.serverBuild` answers all of this where it exists; otherwise it is
+ * reconstructed from the Nitro instance and Nuxt's defaults, so the CLI keeps
+ * working against Nuxt versions that predate the descriptor.
  */
 export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild {
-  const nitro = tryUseNitro(kit)
-  const serverOutput = (nuxt as MaybeModernNuxt).serverOutput
+  const declared = (nuxt as MaybeModernNuxt).serverBuild
+  const nitro = declared?.capabilities.server === false ? undefined : tryUseNitro(kit)
 
   return {
-    name: getServerBuilderName(nuxt, !!nitro),
-    target: nitro?.options.preset,
-    hasServer: !!nitro,
+    name: declared?.name ?? inferBuilderName(nuxt) ?? (nitro ? 'nitro' : 'unknown'),
+    label: getServerBuilderName(nuxt, !!nitro),
+    targetLabel: declared?.targetLabel ?? DEFAULT_TARGET_LABEL,
+    declared: !!declared,
+    hasServer: declared?.capabilities.server ?? !!nitro,
+    hasDevServer: declared?.capabilities.dev ?? true,
+    get target() {
+      return declared ? declared.target?.() : nitro?.options.preset
+    },
     get dir() {
-      return serverOutput?.dir()
+      return declared?.output.dir()
         ?? nitro?.options.output?.dir
         ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.dir || DEFAULT_OUTPUT_DIR)
     },
     get publicDir() {
-      return serverOutput?.publicDir()
+      return declared?.output.publicDir()
         ?? nitro?.options.output?.publicDir
         ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.publicDir || DEFAULT_PUBLIC_DIR)
+    },
+    get previewCommand() {
+      return declared ? declared.preview?.command?.() : nitro?.options.commands?.preview
+    },
+    get previewStaticDir() {
+      return declared ? declared.preview?.staticDir?.() : undefined
     },
   }
 }

--- a/packages/nuxt-cli/src/utils/static-preview.ts
+++ b/packages/nuxt-cli/src/utils/static-preview.ts
@@ -1,0 +1,41 @@
+import type { Server } from 'srvx'
+import { existsSync } from 'node:fs'
+
+import { readFile } from 'node:fs/promises'
+
+import { join } from 'pathe'
+import { serve } from 'srvx'
+import { staticMiddleware } from 'srvx/static'
+
+/** Files a client-only build uses as its entry, most specific first. */
+const SPA_FALLBACKS = ['200.html', 'index.html']
+
+/** Whether a directory looks like the static output of a client-only build. */
+export function findStaticEntry(dir: string): string | undefined {
+  return SPA_FALLBACKS.map(name => join(dir, name)).find(path => existsSync(path))
+}
+
+export interface StaticPreviewOptions {
+  dir: string
+  entry: string
+  port?: string
+  hostname?: string
+}
+
+/**
+ * Serve a build that has no server runtime: static files from disk, with every
+ * unmatched path answered by the client entry so client-side routing works.
+ */
+export async function previewStaticOutput(options: StaticPreviewOptions): Promise<Server> {
+  const server = serve({
+    port: options.port,
+    hostname: options.hostname,
+    middleware: [staticMiddleware({ dir: options.dir })],
+    async fetch() {
+      return new Response(await readFile(options.entry), {
+        headers: { 'content-type': 'text/html;charset=utf-8' },
+      })
+    },
+  })
+  return await server.ready()
+}

--- a/packages/nuxt-cli/src/utils/static-preview.ts
+++ b/packages/nuxt-cli/src/utils/static-preview.ts
@@ -15,6 +15,22 @@ export function findStaticEntry(dir: string): string | undefined {
   return SPA_FALLBACKS.map(name => join(dir, name)).find(path => existsSync(path))
 }
 
+/** Addresses a browser cannot be pointed at, and what to show instead. */
+const WILDCARD_HOSTS: Record<string, string> = {
+  '[::]': 'localhost',
+  '0.0.0.0': 'localhost',
+}
+
+/** The origin to print for a running server, with no wildcard host and no trailing slash. */
+export function formatServerURL(url: string | undefined): string {
+  if (!url) {
+    return ''
+  }
+  const parsed = new URL(url)
+  parsed.hostname = WILDCARD_HOSTS[parsed.hostname] ?? parsed.hostname
+  return parsed.href.replace(/\/$/, '')
+}
+
 export interface StaticPreviewOptions {
   dir: string
   entry: string

--- a/packages/nuxt-cli/test/unit/commands/build.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/build.spec.ts
@@ -2,6 +2,7 @@ import { runCommand } from 'citty'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import build from '../../../src/commands/build'
+import { logger } from '../../../src/utils/logger'
 
 const mocks = vi.hoisted(() => ({
   acquireLock: vi.fn(),
@@ -36,7 +37,7 @@ vi.mock('../../../src/utils/lockfile', () => ({
   formatLockError: mocks.formatLockError,
 }))
 vi.mock('../../../src/utils/logger', () => ({
-  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), message: vi.fn() },
   intro: vi.fn(),
   outro: vi.fn(),
 }))
@@ -144,5 +145,23 @@ describe('build', () => {
     expect(mocks.clearBuildDir).not.toHaveBeenCalled()
     expect(mocks.buildNuxt).not.toHaveBeenCalled()
     expect(mocks.releaseBuildDir).toHaveBeenCalledOnce()
+  })
+
+  it('builds without a server, locking the default output directory', async () => {
+    mocks.buildNuxt.mockResolvedValue(undefined)
+    mocks.useNitro.mockImplementation(() => {
+      throw new Error('Nitro is not initialized!')
+    })
+    mocks.loadNuxt.mockResolvedValue({
+      hook: vi.fn(),
+      ready: vi.fn(),
+      options: { buildDir, rootDir: cwd, ssr: false, server: { builder: 'vite' } },
+    })
+
+    await run()
+
+    expect(mocks.acquireOutputLock).toHaveBeenCalledWith(cwd, outputDir, { command: 'build', cwd })
+    expect(mocks.buildNuxt).toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('preset'))
   })
 })

--- a/packages/nuxt-cli/test/unit/commands/build.spec.ts
+++ b/packages/nuxt-cli/test/unit/commands/build.spec.ts
@@ -147,6 +147,38 @@ describe('build', () => {
     expect(mocks.releaseBuildDir).toHaveBeenCalledOnce()
   })
 
+  it.each(['--target=vercel', '--preset=vercel'])('maps %s onto the Nitro preset', async (arg) => {
+    mocks.buildNuxt.mockResolvedValue(undefined)
+
+    await run([arg])
+
+    expect(mocks.loadNuxt).toHaveBeenCalledWith(expect.objectContaining({
+      overrides: expect.objectContaining({ nitro: { static: undefined, preset: 'vercel' } }),
+    }))
+  })
+
+  it('names the deploy target as the builder does', async () => {
+    mocks.buildNuxt.mockResolvedValue(undefined)
+    mocks.loadNuxt.mockResolvedValue({
+      hook: vi.fn(),
+      ready: vi.fn(),
+      options: { buildDir, rootDir: cwd, ssr: true },
+      serverBuild: {
+        name: 'nitro',
+        label: 'Nitro',
+        targetLabel: 'preset',
+        target: () => 'vercel',
+        capabilities: { server: true, dev: true },
+        output: { dir: () => outputDir, publicDir: () => `${outputDir}/public` },
+      },
+    })
+
+    await run()
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Nitro preset:'))
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('vercel'))
+  })
+
   it('builds without a server, locking the default output directory', async () => {
     mocks.buildNuxt.mockResolvedValue(undefined)
     mocks.useNitro.mockImplementation(() => {

--- a/packages/nuxt-cli/test/unit/help.spec.ts
+++ b/packages/nuxt-cli/test/unit/help.spec.ts
@@ -156,7 +156,7 @@ describe('help', () => {
 
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
                              --prerender    Build Nuxt and prerender static routes                                                                                                              
-                 --preset=<nitro-preset>    Nitro server preset (e.g. \`node-server\`, \`vercel\`, \`netlify\`)                                                                                       
+                       --target=<target>    Deploy target for the configured server builder (e.g. \`node-server\`, \`vercel\`, \`netlify\`)                                                           
                       --dotenv=<path>...    Path to \`.env\` file to load, relative to the root directory. Can be repeated, with later files taking precedence.                                   
                  --envName=<environment>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
            -e, --extends=<layer-name>...    Extend from a Nuxt layer                                                                                                                            
@@ -292,7 +292,7 @@ describe('help', () => {
       OPTIONS
 
         --logLevel=<silent|info|verbose>    Specify build-time log level                                                                                                                        
-                 --preset=<nitro-preset>    Nitro server preset (e.g. \`node-server\`, \`vercel\`, \`netlify\`)                                                                                       
+                       --target=<target>    Deploy target for the configured server builder (e.g. \`node-server\`, \`vercel\`, \`netlify\`)                                                           
                       --dotenv=<path>...    Path to \`.env\` file to load, relative to the root directory. Can be repeated, with later files taking precedence.                                   
                  --envName=<environment>    The environment to use when resolving configuration overrides (default is \`production\` when building, and \`development\` when running the dev server)
            -e, --extends=<layer-name>...    Extend from a Nuxt layer                                                                                                                            

--- a/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
@@ -132,6 +132,14 @@ describe('resolveServerBuild', () => {
     expect(build.publicDir).toBe('/project/.output/public')
   })
 
+  it('should strip the trailing slash Nitro puts on its output paths', () => {
+    const kit = { useNitro: () => ({ options: { output: { dir: '/project/.output/', publicDir: '/project/.output/public/' } } }) }
+    const build = resolveServerBuild(kit, makeNuxt())
+
+    expect(build.dir).toBe('/project/.output')
+    expect(build.publicDir).toBe('/project/.output/public')
+  })
+
   it('should honour a configured Nitro output directory without an instance', () => {
     const build = resolveServerBuild(serverlessKit, makeNuxt({ nitro: { output: { dir: 'dist' } } }))
 

--- a/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
@@ -10,8 +10,17 @@ function makeNuxt(options: Record<string, any> = {}, extra: Record<string, any> 
   } as unknown as Nuxt
 }
 
+function descriptor(overrides: Record<string, any> = {}) {
+  return {
+    name: 'nitro',
+    capabilities: { server: true, dev: true },
+    output: { dir: () => '/project/.output', publicDir: () => '/project/.output/public' },
+    ...overrides,
+  }
+}
+
 const nitroKit = {
-  useNitro: () => ({ options: { preset: 'node-server', output: { dir: '/project/.output', publicDir: '/project/.output/public' } } }),
+  useNitro: () => ({ options: { preset: 'node-server', output: { dir: '/project/.output', publicDir: '/project/.output/public' }, commands: { preview: 'node ./server/index.mjs' } } }),
 }
 
 const serverlessKit = {
@@ -37,7 +46,7 @@ describe('getServerBuilderName', () => {
     [{ server: { builder: '@nuxt/vite-server' } }, 'vite'],
     [{ server: { builder: 'vite' } }, 'vite'],
     [{ server: { builder: () => {} } }, 'custom'],
-    [{}, 'nitro'],
+    [{}, 'Nitro'],
   ])('should describe %j as %s', (options, expected) => {
     expect(getServerBuilderName(makeNuxt(options))).toBe(expected)
   })
@@ -45,32 +54,80 @@ describe('getServerBuilderName', () => {
   it('should not claim Nitro when there is no server and no configured builder', () => {
     expect(getServerBuilderName(makeNuxt(), false)).toBe('unknown')
   })
+
+  it('should use the label Nuxt declares', () => {
+    const nuxt = makeNuxt({ server: { builder: 'vite' } }, { serverBuild: descriptor({ name: 'vite', label: 'Vite SPA' }) })
+    expect(getServerBuilderName(nuxt)).toBe('Vite SPA')
+  })
 })
 
 describe('resolveServerBuild', () => {
   it('should read output paths from the Nitro instance', () => {
     const build = resolveServerBuild(nitroKit, makeNuxt())
 
-    expect(build).toMatchObject({ name: 'nitro', target: 'node-server', hasServer: true })
+    expect(build).toMatchObject({ name: 'nitro', label: 'Nitro', declared: false, hasServer: true })
+    expect(build.target).toBe('node-server')
+    expect(build.previewCommand).toBe('node ./server/index.mjs')
     expect(build.dir).toBe('/project/.output')
     expect(build.publicDir).toBe('/project/.output/public')
   })
 
-  it('should prefer `nuxt.serverOutput`, re-reading it on each access', () => {
+  it('should prefer the descriptor Nuxt declares, re-reading it on each access', () => {
     let dir = '/project/.vercel/output'
-    const nuxt = makeNuxt({}, { serverOutput: { dir: () => dir, publicDir: () => `${dir}/static` } })
+    const nuxt = makeNuxt({}, {
+      serverBuild: descriptor({
+        name: 'nitro',
+        label: 'Nitro',
+        targetLabel: 'preset',
+        target: () => 'vercel',
+        output: { dir: () => dir, publicDir: () => `${dir}/static` },
+        preview: { command: () => 'node ./server/index.mjs' },
+      }),
+    })
     const build = resolveServerBuild(nitroKit, nuxt)
 
+    expect(build).toMatchObject({ name: 'nitro', label: 'Nitro', targetLabel: 'preset', declared: true, hasServer: true, hasDevServer: true })
+    expect(build.target).toBe('vercel')
+    expect(build.previewCommand).toBe('node ./server/index.mjs')
     expect(build.dir).toBe('/project/.vercel/output')
     dir = '/project/.output'
     expect(build.dir).toBe('/project/.output')
     expect(build.publicDir).toBe('/project/.output/static')
   })
 
+  it('should describe a declared build with no server without consulting Nitro', () => {
+    const useNitro = vi.fn(() => {
+      throw new Error('Nitro is not initialized!')
+    })
+    const nuxt = makeNuxt({ server: { builder: 'vite' } }, {
+      serverBuild: descriptor({
+        name: 'vite',
+        label: 'Vite SPA',
+        capabilities: { server: false, dev: true },
+        output: { dir: () => '/project/.output', publicDir: () => '/project/.output/public' },
+        preview: { staticDir: () => '/project/.output/public' },
+      }),
+    })
+
+    const build = resolveServerBuild({ useNitro }, nuxt)
+
+    expect(build).toMatchObject({ name: 'vite', label: 'Vite SPA', declared: true, hasServer: false, hasDevServer: true })
+    expect(build.target).toBeUndefined()
+    expect(build.previewCommand).toBeUndefined()
+    expect(build.previewStaticDir).toBe('/project/.output/public')
+    expect(useNitro).not.toHaveBeenCalled()
+  })
+
+  it('should report a builder that declares no dev server', () => {
+    const nuxt = makeNuxt({}, { serverBuild: descriptor({ capabilities: { server: true, dev: false } }) })
+    expect(resolveServerBuild(nitroKit, nuxt).hasDevServer).toBe(false)
+  })
+
   it('should fall back to defaults when there is no server', () => {
     const build = resolveServerBuild(serverlessKit, makeNuxt({ server: { builder: 'vite' } }))
 
-    expect(build).toMatchObject({ name: 'vite', target: undefined, hasServer: false })
+    expect(build).toMatchObject({ name: 'vite', label: 'vite', declared: false, hasServer: false })
+    expect(build.target).toBeUndefined()
     expect(build.dir).toBe('/project/.output')
     expect(build.publicDir).toBe('/project/.output/public')
   })

--- a/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
@@ -1,0 +1,83 @@
+import type { Nuxt } from '@nuxt/schema'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getServerBuilderName, resolveServerBuild, tryUseNitro } from '../../../src/utils/server-build'
+
+function makeNuxt(options: Record<string, any> = {}, extra: Record<string, any> = {}) {
+  return {
+    options: { rootDir: '/project', ...options },
+    ...extra,
+  } as unknown as Nuxt
+}
+
+const nitroKit = {
+  useNitro: () => ({ options: { preset: 'node-server', output: { dir: '/project/.output', publicDir: '/project/.output/public' } } }),
+}
+
+const serverlessKit = {
+  useNitro: () => {
+    throw new Error('Nitro is not initialized!')
+  },
+}
+
+describe('tryUseNitro', () => {
+  it('should prefer the kit helper when it exists', () => {
+    const tryUse = vi.fn(() => undefined)
+    expect(tryUseNitro({ ...nitroKit, tryUseNitro: tryUse })).toBeUndefined()
+    expect(tryUse).toHaveBeenCalledOnce()
+  })
+
+  it('should treat a throwing `useNitro` as no server', () => {
+    expect(tryUseNitro(serverlessKit)).toBeUndefined()
+  })
+})
+
+describe('getServerBuilderName', () => {
+  it.each([
+    [{ server: { builder: '@nuxt/vite-server' } }, 'vite'],
+    [{ server: { builder: 'vite' } }, 'vite'],
+    [{ server: { builder: () => {} } }, 'custom'],
+    [{}, 'nitro'],
+  ])('should describe %j as %s', (options, expected) => {
+    expect(getServerBuilderName(makeNuxt(options))).toBe(expected)
+  })
+
+  it('should not claim Nitro when there is no server and no configured builder', () => {
+    expect(getServerBuilderName(makeNuxt(), false)).toBe('unknown')
+  })
+})
+
+describe('resolveServerBuild', () => {
+  it('should read output paths from the Nitro instance', () => {
+    const build = resolveServerBuild(nitroKit, makeNuxt())
+
+    expect(build).toMatchObject({ name: 'nitro', target: 'node-server', hasServer: true })
+    expect(build.dir).toBe('/project/.output')
+    expect(build.publicDir).toBe('/project/.output/public')
+  })
+
+  it('should prefer `nuxt.serverOutput`, re-reading it on each access', () => {
+    let dir = '/project/.vercel/output'
+    const nuxt = makeNuxt({}, { serverOutput: { dir: () => dir, publicDir: () => `${dir}/static` } })
+    const build = resolveServerBuild(nitroKit, nuxt)
+
+    expect(build.dir).toBe('/project/.vercel/output')
+    dir = '/project/.output'
+    expect(build.dir).toBe('/project/.output')
+    expect(build.publicDir).toBe('/project/.output/static')
+  })
+
+  it('should fall back to defaults when there is no server', () => {
+    const build = resolveServerBuild(serverlessKit, makeNuxt({ server: { builder: 'vite' } }))
+
+    expect(build).toMatchObject({ name: 'vite', target: undefined, hasServer: false })
+    expect(build.dir).toBe('/project/.output')
+    expect(build.publicDir).toBe('/project/.output/public')
+  })
+
+  it('should honour a configured Nitro output directory without an instance', () => {
+    const build = resolveServerBuild(serverlessKit, makeNuxt({ nitro: { output: { dir: 'dist' } } }))
+
+    expect(build.dir).toBe('/project/dist')
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
@@ -132,6 +132,29 @@ describe('resolveServerBuild', () => {
     expect(build.publicDir).toBe('/project/.output/public')
   })
 
+  it('should pick up a Nitro instance created after the build was described', () => {
+    let nitro: any
+    const kit = {
+      useNitro: () => {
+        if (!nitro) {
+          throw new Error('Nitro is not initialized!')
+        }
+        return nitro
+      },
+    }
+    const build = resolveServerBuild(kit, makeNuxt())
+
+    expect(build).toMatchObject({ name: 'unknown', label: 'unknown', hasServer: false })
+    expect(build.dir).toBe('/project/.output')
+
+    nitro = { options: { preset: 'vercel', output: { dir: '/project/.vercel/output' }, commands: { preview: 'vercel dev' } } }
+
+    expect(build).toMatchObject({ name: 'nitro', label: 'Nitro', hasServer: true })
+    expect(build.target).toBe('vercel')
+    expect(build.dir).toBe('/project/.vercel/output')
+    expect(build.previewCommand).toBe('vercel dev')
+  })
+
   it('should strip the trailing slash Nitro puts on its output paths', () => {
     const kit = { useNitro: () => ({ options: { output: { dir: '/project/.output/', publicDir: '/project/.output/public/' } } }) }
     const build = resolveServerBuild(kit, makeNuxt())

--- a/packages/nuxt-cli/test/unit/utils/static-preview.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/static-preview.spec.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+
+import { join } from 'pathe'
+import { describe, expect, it } from 'vitest'
+
+import { findStaticEntry, previewStaticOutput } from '../../../src/utils/static-preview'
+
+function makeOutput(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'nuxt-static-preview-'))
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(dir, name), contents)
+  }
+  return dir
+}
+
+describe('findStaticEntry', () => {
+  it('should prefer `200.html` over `index.html`', () => {
+    const dir = makeOutput({ '200.html': 'spa', 'index.html': 'home' })
+    expect(findStaticEntry(dir)).toBe(join(dir, '200.html'))
+  })
+
+  it('should return nothing for a directory with no client entry', () => {
+    expect(findStaticEntry(makeOutput({}))).toBeUndefined()
+  })
+})
+
+describe('previewStaticOutput', () => {
+  it('should serve files from disk and answer unknown paths with the client entry', async () => {
+    const dir = makeOutput({ 'index.html': 'home', 'app.js': 'console.log(1)' })
+
+    const server = await previewStaticOutput({ dir, entry: join(dir, 'index.html'), port: '0', hostname: '127.0.0.1' })
+    try {
+      const origin = server.url!.replace(/\/$/, '')
+      await expect(fetch(`${origin}/app.js`).then(r => r.text())).resolves.toBe('console.log(1)')
+      await expect(fetch(`${origin}/some/route`).then(r => r.text())).resolves.toBe('home')
+    }
+    finally {
+      await server.close(true)
+    }
+  })
+})

--- a/packages/nuxt-cli/test/unit/utils/static-preview.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/static-preview.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'pathe'
 import { describe, expect, it } from 'vitest'
 
-import { findStaticEntry, previewStaticOutput } from '../../../src/utils/static-preview'
+import { findStaticEntry, formatServerURL, previewStaticOutput } from '../../../src/utils/static-preview'
 
 function makeOutput(files: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), 'nuxt-static-preview-'))
@@ -38,5 +38,16 @@ describe('previewStaticOutput', () => {
     finally {
       await server.close(true)
     }
+  })
+})
+
+describe('formatServerURL', () => {
+  it.each([
+    ['http://[::]:3000/', 'http://localhost:3000'],
+    ['http://0.0.0.0:3000/', 'http://localhost:3000'],
+    ['http://127.0.0.1:3000/', 'http://127.0.0.1:3000'],
+    [undefined, ''],
+  ])('should format %s as %s', (url, expected) => {
+    expect(formatServerURL(url)).toBe(expected)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

companion piece to work happening in nuxt - currently we hard-expect nitro, which is tricky if the version of nitro might change

this makes us more resilient to different versions, or even a pure vite spa build