### PR TITLE
fix(analyze,build,dev,preview): server build descriptor with nitro fallback

### DIFF
--- a/packages/nuxt-cli/src/commands/preview.ts
+++ b/packages/nuxt-cli/src/commands/preview.ts
@@ -143,8 +143,9 @@ const command = defineCommand({
           target = ['Nitro preset:', nitroJSON.preset]
         }
       }
-      staticDirs.push(resolve(cwd, '.output', 'public'))
     }
+
+    staticDirs.push(resolve(cwd, '.output', 'public'))
 
     if (typeof previewCommand !== 'string' || !previewCommand.trim()) {
       // A build with no server runtime leaves only static files, which the CLI

--- a/packages/nuxt-cli/src/utils/server-build.ts
+++ b/packages/nuxt-cli/src/utils/server-build.ts
@@ -108,11 +108,9 @@ export function tryUseNitro(kit: MaybeModernKit): NitroLike | undefined {
  */
 export function getServerBuilderName(nuxt: Nuxt, hasServer?: boolean): string {
   const declared = (nuxt as MaybeModernNuxt).serverBuild
-  if (declared) {
-    return declared.label || declared.name
-  }
-
-  const name = inferBuilderName(nuxt)
+  // A descriptor Nuxt seeded but no builder replaced carries the raw specifier
+  // as its name, so it is read the same way as the `server.builder` option.
+  const name = declared ? declared.label || normalizeBuilderName(declared.name) : inferBuilderName(nuxt)
   if (name === 'nitro') {
     return 'Nitro'
   }
@@ -130,9 +128,14 @@ export function getServerBuilderName(nuxt: Nuxt, hasServer?: boolean): string {
 function inferBuilderName(nuxt: Nuxt): string | undefined {
   const builder = (nuxt as MaybeModernNuxt).options.server?.builder
   if (typeof builder === 'string' && builder) {
-    return builder.replace(/^@nuxt\//, '').replace(/-server$/, '')
+    return normalizeBuilderName(builder)
   }
   return builder ? 'custom' : undefined
+}
+
+/** A module specifier such as `@nuxt/vite-server` read as a builder name. */
+function normalizeBuilderName(specifier: string): string {
+  return specifier.replace(/^@nuxt\//, '').replace(/-server$/, '')
 }
 
 /**
@@ -163,7 +166,7 @@ export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild
     declared: !!declared,
     hasDevServer: declared?.capabilities.dev ?? true,
     get name() {
-      return declared?.name ?? inferBuilderName(nuxt) ?? (getNitro() ? 'nitro' : 'unknown')
+      return (declared ? normalizeBuilderName(declared.name) : undefined) ?? inferBuilderName(nuxt) ?? (getNitro() ? 'nitro' : 'unknown')
     },
     get label() {
       return getServerBuilderName(nuxt, !!getNitro())
@@ -172,7 +175,7 @@ export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild
       return declared?.capabilities.server ?? !!getNitro()
     },
     get target() {
-      return declared ? declared.target?.() : getNitro()?.options.preset
+      return declared?.target?.() ?? getNitro()?.options.preset
     },
     get dir() {
       return normalizeDir(declared?.output.dir()
@@ -185,7 +188,7 @@ export function resolveServerBuild(kit: MaybeModernKit, nuxt: Nuxt): ServerBuild
         ?? resolve(nuxt.options.rootDir, nuxt.options.nitro?.output?.publicDir || DEFAULT_PUBLIC_DIR))
     },
     get previewCommand() {
-      return declared ? declared.preview?.command?.() : getNitro()?.options.commands?.preview
+      return declared?.preview?.command?.() ?? getNitro()?.options.commands?.preview
     },
     get previewStaticDir() {
       const dir = declared?.preview?.staticDir?.()

--- a/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
+++ b/packages/nuxt-cli/test/unit/utils/server-build.spec.ts
@@ -55,6 +55,11 @@ describe('getServerBuilderName', () => {
     expect(getServerBuilderName(makeNuxt(), false)).toBe('unknown')
   })
 
+  it('should read an unresolved descriptor name as a builder name', () => {
+    const nuxt = makeNuxt({}, { serverBuild: descriptor({ name: '@nuxt/nitro-server' }) })
+    expect(getServerBuilderName(nuxt)).toBe('Nitro')
+  })
+
   it('should use the label Nuxt declares', () => {
     const nuxt = makeNuxt({ server: { builder: 'vite' } }, { serverBuild: descriptor({ name: 'vite', label: 'Vite SPA' }) })
     expect(getServerBuilderName(nuxt)).toBe('Vite SPA')
@@ -116,6 +121,26 @@ describe('resolveServerBuild', () => {
     expect(build.previewCommand).toBeUndefined()
     expect(build.previewStaticDir).toBe('/project/.output/public')
     expect(useNitro).not.toHaveBeenCalled()
+  })
+
+  it('should fall back to Nitro for a descriptor that declares no target or preview command', () => {
+    const nuxt = makeNuxt({}, { serverBuild: descriptor({ name: '@nuxt/nitro-server' }) })
+    const build = resolveServerBuild(nitroKit, nuxt)
+
+    expect(build).toMatchObject({ name: 'nitro', label: 'Nitro', declared: true, hasServer: true })
+    expect(build.target).toBe('node-server')
+    expect(build.previewCommand).toBe('node ./server/index.mjs')
+    expect(build.previewStaticDir).toBeUndefined()
+  })
+
+  it('should fall back to Nitro for a descriptor whose getters resolve to nothing', () => {
+    const nuxt = makeNuxt({}, {
+      serverBuild: descriptor({ target: () => undefined, preview: { command: () => undefined } }),
+    })
+    const build = resolveServerBuild(nitroKit, nuxt)
+
+    expect(build.target).toBe('node-server')
+    expect(build.previewCommand).toBe('node ./server/index.mjs')
   })
 
   it('should report a builder that declares no dev server', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

follow-up to #1505 - issue is in nuxt v4.6+, we _always_ write a descriptor, meaning it no longer tells us anything except that nuxt is newer...

so this makes the descriptor a preferred source rather than an exclusive one, respecting nitro-reported values unless it's been overridden...