### PR TITLE
fix(dev): quit command hangs/timeouts on Windows

### DIFF
--- a/packages/nuxt-cli/src/dev/utils.ts
+++ b/packages/nuxt-cli/src/dev/utils.ts
@@ -1129,15 +1129,16 @@ export class NuxtDevServer extends EventEmitter<DevServerEventMap> {
         const baseURL = nuxt.options.app.baseURL.startsWith('./') ? nuxt.options.app.baseURL.slice(1) : nuxt.options.app.baseURL
         const assetsDir = nuxt.options.app.buildAssetsDir
         const viteHmrPath = `${baseURL.replace(/\/$/, '')}/${assetsDir.replace(/^\//, '')}`
-        if (req.url?.startsWith(viteHmrPath)) {
-          return // Skip for Vite HMR
-        }
-        nuxt.server.upgrade(req, socket as any, head)
-
+        // fix #1531: track all opened connections
+        // quit command hangs/timeouts on Windows 10 with Vite HMR
         this.#websocketConnections.add(socket)
         socket.on('close', () => {
           this.#websocketConnections.delete(socket)
         })
+        if (req.url?.startsWith(viteHmrPath)) {
+          return // Skip for Vite HMR
+        }
+        nuxt.server.upgrade(req, socket as any, head)
       })
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #1531 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This PR includes:
- track Vite HMR connections to allow close them, check https://github.com/nuxt/cli/pull/1532#issuecomment-5626405787
- WIP: resolve deadlock: upstream, check https://github.com/nuxt/cli/pull/1532#issuecomment-5626202941

Maybe we can fix the deadlock here, not yet sure...

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
